### PR TITLE
fix: Fix undefined positions when cache is not primed

### DIFF
--- a/src/position/position-source/position-source.registry.ts
+++ b/src/position/position-source/position-source.registry.ts
@@ -75,7 +75,9 @@ export class RegistryPositionSource implements PositionSource {
     );
 
     const validFetchers = compact(fetchers);
-    const positions = (await Promise.all(validFetchers.map(fetcher => fetcher.getPositions()))) as T[][];
+    const positions = (await Promise.all(
+      validFetchers.map(async fetcher => (await fetcher.getPositions()) ?? []),
+    )) as T[][];
     return positions.flat();
   }
 }


### PR DESCRIPTION
## Description

- Unprimed cache returns undefined; default to an empty array in `getPositions` so that callers run successfully

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

No errors when starting `ENABLED_APPS` as `pickle,yearn,curve,synthetix`