### PR TITLE
chore: Add enabled helpers env support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,3 +7,4 @@
 # e.g: ENABLED_APPS="tokemak,synthetix"
 
 ENABLED_APPS=
+ENABLED_HELPERS=


### PR DESCRIPTION
## Description

In order to migrate quickly apps from _Zapper Api_ to _Studio_, this adds a way to easily port app-specific helpers, without them being considered as apps.

### Usage

1. Port the app specific helper as it was an app -- add the helpers in `src/apps/<app>`, and create `<app>.module.ts`.
2. The app module needs to be configured as a **dynamic app**, just like regular apps
3. Add the app ID in the `ENABLED_HELPERS`  env var in **.env** (ex: `ENABLED_HELPERS=my-app`)
4. Import the app containing your helpers into another app that needs them as dependency using `externallyConfigured`

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)