### PR TITLE
fix(illuvium): Fix missing await in v1 staked balances

### DIFF
--- a/src/apps/illuvium/ethereum/illuvium.balance-fetcher.ts
+++ b/src/apps/illuvium/ethereum/illuvium.balance-fetcher.ts
@@ -46,7 +46,7 @@ export class EthereumIlluviumBalanceFetcher implements BalanceFetcher {
           voidAmountBN = voidDeposits.reduce((acc, v) => acc.plus(v.tokenAmount.toString()), new BigNumber(0));
         }
 
-        const stakedBalance = multicall.wrap(contract).balanceOf(address);
+        const stakedBalance = await multicall.wrap(contract).balanceOf(address);
         return new BigNumber(stakedBalance.toString()).minus(voidAmountBN).toString();
       },
       resolveRewardTokenBalances: () => 0,

--- a/src/apps/illuvium/ethereum/illuvium.balance-fetcher.ts
+++ b/src/apps/illuvium/ethereum/illuvium.balance-fetcher.ts
@@ -13,11 +13,6 @@ import { IlluviumContractFactory, IlluviumCorePool, IlluviumIlvPoolV2 } from '..
 import { ILLUVIUM_DEFINITION } from '../illuvium.definition';
 
 const network = Network.ETHEREUM_MAINNET;
