### PR TITLE
fix: Capitalize DFX app name

### DIFF
--- a/src/apps/dfx/dfx.definition.ts
+++ b/src/apps/dfx/dfx.definition.ts
@@ -5,7 +5,7 @@ import { Network } from '~types/network.interface';
 
 export const DFX_DEFINITION = appDefinition({
   id: 'dfx',
-  name: 'dfx',
+  name: 'DFX',
   description: 'DFX.Finance is a decentralized foreign exchange protocol optimized for stablecoins',
   url: 'https://app.dfx.finance/',
   links: {


### PR DESCRIPTION
## Description

Small fix to capitalize the DFX app name.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

Name displays properly in DFX app page.