### PR TITLE
ci: Rugged by deprecated github action version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Fetch Release
         id: fetch-latest-release
-        uses: thebritican/fetch-latest-release@v1
+        uses: thebritican/fetch-latest-release@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Description

thebritican/fetch-latest-release@v1 doesn't exist anymore
## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
