### PR TITLE
chore: Add script intermediary

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "prepublish:npm": "pnpm build",
     "publish:npm": "pnpm publish --access public",
     "start": "nest start",
-    "studio": "./studio.sh",
-    "studio-n": "node ./scripts/run-cli.js",
+    "studio": "node ./scripts/run-cli.js",
     "test": "jest --runInBand --forceExit",
     "test:integration": "jest --runInBand --forceExit --config jest.integration.config.js",
     "test:watch": "jest --watch"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "publish:npm": "pnpm publish --access public",
     "start": "nest start",
     "studio": "./studio.sh",
+    "studio-n": "node ./scripts/run-cli.js",
     "test": "jest --runInBand --forceExit",
     "test:integration": "jest --runInBand --forceExit --config jest.integration.config.js",
     "test:watch": "jest --watch"

--- a/scripts/run-cli.js
+++ b/scripts/run-cli.js
@@ -1,0 +1,10 @@
+const { execSync } = require('child_process');
+
+const isWin = process.platform === 'win32';
+const args = process.argv.slice(2).join(' ');
+
+if (isWin) {
+  execSync(`./studio.bat ${args}`, { stdio: 'inherit' });
+} else {
+  execSync(`./studio.sh ${args}`, { stdio: 'inherit' });
+}

--- a/scripts/run-cli.js
+++ b/scripts/run-cli.js
@@ -4,7 +4,7 @@ const isWin = process.platform === 'win32';
 const args = process.argv.slice(2).join(' ');
 
 if (isWin) {
-  execSync(`./studio.bat ${args}`, { stdio: 'inherit' });
+  execSync(`studio.bat ${args}`, { stdio: 'inherit' });
 } else {
   execSync(`./studio.sh ${args}`, { stdio: 'inherit' });
 }


### PR DESCRIPTION
## Description

Need to provide a way to switch scripts between windows and *nix like envs

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
