### PR TITLE
fix: Split Olympus bond balance helper for v1 and v2 bonds, keep bond position fetcher generic, fix linting

### DIFF
--- a/src/apps/olympus/ethereum/olympus.bond.contract-position-fetcher.ts
+++ b/src/apps/olympus/ethereum/olympus.bond.contract-position-fetcher.ts
@@ -25,8 +25,10 @@ export class EthereumOlympusBondContractPositionFetcher implements PositionFetch
     return this.olympusContractPositionHelper.getPositions({
       appId: OLYMPUS_DEFINITION.id,
       network,
+      mintedTokenAddress: '0x0ab87046fbb341d058f17cbc4c1133f25a20a52f', // gOHM
       groupId: OLYMPUS_DEFINITION.groups.bond.id,
       depositories,
+      dependencies: [{ appId: OLYMPUS_DEFINITION.id, groupIds: [OLYMPUS_DEFINITION.groups.gOhm.id], network }],
     });
   }
 }

--- a/src/apps/olympus/helpers/olympus.bond-v1.contract-position-balance-helper.ts
+++ b/src/apps/olympus/helpers/olympus.bond-v1.contract-position-balance-helper.ts
@@ -1,0 +1,77 @@
+import { Inject, Injectable } from '@nestjs/common';
+import BigNumber from 'bignumber.js';
+import { BigNumberish } from 'ethers';
+import { sumBy } from 'lodash';
+
+import { drillBalance } from '~app-toolkit';
+import { APP_TOOLKIT, IAppToolkit } from '~lib';
+import { EthersMulticall as Multicall } from '~multicall/multicall.ethers';
+import { DefaultDataProps } from '~position/display.interface';
+import { ContractPositionBalance } from '~position/position-balance.interface';
+import { ContractPosition } from '~position/position.interface';
+import { isClaimable, isVesting } from '~position/position.utils';
+import { Network } from '~types/network.interface';
+
+type OlympusBondV1ContractPositionBalanceHelperParams<T, V> = {
+  address: string;
+  appId: string;
+  groupId: string;
+  network: Network;
+  resolveDepositoryContract: (opts: { depositoryAddress: string; network: Network }) => T;
+  resolveTotalPayout: (opts: {
+    multicall: Multicall;
+    contract: T;
+    address: string;
+    contractPosition: ContractPosition<V>;
+  }) => Promise<BigNumberish>;
+  resolveClaimablePayout: (opts: {
+    multicall: Multicall;
+    contract: T;
+    address: string;
+    contractPosition: ContractPosition<V>;
+  }) => Promise<BigNumberish>;
+};
+
+@Injectable()
+export class OlympusBondV1ContractPositionBalanceHelper {
+  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
+
+  async getBalances<T, V = DefaultDataProps>(
+    opts: OlympusBondV1ContractPositionBalanceHelperParams<T, V>,
+  ): Promise<ContractPositionBalance<V>[]> {
+    const { address, appId, groupId, network, resolveDepositoryContract, resolveTotalPayout, resolveClaimablePayout } =
+      opts;
+
+    const multicall = this.appToolkit.getMulticall(network);
+    const contractPositions = await this.appToolkit.getAppContractPositions<V>({ network, appId, groupIds: [groupId] });
+
+    const contractPositionBalances = await Promise.all(
+      contractPositions.map(async contractPosition => {
+        const contract = resolveDepositoryContract({ depositoryAddress: contractPosition.address, network });
+
+        const vestingToken = contractPosition.tokens.find(isVesting)!;
+        const claimableToken = contractPosition.tokens.find(isClaimable)!;
+
+        const [pendingPayoutRaw, claimableBalanceRaw] = await Promise.all([
+          resolveTotalPayout({ multicall, contract, address, contractPosition }),
+          resolveClaimablePayout({ multicall, contract, address, contractPosition }),
+        ]);
+
+        const pendingPayoutRawBN = new BigNumber(pendingPayoutRaw.toString());
+        const claimableBalanceRawBN = new BigNumber(claimableBalanceRaw.toString());
+
+        const vestingBalanceRaw = pendingPayoutRawBN.gt(claimableBalanceRawBN)
+          ? pendingPayoutRawBN.minus(claimableBalanceRawBN).toFixed(0)
+          : '0';
+        const claimableTokenBalance = drillBalance(claimableToken, claimableBalanceRaw.toString());
+        const vestingTokenBalance = drillBalance(vestingToken, vestingBalanceRaw);
+        const tokens = [claimableTokenBalance, vestingTokenBalance].filter(v => v.balanceUSD > 0);
+        const balanceUSD = sumBy(tokens, t => t.balanceUSD);
+
+        return { ...contractPosition, tokens, balanceUSD };
+      }),
+    );
+
+    return contractPositionBalances;
+  }
+}

