### PR TITLE
fix: Use single quotes for release body on publish in case commit message has double quotes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Output Release Changelog
         if: steps.release.outputs.released == 'true'
-        run: echo "${{ steps.fetch_release.outputs.body }}"
+        run: echo '${{ steps.fetch_release.outputs.body }}'
 
       - name: Persist Release
         if: steps.release.outputs.released == 'true'
@@ -68,7 +68,7 @@ jobs:
         run: |
           mkdir tmp
           touch tmp/changelog.txt
-          echo "${{ steps.fetch_release.outputs.body }}" > tmp/changelog.txt
+          echo '${{ steps.fetch_release.outputs.body }}' > tmp/changelog.txt
           export CHANGELOG="$(node ./scripts/rewrite-changelog.js ./tmp/changelog.txt $REPO_URL)"
           CHANGELOG="${CHANGELOG//'%'/'%25'}"
           CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"


### PR DESCRIPTION
## Description

Revert message in a previous commit had double quotes, which is failing the build.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

Publish step succeeds.