### PR TITLE
build: Trigger Studio Docs deployment when CHANGELOG.md is updated

### DIFF
--- a/.github/workflows/trigger-studio-docs-deploy.yml
+++ b/.github/workflows/trigger-studio-docs-deploy.yml
@@ -1,0 +1,16 @@
+name: Trigger Studio Docs Deploy
+
+on:
+  push:
+    paths:
+      - 'CHANGELOG.md'
+    branches: ['main']
+
+jobs:
+  trigger-studio-docs-deploy:
+    name: Trigger Studio Docs Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger deploy hook
+        run: |
+          curl -X POST ${{ secrets.STUDIO_DOCS_DEPLOY_HOOK }}


### PR DESCRIPTION
## Description

When `CHANGELOG.md` is updated, trigger a deployment on Studio Docs so that https://studio-docs.zapper.fi/docs/CHANGELOG is updated.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
