### PR TITLE
fix(tokemak): Use App Toolkit instead of position service

### DIFF
--- a/src/apps/tokemak/ethereum/tokemak.tvl-fetcher.ts
+++ b/src/apps/tokemak/ethereum/tokemak.tvl-fetcher.ts
@@ -3,7 +3,7 @@ import { sumBy } from 'lodash';
 
 import { SingleStakingFarmDataProps } from '~app-toolkit';
 import { Register } from '~app-toolkit/decorators';
-import { PositionService } from '~position/position.service';
+import { APP_TOOLKIT, IAppToolkit } from '~lib';
 import { TvlFetcher } from '~stats/tvl/tvl-fetcher.interface';
 import { Network } from '~types/network.interface';
 
@@ -11,10 +11,10 @@ import { TOKEMAK_DEFINITION } from '../tokemak.definition';
 
 @Register.TvlFetcher({ appId: TOKEMAK_DEFINITION.id, network: Network.ETHEREUM_MAINNET })
 export class EthereumTokemakTvlFetcher implements TvlFetcher {
-  constructor(@Inject(PositionService) private readonly positionService: PositionService) {}
+  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
 
   async getTvl() {
-    const farmPositions = await this.positionService.getAppContractPositions<SingleStakingFarmDataProps>({
+    const farmPositions = await this.appToolkit.getAppContractPositions<SingleStakingFarmDataProps>({
       appId: TOKEMAK_DEFINITION.id,
       network: Network.ETHEREUM_MAINNET,
       groupIds: [TOKEMAK_DEFINITION.groups.farm.id],

--- a/src/apps/tokemak/tokemak.module.ts
+++ b/src/apps/tokemak/tokemak.module.ts
@@ -2,7 +2,6 @@ import { Module } from '@nestjs/common';
 
 import { AbstractDynamicApp } from '~app/app.dynamic-module';
 import { SynthetixAppModule } from '~apps/synthetix';
-import { PositionModule } from '~position/position.module';
 
 import { TokemakContractFactory } from './contracts';
 import { EthereumTokemakBalanceFetcher } from './ethereum/tokemak.balance-fetcher';
@@ -12,7 +11,7 @@ import { EthereumTokemakTvlFetcher } from './ethereum/tokemak.tvl-fetcher';
 import { TokemakAppDefinition } from './tokemak.definition';
 
 @Module({
-  imports: [SynthetixAppModule.externallyConfigured(SynthetixAppModule, 0), PositionModule],
+  imports: [SynthetixAppModule.externallyConfigured(SynthetixAppModule, 0)],
   providers: [
     TokemakAppDefinition,
     TokemakContractFactory,


### PR DESCRIPTION
## Description

Would have broken when consumed into Zapper API
## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
