### PR TITLE
fix: Rename resolveTotalRewardPerBlock to resolveTotalRewardRate

### DIFF
--- a/src/app-toolkit/helpers/master-chef/master-chef.default.reward-token-reward-rate-strategy.ts
+++ b/src/app-toolkit/helpers/master-chef/master-chef.default.reward-token-reward-rate-strategy.ts
@@ -20,7 +20,7 @@ export type MasterChefDefaultRewardRateStrategyParams<T> = {
     multicall: Multicall;
     poolIndex: number;
   }) => BigNumberish | Promise<BigNumberish>;
-  resolveTotalRewardPerBlock: (opts: {
+  resolveTotalRewardRate: (opts: {
     network: Network;
     contract: T;
     multicall: Multicall;
@@ -39,13 +39,13 @@ export class MasterChefDefaultRewardRateStrategy {
   build<T>({
     resolvePoolAllocPoints,
     resolveTotalAllocPoints,
-    resolveTotalRewardPerBlock,
+    resolveTotalRewardRate,
     resolveRewardMultiplier = async () => [1],
   }: MasterChefDefaultRewardRateStrategyParams<T>): MasterChefRewardRateStrategy<T> {
     return async ({ multicall, poolIndex, contract, network }) => {
       const [totalAllocPoints, totalRewardPerBlock, poolAllocPoints, rewardMultiplier] = await Promise.all([
         resolveTotalAllocPoints({ contract, multicall, poolIndex, network }),
-        resolveTotalRewardPerBlock({ contract, multicall, poolIndex, network }),
+        resolveTotalRewardRate({ contract, multicall, poolIndex, network }),
         resolvePoolAllocPoints({ contract, multicall, poolIndex, network }),
         resolveRewardMultiplier({ contract, multicall, poolIndex, network }),
       ]);

--- a/src/apps/naos/ethereum/naos.farm.contract-position-fetcher.ts
+++ b/src/apps/naos/ethereum/naos.farm.contract-position-fetcher.ts
@@ -42,7 +42,7 @@ export class EthereumNaosFarmContractPositionFetcher implements PositionFetcher<
         resolvePoolAllocPoints: async ({ poolIndex, contract, multicall }) =>
           multicall.wrap(contract).getPoolRewardWeight(poolIndex),
         resolveTotalAllocPoints: ({ multicall, contract }) => multicall.wrap(contract).totalRewardWeight(),
-        resolveTotalRewardPerBlock: ({ multicall, contract }) => multicall.wrap(contract).rewardRate(),
+        resolveTotalRewardRate: ({ multicall, contract }) => multicall.wrap(contract).rewardRate(),
       }),
     });
   }


### PR DESCRIPTION
## Description

We support reward per block and reward per second, so rename `resolveTotalRewardPerBlock` to `resolveTotalRewardRate`.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

N/A. Refactor.