### PR TITLE
Add indexes to apps for easier access

### DIFF
--- a/src/apps/aelin/index.ts
+++ b/src/apps/aelin/index.ts
@@ -1,0 +1,3 @@
+export { AELIN_DEFINITION, AelinAppDefinition } from './aelin.definition';
+export { AelinAppModule } from './aelin.module';
+export { AelinContractFactory } from './contracts';

--- a/src/apps/synthetix/index.ts
+++ b/src/apps/synthetix/index.ts
@@ -1,0 +1,7 @@
+export { SYNTHETIX_DEFINITION, SynthetixAppDefinition } from './synthetix.definition';
+export { SynthetixAppModule } from './synthetix.module';
+export { SynthetixContractFactory } from './contracts';
+export { SynthetixSingleStakingFarmContractPositionBalanceHelper } from './helpers/synthetix.single-staking-farm-contract-position-balance-helper';
+export { SynthetixSingleStakingFarmContractPositionHelper } from './helpers/synthetix.single-staking-farm-contract-position-helper';
+export { SynthetixSingleStakingIsActiveStrategy } from './helpers/synthetix.single-staking.is-active-strategy';
+export { SynthetixSingleStakingRoiStrategy } from './helpers/synthetix.single-staking.roi-strategy';

--- a/src/apps/unagii/index.ts
+++ b/src/apps/unagii/index.ts
@@ -1,0 +1,3 @@
+export { UNAGII_DEFINITION, UnagiiAppDefinition } from './unagii.definition';
+export { UnagiiAppModule } from './unagii.module';
+export { UnagiiContractFactory } from './contracts';


### PR DESCRIPTION
## Description

Enables us to import helpers, definitions, and modules via very succinct entrypoints:

`import { SynthetixSingleStakingFarmContractPositionBalanceHelper } from '@zapper-fi/apps/synthetix';`

(combined with tsc path aliasing)

## How to test?

What steps can be followed to test this feature? What block chain addresses can be used to test this feature?