--- a/src/apps/olympus/helpers/olympus.bond-v2.contract-position-balance-helper.ts
+++ b/src/apps/olympus/helpers/olympus.bond-v2.contract-position-balance-helper.ts
@@ -4,49 +4,43 @@ import { sumBy } from 'lodash';
 
 import { drillBalance } from '~app-toolkit';
 import { APP_TOOLKIT, IAppToolkit } from '~lib';
-import { EthersMulticall as Multicall } from '~multicall/multicall.ethers';
-import { DefaultDataProps } from '~position/display.interface';
 import { ContractPositionBalance } from '~position/position-balance.interface';
-import { ContractPosition } from '~position/position.interface';
 import { isClaimable, isVesting } from '~position/position.utils';
 import { Network } from '~types/network.interface';
 
-type OlympusBondContractPositionBalanceHelperParams<T, V> = {
+import { OlympusContractFactory } from '../contracts';
+
+type OlympusBondV2ContractPositionBalanceHelperParams = {
   address: string;
   appId: string;
   groupId: string;
   network: Network;
-  resolveDepositoryContract: (opts: { depositoryAddress: string; network: Network }) => T;
-  resolveClaimablePayout: (opts: {
-    multicall: Multicall;
-    contract: T;
-    address: string;
-    contractPosition: ContractPosition<V>;
-  }) => Promise<any>;
 };
 
 @Injectable()
-export class OlympusBondContractPositionBalanceHelper {
-  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
+export class OlympusBondV2ContractPositionBalanceHelper {
+  constructor(
+    @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
+    @Inject(OlympusContractFactory) private readonly contractFactory: OlympusContractFactory,
+  ) {}
 
-  async getBalances<T, V = DefaultDataProps>(
-    opts: OlympusBondContractPositionBalanceHelperParams<T, V>,
-  ): Promise<ContractPositionBalance<V>[]> {
-    const { address, appId, groupId, network, resolveDepositoryContract, resolveClaimablePayout } = opts;
+  async getBalances(opts: OlympusBondV2ContractPositionBalanceHelperParams): Promise<ContractPositionBalance[]> {
+    const { address, appId, groupId, network } = opts;
     const multicall = this.appToolkit.getMulticall(network);
-    const contractPositions = await this.appToolkit.getAppContractPositions<V>({ network, appId, groupIds: [groupId] });
+    const contractPositions = await this.appToolkit.getAppContractPositions({ network, appId, groupIds: [groupId] });
     const contractPositionBalances = await Promise.all(
       contractPositions.map(async contractPosition => {
-        const contract = resolveDepositoryContract({ depositoryAddress: contractPosition.address, network });
+        const contract = this.contractFactory.olympusV2BondDepository({ address: contractPosition.address, network });
         const vestingToken = contractPosition.tokens.find(isVesting)!;
         const claimableToken = contractPosition.tokens.find(isClaimable)!;
 
-        const [claimableBalanceRaw] = await Promise.all([
-          resolveClaimablePayout({ multicall, contract, address, contractPosition }),
-        ]);
+        const indexes = await multicall.wrap(contract).indexesFor(address);
+        const pendingBonds = await Promise.all(
+          indexes.map(index => multicall.wrap(contract).pendingFor(address, index)),
+        );
 
-        const claimableBonds = claimableBalanceRaw.filter(p => p.matured_);
-        const vestingBonds = claimableBalanceRaw.filter(p => !p.matured_);
+        const claimableBonds = pendingBonds.filter(p => p.matured_);
+        const vestingBonds = pendingBonds.filter(p => !p.matured_);
 
         const claimableAmount = claimableBonds.reduce((acc, bond) => acc.add(bond.payout_), BigNumber.from('0'));
         const vestingAmount = vestingBonds.reduce((acc, bond) => {

--- a/src/apps/olympus/helpers/olympus.bond.contract-position-helper.ts
+++ b/src/apps/olympus/helpers/olympus.bond.contract-position-helper.ts
@@ -9,8 +9,6 @@ import { AppGroupsDefinition } from '~position/position.service';
 import { claimable, vesting } from '~position/position.utils';
 import { Network } from '~types/network.interface';
 
-import { OLYMPUS_DEFINITION } from '../olympus.definition';
-
 type OlympusDepository = {
   depositoryAddress: string;
   symbol: string;
@@ -21,6 +19,7 @@ type OlympusBondContractPositionHelperParams = {
   appId: string;
   groupId: string;
   network: Network;
+  mintedTokenAddress: string;
   depositories: OlympusDepository[];
   dependencies?: AppGroupsDefinition[];
 };
@@ -34,8 +33,8 @@ export class OlympusBondContractPositionHelper {
     groupId,
     network,
     depositories,
-
-    dependencies = [{ appId, groupIds: [OLYMPUS_DEFINITION.groups.gOhm.id], network }],
+    mintedTokenAddress,
+    dependencies = [],
   }: OlympusBondContractPositionHelperParams) {
     const [baseTokens, appTokens] = await Promise.all([
       this.appToolkit.getBaseTokenPrices(network),
@@ -43,9 +42,9 @@ export class OlympusBondContractPositionHelper {
     ]);
     const allTokens = [...appTokens, ...baseTokens];
 
-    const mintedToken = allTokens.find(token => token.symbol === 'gOHM');
+    const mintedToken = allTokens.find(token => token.address === mintedTokenAddress);
     if (!mintedToken) {
-      throw new Error(`minted token with address gOHM is missing`);
+      throw new Error(`minted token with address ${mintedTokenAddress} is missing`);
     }
 
     const depositoryContractPositions = await Promise.all(
@@ -59,7 +58,7 @@ export class OlympusBondContractPositionHelper {
           tokens: [vesting(mintedToken), claimable(mintedToken)],
           dataProps: {},
           displayProps: {
-            label: `Bond`,
+            label: `${symbol} Bond`,
             images: images || [getTokenImg(symbol, network)],
             statsItems: [],
           },

--- a/src/apps/olympus/olympus.module.ts
+++ b/src/apps/olympus/olympus.module.ts
@@ -17,7 +17,8 @@ import { EthereumOlympusSOhmTokenFetcher } from './ethereum/olympus.s-ohm.token-
 import { EthereumOlympusWsOhmV1TokenFetcher } from './ethereum/olympus.ws-ohm-v1.token-fetcher';
 import { FantomOlympusBalanceFetcher } from './fantom/olympus.balance-fetcher';
 import { FantomOlympusGOhmTokenFetcher } from './fantom/olympus.g-ohm.token-fetcher';
-import { OlympusBondContractPositionBalanceHelper } from './helpers/olympus.bond.contract-position-balance-helper';
+import { OlympusBondV1ContractPositionBalanceHelper } from './helpers/olympus.bond-v1.contract-position-balance-helper';
+import { OlympusBondV2ContractPositionBalanceHelper } from './helpers/olympus.bond-v2.contract-position-balance-helper';
 import { OlympusBondContractPositionHelper } from './helpers/olympus.bond.contract-position-helper';
 import { OlympusBridgeTokenHelper } from './helpers/olympus.bridge-token-helper';
 import { OlympusAppDefinition } from './olympus.definition';
@@ -52,13 +53,15 @@ import { PolygonOlympusGOhmTokenFetcher } from './polygon/olympus.g-ohm.token-fe
     // Helpers
     OlympusBridgeTokenHelper,
     OlympusBondContractPositionHelper,
-    OlympusBondContractPositionBalanceHelper,
+    OlympusBondV1ContractPositionBalanceHelper,
+    OlympusBondV2ContractPositionBalanceHelper,
   ],
   exports: [
     OlympusAppDefinition,
     OlympusContractFactory,
     OlympusBondContractPositionHelper,
-    OlympusBondContractPositionBalanceHelper,
+    OlympusBondV1ContractPositionBalanceHelper,
+    OlympusBondV2ContractPositionBalanceHelper,
     OlympusBridgeTokenHelper,
   ],
 })

--- a/src/apps/tokemak/ethereum/tokemak.balance-fetcher.ts
+++ b/src/apps/tokemak/ethereum/tokemak.balance-fetcher.ts
@@ -87,7 +87,7 @@ export class EthereumTokemakBalanceFetcher implements BalanceFetcher {
   }
 
   async getClaimableBalanceData(address: string) {
-    const [latestClaimableRewardsHash, _] = await this.getCycleRewardsHash();
+    const [latestClaimableRewardsHash] = await this.getCycleRewardsHash();
     const url = `https://ipfs.tokemaklabs.xyz/ipfs/${latestClaimableRewardsHash}/${address.toLowerCase()}.json`;
     const data: ClaimableDataResponse['payload'] | null = await Axios.get<ClaimableDataResponse>(url)
       .then(t => t.data.payload)


### PR DESCRIPTION
## Description

- Olympus bond balance helper is split into V1 and V2 helpers (V1 helper is still being used in Zapper API for Olympus V1 forks)
- Keep bond position fetcher generic since its also being used for Olympus V1 forks
- Fix linting in Tokemak

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

[gOHM Bonds](http://localhost:5001/apps/olympus/balances?addresses[]=0x7ea8e1b9feb9f6a3420538a21497180866e44765)