-// const LAST_V1_YIELD_CREATED = 1642660625;
-// 0: {ticker: 'ILV', name: 'ILV', type: 'core', contractId: '0x7f5f854FfB6b7701540a00C69c4AB2De2B34291D', tokenContractId: '0x767FE9EDC9E0dF98E07454847909b5E959D7ca0E', …}
-// 1: {ticker: 'SLP', name: 'ILV/ETH', type: 'core', contractId: '0xe98477bDc16126bB0877c6e3882e3Edd72571Cc2', tokenContractId: '0x6a091a3406E0073C3CD6340122143009aDac0EDa', …}
-// 0: {ticker: 'ILV', name: 'ILV', type: 'core', contractId: '0x25121EDDf746c884ddE4619b573A7B10714E2a36', tokenContractId: '0x767FE9EDC9E0dF98E07454847909b5E959D7ca0E', …}
-// 1: {ticker: 'SLP', name: 'ILV/ETH', type: 'core', contractId: '0x8B4d8443a0229349A9892D4F7CbE89eF5f843F72', tokenContractId: '0x6a091a3406E0073C3CD6340122143009aDac0EDa', …}
 
 @Register.BalanceFetcher(ILLUVIUM_DEFINITION.id, Network.ETHEREUM_MAINNET)
 export class EthereumIlluviumBalanceFetcher implements BalanceFetcher {

--- a/src/apps/illuvium/ethereum/illuvium.farm.contract-position-fetcher.ts
+++ b/src/apps/illuvium/ethereum/illuvium.farm.contract-position-fetcher.ts
@@ -13,12 +13,6 @@ const appId = ILLUVIUM_DEFINITION.id;
 const groupId = ILLUVIUM_DEFINITION.groups.farm.id;
 const network = Network.ETHEREUM_MAINNET;
 
-// 0x4b6d71711d5405a8cb1df10e8a54d25155abcabf
-// Migrated, shows 1.9 in V2, and 1.4 in V1
-
-// 0x1f279aad56278d67d31ca1c89480ac7152e5c45a
-// Not migrated, shows 0 in V2, and 3.9 in V1
-
 @Register.ContractPositionFetcher({ appId, groupId, network })
 export class EthereumIlluviumFarmContractPositionFetcher implements PositionFetcher<ContractPosition> {
   private readonly ILV_STAKING_ADDRESS = '0x25121eddf746c884dde4619b573a7b10714e2a36';

--- a/src/apps/illuvium/ethereum/illuvium.migration-manager.ts
+++ b/src/apps/illuvium/ethereum/illuvium.migration-manager.ts
@@ -7,8 +7,6 @@ import { Network } from '~types/network.interface';
 import { IlluviumContractFactory } from '../contracts';
 import { ILLUVIUM_DEFINITION } from '../illuvium.definition';
 
-import merkleBalances from './illuvium.merkle-balances.json';
-
 type MerkleBalanceEntry = {
   account: string;
   pendingV1Rewards: {
@@ -39,7 +37,8 @@ export class EthereumIlluviumMigrationManager {
   }
 
   async hasMigrated(address: string) {
-    const index = (merkleBalances as MerkleBalanceEntry[]).findIndex(v => v.account.toLowerCase() === address);
+    const merkleBalances = await this.getMerkleBalances();
+    const index = merkleBalances.findIndex(v => v.account.toLowerCase() === address);
     if (index === -1) return false;
 
     const migrateContract = this.contractFactory.illuviumIlvPoolV2({

--- a/src/apps/illuvium/ethereum/illuvium.migration-manager.ts
+++ b/src/apps/illuvium/ethereum/illuvium.migration-manager.ts
@@ -1,0 +1,53 @@
+import { Inject, Injectable } from '@nestjs/common';
+import Axios from 'axios';
+
+import { CacheOnInterval } from '~cache/cache-on-interval.decorator';
+import { Network } from '~types/network.interface';
+
+import { IlluviumContractFactory } from '../contracts';
+import { ILLUVIUM_DEFINITION } from '../illuvium.definition';
+
+import merkleBalances from './illuvium.merkle-balances.json';
+
+type MerkleBalanceEntry = {
+  account: string;
+  pendingV1Rewards: {
+    type: string;
+    hex: string;
+  };
+  weight: {
+    type: string;
+    hex: string;
+  };
+};
+
+@Injectable()
+export class EthereumIlluviumMigrationManager {
+  private readonly ILV_MIGRATE_ADDRESS = '0x7f5f854ffb6b7701540a00c69c4ab2de2b34291d';
+
+  constructor(@Inject(IlluviumContractFactory) private readonly contractFactory: IlluviumContractFactory) {}
+
+  @CacheOnInterval({
+    key: `studio:${ILLUVIUM_DEFINITION.id}:${Network.ETHEREUM_MAINNET}:merkle-balances`,
+    timeout: 15 * 60 * 1000,
+  })
+  async getMerkleBalances() {
+    const ipfsHost = process.env.IPFS_HOST || 'https://cf-ipfs.com';
+    const endpoint = `${ipfsHost}/ipfs/QmTT8nx2QMbJYsyavKvsBLZ76veT8jN6zQ1sxcaqR5GDg9`;
+    const result = await Axios.get<MerkleBalanceEntry[]>(endpoint).then(v => v.data);
+    return result;
+  }
+
+  async hasMigrated(address: string) {
+    const index = (merkleBalances as MerkleBalanceEntry[]).findIndex(v => v.account.toLowerCase() === address);
+    if (index === -1) return false;
+
+    const migrateContract = this.contractFactory.illuviumIlvPoolV2({
+      address: this.ILV_MIGRATE_ADDRESS,
+      network: Network.ETHEREUM_MAINNET,
+    });
+
+    const hasMigrated = await migrateContract.hasMigratedYield(index);
+    return hasMigrated;
+  }
+}

--- a/src/apps/illuvium/illuvium.module.ts
+++ b/src/apps/illuvium/illuvium.module.ts
@@ -6,6 +6,7 @@ import { IlluviumContractFactory } from './contracts';
 import { EthereumIlluviumBalanceFetcher } from './ethereum/illuvium.balance-fetcher';
 import { EthereumIlluviumFarmV2ContractPositionFetcher } from './ethereum/illuvium.farm-v2.contract-position-fetcher';
 import { EthereumIlluviumFarmContractPositionFetcher } from './ethereum/illuvium.farm.contract-position-fetcher';
+import { EthereumIlluviumMigrationManager } from './ethereum/illuvium.migration-manager';
 import { IlluviumAppDefinition } from './illuvium.definition';
 
 @Module({
@@ -15,6 +16,7 @@ import { IlluviumAppDefinition } from './illuvium.definition';
     EthereumIlluviumFarmContractPositionFetcher,
     EthereumIlluviumFarmV2ContractPositionFetcher,
     EthereumIlluviumBalanceFetcher,
+    EthereumIlluviumMigrationManager,
   ],
 })
 export class IlluviumAppModule extends AbstractApp() {}


### PR DESCRIPTION
## Description

- Missing await in V1 balances
- Add migration manager class (not used right now) for tracking migrations... might be useful, but not used in Illuvium FE anyway

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

http://localhost:5001/apps/illuvium/balances?addresses[]=0x1f279aad56278d67d31ca1c89480ac7152e5c45a
Tested with Impersonator on Illuvium staking, final amount matches.