### PR TITLE
Do not commit/tag on auto-publish from npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           run_install: true
 
       - name: Bump Version
-        run: pnpm version ${{ github.event.inputs.version }}
+        run: npm --no-git-tag-version version ${{ github.event.inputs.version }}
 
       - name: Get Package Version
         id: package-version


### PR DESCRIPTION
## Description

NPM was trying to commit using the default git credentials, use the github action instead
## How to test?

What steps can be followed to test this feature? What block chain addresses can be used to test this feature?
