### PR TITLE
Clearer errors on import errors in dynamic app importer

### DIFF
--- a/cli/commands/codegen-app.ts
+++ b/cli/commands/codegen-app.ts
@@ -193,6 +193,7 @@ function generateTokenFetcher(appId: string, groupdId: string, groupdValue: stri
 function generateContractPosition(appId: string, groupId: string, groupdValue: string, networkRaw: string) {
   const appDefinitionName = `${strings.upperCase(appId)}_DEFINITION`;
   const appTitleCase = strings.titleCase(appId);
+  const appCamelCase = strings.camelCase(appTitleCase);
 
   const groupTitleCase = strings.titleCase(groupdValue);
 
@@ -204,13 +205,11 @@ function generateContractPosition(appId: string, groupId: string, groupdValue: s
 
   import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
   import { Register } from '~app-toolkit/decorators';
-  // helper for displayProps
-  //import { buildDollarDisplayItem } from '~app-toolkit/helpers/presentation/display-item.present';
-  //import { ContractType } from '~position/contract.interface';
   import { PositionFetcher } from '~position/position-fetcher.interface';
   import { ContractPosition } from '~position/position.interface';
   import { Network } from '~types/network.interface';
   
+  import { ${appTitleCase}ContractFactory } from '../contracts';
   import { ${appDefinitionName} } from '../${appId}.definition';
   
   const appId = ${appDefinitionName}.id;
@@ -219,39 +218,12 @@ function generateContractPosition(appId: string, groupId: string, groupdValue: s
   
   @Register.ContractPositionFetcher({ appId, groupId, network })
   export class ${networkTitleCase}${appTitleCase}${groupTitleCase}ContractPositionFetcher implements PositionFetcher<ContractPosition> {
-    constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
+    constructor(
+      @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
+      @Inject(${appTitleCase}ContractFactory) private readonly ${appCamelCase}ContractFactory: ${appTitleCase}ContractFactory,
+    ) {}
   
     async getPositions() {
-      // In case you need tokens defined in the token-fetchers, here's how you can get those
-      /*const appTokens = await this.appToolkit.getAppTokenPositions({
-        appId: ${appDefinitionName}.id,
-        // replace "token" with the appropriate group id in order to fetch app tokens
-        groupIds: [${appDefinitionName}.groups.token.id],
-        network,
-      });*/
-  
-      // This is the shape of a position the function could return
-      /*const positions = appTokens.map(token => {
-        const position = {
-          address: token.address,
-          type: ContractType.POSITION,
-          network,
-          appId,
-          groupId,
-          tokens: [token],
-  
-          dataProps: {},
-  
-          displayProps: {
-            label: token.symbol,
-            images: token.displayProps.images,
-            secondaryLabel: buildDollarDisplayItem(token.price),
-          },
-        };
-        return position;
-      });
-  
-      return positions;*/
       return [];
     }
   }

--- a/src/app/app.importer.ts
+++ b/src/app/app.importer.ts
@@ -2,12 +2,18 @@ import path from 'path';
 
 import { IConfigurableDynamicRootModule } from '@golevelup/nestjs-modules';
 import { Type } from '@nestjs/common';
+import chalk from 'chalk';
 
 import { AppDefinition } from './app.definition';
 import { AppModuleOptions } from './app.dynamic-module';
 
+type BuildImporterParams = {
+  match: RegExp;
+  filename: (appId: string) => string;
+};
+
 const buildImporter =
-  <T>({ match, filename }: { match: RegExp; filename: (appId: string) => string }) =>
+  <T>({ match, filename }: BuildImporterParams) =>
   async (appId: string) => {
     try {
       const modulePath = path.resolve(__dirname, '../apps', appId, filename(appId));
@@ -16,6 +22,8 @@ const buildImporter =
       if (!key) throw new Error(`No matched export found in ${modulePath}`);
       return mod[key] as T;
     } catch (err) {
+      // eslint-disable-next-line
+      console.error(chalk.red(`Failed to import ${filename(appId)}: ${err.message}`));
       return null;
     }
   };


### PR DESCRIPTION
## Description

Locally, my Pickle farms weren't working. I realized it actually wasn't importing the Pickle module because of an import errorI had on my side, but the import error was being swallowed. Clearly show the error to the user.

## How to test?

What steps can be followed to test this feature? What block chain addresses can be used to test this feature?
