### PR TITLE
fix: Temporarily disable Olympus

### DIFF
--- a/src/apps/olympus/olympus.module.ts
+++ b/src/apps/olympus/olympus.module.ts
@@ -2,64 +2,48 @@ import { Module } from '@nestjs/common';
 
 import { AbstractDynamicApp } from '~app/app.dynamic-module';
 
-import { ArbitrumOlympusBalanceFetcher } from './arbitrum/olympus.balance-fetcher';
-import { ArbitrumOlympusGOhmTokenFetcher } from './arbitrum/olympus.g-ohm.token-fetcher';
-import { ArbitrumOlympusWsOhmV1TokenFetcher } from './arbitrum/olympus.ws-ohm-v1.token-fetcher';
-import { AvalancheOlympusBalanceFetcher } from './avalanche/olympus.balance-fetcher';
-import { AvalancheOlympusGOhmTokenFetcher } from './avalanche/olympus.g-ohm.token-fetcher';
-import { AvalancheOlympusWsOhmV1TokenFetcher } from './avalanche/olympus.ws-ohm-v1.token-fetcher';
 import { OlympusContractFactory } from './contracts';
-import { EthereumOlympusBalanceFetcher } from './ethereum/olympus.balance-fetcher';
-import { EthereumOlympusBondContractPositionFetcher } from './ethereum/olympus.bond.contract-position-fetcher';
-import { EthereumOlympusGOhmTokenFetcher } from './ethereum/olympus.g-ohm.token-fetcher';
-import { EthereumOlympusSOhmV1TokenFetcher } from './ethereum/olympus.s-ohm-v1.token-fetcher';
-import { EthereumOlympusSOhmTokenFetcher } from './ethereum/olympus.s-ohm.token-fetcher';
-import { EthereumOlympusWsOhmV1TokenFetcher } from './ethereum/olympus.ws-ohm-v1.token-fetcher';
-import { FantomOlympusBalanceFetcher } from './fantom/olympus.balance-fetcher';
-import { FantomOlympusGOhmTokenFetcher } from './fantom/olympus.g-ohm.token-fetcher';
 import { OlympusBondContractPositionBalanceHelper } from './helpers/olympus.bond.contract-position-balance-helper';
 import { OlympusBondContractPositionHelper } from './helpers/olympus.bond.contract-position-helper';
 import { OlympusBridgeTokenHelper } from './helpers/olympus.bridge-token-helper';
 import { OlympusAppDefinition } from './olympus.definition';
-import { PolygonOlympusBalanceFetcher } from './polygon/olympus.balance-fetcher';
-import { PolygonOlympusGOhmTokenFetcher } from './polygon/olympus.g-ohm.token-fetcher';
 
 @Module({
   providers: [
     OlympusAppDefinition,
     OlympusContractFactory,
     // Arbitrum
-    ArbitrumOlympusBalanceFetcher,
-    ArbitrumOlympusGOhmTokenFetcher,
-    ArbitrumOlympusWsOhmV1TokenFetcher,
-    // Avalanche
-    AvalancheOlympusBalanceFetcher,
-    AvalancheOlympusGOhmTokenFetcher,
-    AvalancheOlympusWsOhmV1TokenFetcher,
-    // Ethereum
-    EthereumOlympusBalanceFetcher,
-    EthereumOlympusBondContractPositionFetcher,
-    EthereumOlympusSOhmTokenFetcher,
-    EthereumOlympusSOhmV1TokenFetcher,
-    EthereumOlympusWsOhmV1TokenFetcher,
-    EthereumOlympusGOhmTokenFetcher,
-    // Fantom
-    FantomOlympusBalanceFetcher,
-    FantomOlympusGOhmTokenFetcher,
-    // Polygon
-    PolygonOlympusBalanceFetcher,
-    PolygonOlympusGOhmTokenFetcher,
+    // ArbitrumOlympusBalanceFetcher,
+    // ArbitrumOlympusGOhmTokenFetcher,
+    // ArbitrumOlympusWsOhmV1TokenFetcher,
+    // // Avalanche
+    // AvalancheOlympusBalanceFetcher,
+    // AvalancheOlympusGOhmTokenFetcher,
+    // AvalancheOlympusWsOhmV1TokenFetcher,
+    // // Ethereum
+    // EthereumOlympusBalanceFetcher,
+    // EthereumOlympusBondContractPositionFetcher,
+    // EthereumOlympusSOhmTokenFetcher,
+    // EthereumOlympusSOhmV1TokenFetcher,
+    // EthereumOlympusWsOhmV1TokenFetcher,
+    // EthereumOlympusGOhmTokenFetcher,
+    // // Fantom
+    // FantomOlympusBalanceFetcher,
+    // FantomOlympusGOhmTokenFetcher,
+    // // Polygon
+    // PolygonOlympusBalanceFetcher,
+    // PolygonOlympusGOhmTokenFetcher,
     // Helpers
     OlympusBridgeTokenHelper,
     OlympusBondContractPositionHelper,
     OlympusBondContractPositionBalanceHelper,
   ],
   exports: [
-    OlympusAppDefinition,
-    OlympusContractFactory,
-    OlympusBondContractPositionHelper,
-    OlympusBondContractPositionBalanceHelper,
-    OlympusBridgeTokenHelper,
+    // OlympusAppDefinition,
+    // OlympusContractFactory,
+    // OlympusBondContractPositionHelper,
+    // OlympusBondContractPositionBalanceHelper,
+    // OlympusBridgeTokenHelper,
   ],
 })
 export class OlympusAppModule extends AbstractDynamicApp<OlympusAppModule>() {}


### PR DESCRIPTION
## Description

Some weird infinite loop occurring that is crashing the app when Olympus is activated. Temporarily prevent it from being loaded until we can look into this further.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

`yarn dev` with `olympus` in `ENABLED_APPS` doesn't crash the application.