### PR TITLE
fix(prices): Cache prices for 1 minute

### DIFF
--- a/src/token/token.service.ts
+++ b/src/token/token.service.ts
@@ -17,7 +17,7 @@ export class TokenService {
     });
   }
 
-  @Cache({ key: (network: Network) => `token-prices:${network}` })
+  @Cache({ key: (network: Network) => `token-prices:${network}`, ttl: 60 })
   async getTokenPrices(network: Network) {
     const { data: tokenPrices } = await this.axios.get<BaseToken[]>('/v1/prices-v3', { params: { network } });
     return tokenPrices;


### PR DESCRIPTION
## Description

If the cache is not set with a TTL, then the prices cache is never cleared. This was an issue for a user that needed the THALES token. We added the token, but their prices response still didn't have THALES token because it was always reading from cache.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

