### PR TITLE
fix(cli): string upperCase and kebabCase error

### DIFF
--- a/cli/strings/strings.ts
+++ b/cli/strings/strings.ts
@@ -27,7 +27,7 @@ const lines = (xs: string[]) => {
  * @returns KebabCased string
  */
 const kebabCase = (s: string) => {
-  return _.kebabCase(s).replace(' ', '-');
+  return _.kebabCase(s).replaceAll(' ', '-');
 };
 
 /**
@@ -37,7 +37,7 @@ const kebabCase = (s: string) => {
  * @returns UpperCased string
  */
 const upperCase = (s: string) => {
-  return _.upperCase(s).replace(' ', '_').replace('-', '_');
+  return _.upperCase(s).replaceAll(' ', '_').replaceAll('-', '_');
 };
 
 /**


### PR DESCRIPTION
## Description

### Issue
Running `yarn studio create-app` and input `a-b-c` as ID of the app and the following error will be encountered.
```
yarn run v1.22.18
$ ./studio.sh create-app
What is the name of the app : abc
What is the ID of the app  [abc]: a-b-c
What is the description of your app : abc
What is the URL of your app : abc.com
? Select networks supported by the app ethereum
SyntaxError: ',' expected. (6:18)
  4 | import { Network } from '~types/network.interface';
  5 |
> 6 | export const A_B C_DEFINITION = {
    |                  ^
  7 |   id: 'a-b-c',
  8 |   name: 'abc',
  9 |   description: 'abc',
    at $e (/home/haotongye/Repos/studio/node_modules/.pnpm/prettier@2.6.0/node_modules/prettier/parser-typescript.js:1:15901)
    at vU (/home/haotongye/Repos/studio/node_modules/.pnpm/prettier@2.6.0/node_modules/prettier/parser-typescript.js:280:5917)
    at Object.yU [as parse] (/home/haotongye/Repos/studio/node_modules/.pnpm/prettier@2.6.0/node_modules/prettier/parser-typescript.js:280:6240)
    at Object.parse (/home/haotongye/Repos/studio/node_modules/.pnpm/prettier@2.6.0/node_modules/prettier/index.js:7339:23)
    at coreFormat (/home/haotongye/Repos/studio/node_modules/.pnpm/prettier@2.6.0/node_modules/prettier/index.js:8650:18)
    at formatWithCursor2 (/home/haotongye/Repos/studio/node_modules/.pnpm/prettier@2.6.0/node_modules/prettier/index.js:8842:18)
    at /home/haotongye/Repos/studio/node_modules/.pnpm/prettier@2.6.0/node_modules/prettier/index.js:40191:12
    at Object.format (/home/haotongye/Repos/studio/node_modules/.pnpm/prettier@2.6.0/node_modules/prettier/index.js:40205:12)
    at CreateApp.run (/home/haotongye/Repos/studio/cli/cli/commands/create-app.ts:49:16)
    at CreateApp._run (/home/haotongye/Repos/studio/node_modules/.pnpm/@oclif+core@1.6.3/node_modules/@oclif/core/lib/command.js:67:22) {
  loc: { start: { line: 6, column: 18 } },
  codeFrame: "\x1B[0m \x1B[90m 4 |\x1B[39m \x1B[36mimport\x1B[39m { \x1B[33mNetwork\x1B[39m } \x1B[36mfrom\x1B[39m \x1B[32m'~types/network.interface'\x1B[39m\x1B[33m;\x1B[39m\x1B[0m\n" +
    '\x1B[0m \x1B[90m 5 |\x1B[39m\x1B[0m\n' +
    '\x1B[0m\x1B[31m\x1B[1m>\x1B[22m\x1B[39m\x1B[90m 6 |\x1B[39m \x1B[36mexport\x1B[39m \x1B[36mconst\x1B[39m \x1B[33mA_B\x1B[39m \x1B[33mC_DEFINITION\x1B[39m \x1B[33m=\x1B[39m {\x1B[0m\n' +
    '\x1B[0m \x1B[90m   |\x1B[39m                  \x1B[31m\x1B[1m^\x1B[22m\x1B[39m\x1B[0m\n' +
    "\x1B[0m \x1B[90m 7 |\x1B[39m   id\x1B[33m:\x1B[39m \x1B[32m'a-b-c'\x1B[39m\x1B[33m,\x1B[39m\x1B[0m\n" +
    "\x1B[0m \x1B[90m 8 |\x1B[39m   name\x1B[33m:\x1B[39m \x1B[32m'abc'\x1B[39m\x1B[33m,\x1B[39m\x1B[0m\n" +
    "\x1B[0m \x1B[90m 9 |\x1B[39m   description\x1B[33m:\x1B[39m \x1B[32m'abc'\x1B[39m\x1B[33m,\x1B[39m\x1B[0m"
}
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### Cause
`String.prototype.replace()` will only replace the first instance of matched substring if the first argument isn't a regex pattern. ([Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#parameters))

### Solution
Replace `replace` with `replaceAll`.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: 0xYYY.eth

## How to test?

Run `yarn studio create-app` with `a-b-c` as ID of the app .
