### PR TITLE
fix(multicall): Fix typing on wrap function for Multicall wrapper

### DIFF
--- a/src/multicall/multicall.ethers.ts
+++ b/src/multicall/multicall.ethers.ts
@@ -12,6 +12,8 @@ export type ContractCall = {
   params: any[];
 };
 
+type TargetContract = Pick<Contract, 'functions' | 'interface' | 'callStatic' | 'address'>;
+
 export class EthersMulticall {
   private multicall: Multicall;
   private dataLoader: DataLoader<ContractCall, any>;
@@ -53,7 +55,7 @@ export class EthersMulticall {
     return result;
   }
 
-  wrap<T extends Contract>(contract: T) {
+  wrap<T extends TargetContract>(contract: T) {
     const abi = contract.interface.fragments;
     const multicallContract = new MulticallContract(contract.address, abi as any);
 


### PR DESCRIPTION
## Description

Zapper API does not like the typing, probably due to a `ethers` or `typechain` version mismatch. Revert to the previous typing for `wrap`.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

Zapper API build succeeds.