### PR TITLE
fix(convex): Add synths as deps for factory pools

### DIFF
--- a/src/apps/curve/ethereum/curve.pool.token-fetcher.ts
+++ b/src/apps/curve/ethereum/curve.pool.token-fetcher.ts
@@ -91,7 +91,7 @@ export class EthereumCurvePoolTokenFetcher implements PositionFetcher<AppTokenPo
           { appId: 'aave-v2', groupIds: ['supply'], network },
           { appId: 'compound', groupIds: ['supply'], network },
           { appId: 'iron-bank', groupIds: ['supply'], network },
-          { appId: SYNTHETIX_DEFINITION.id, groupIds: [SYNTHETIX_DEFINITION.groups.farm.id], network },
+          { appId: SYNTHETIX_DEFINITION.id, groupIds: [SYNTHETIX_DEFINITION.groups.farm.id, SYNTHETIX_DEFINITION.groups.synth.id], network },
           { appId: 'convex', groupIds: ['farm'], network },
           { appId: YEARN_DEFINITION.id, groupIds: [YEARN_DEFINITION.groups.vault.id], network },
         ],


### PR DESCRIPTION
## Description

Convex sCHF ibCHF & sAUD ibAUD positions were not displayed because synths were not used in curve's deps
## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
