### PR TITLE
fix(pancakeswap): Fix staked cake balance

### DIFF
--- a/src/apps/pancakeswap/binance/pancakeswap.balance-fetcher.ts
+++ b/src/apps/pancakeswap/binance/pancakeswap.balance-fetcher.ts
@@ -25,8 +25,7 @@ const network = Network.BINANCE_SMART_CHAIN_MAINNET;
 export class BinanceSmartChainPancakeSwapBalanceFetcher implements BalanceFetcher {
   constructor(
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
-    @Inject(PancakeswapContractFactory)
-    private readonly contractFactory: PancakeswapContractFactory,
+    @Inject(PancakeswapContractFactory) private readonly contractFactory: PancakeswapContractFactory,
   ) {}
 
   private async getPoolBalances(address: string) {
@@ -155,8 +154,9 @@ export class BinanceSmartChainPancakeSwapBalanceFetcher implements BalanceFetche
           ]);
 
           const shares = userInfo.shares.toString();
+          const userBoostedShare = userInfo.userBoostedShare.toString();
           const pricePerShare = Number(pricePerShareRaw) / 10 ** 18;
-          return new BigNumber(shares).times(pricePerShare).toFixed(0);
+          return new BigNumber(shares).times(pricePerShare).minus(userBoostedShare).toFixed(0);
         },
       }),
       resolveClaimableTokenBalances: this.appToolkit.helpers.masterChefDefaultClaimableBalanceStrategy.build({


### PR DESCRIPTION
## Description

We need to subtract the boosted share amount. See [here](https://github.com/pancakeswap/pancake-frontend/blob/cbb404da0439024f691c3293b4ee36efe7ac8a54/src/state/pools/helpers.ts#L104) for details.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

http://localhost:5001/apps/pancakeswap/balances?addresses[]=0xfbE849ea94Aa5Acd53C83776449620B1B51976DB&network=binance-smart-chain