### PR TITLE
refactor(curve): Rename rewards only gauge strategies to match the Curve naming

### DIFF
--- a/src/apps/curve/arbitrum/curve.farm.contract-position-fetcher.ts
+++ b/src/apps/curve/arbitrum/curve.farm.contract-position-fetcher.ts
@@ -11,8 +11,8 @@ import { CURVE_DEFINITION } from '../curve.definition';
 import { CurveChildLiquidityGaugeFactoryAddressHelper } from '../helpers/curve.child-liquidity-gauge-factory.address-helper';
 import { CurveChildLiquidityGaugeRewardTokenStrategy } from '../helpers/curve.child-liquidity-gauge.reward-token-strategy';
 import { CurveChildLiquidityGaugeRoiStrategy } from '../helpers/curve.child-liquidity-gauge.roi-strategy';
-import { CurveGaugeV2RewardTokenStrategy } from '../helpers/curve.gauge-v2.reward-token-strategy';
-import { CurveGaugeV2RoiStrategy } from '../helpers/curve.gauge-v2.roi-strategy';
+import { CurveRewardsOnlyGaugeRewardTokenStrategy } from '../helpers/curve.rewards-only-gauge.reward-token-strategy';
+import { CurveRewardsOnlyGaugeRoiStrategy } from '../helpers/curve.rewards-only-gauge.roi-strategy';
 
 import { CURVE_V1_POOL_DEFINITIONS, CURVE_V2_POOL_DEFINITIONS } from './curve.pool.definitions';
 
@@ -26,10 +26,10 @@ export class ArbitrumCurveFarmContractPositionFetcher implements PositionFetcher
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
     @Inject(CurveContractFactory)
     private readonly curveContractFactory: CurveContractFactory,
-    @Inject(CurveGaugeV2RoiStrategy)
-    private readonly curveGaugeV2RoiStrategy: CurveGaugeV2RoiStrategy,
-    @Inject(CurveGaugeV2RewardTokenStrategy)
-    private readonly curveGaugeV2RewardTokenStrategy: CurveGaugeV2RewardTokenStrategy,
+    @Inject(CurveRewardsOnlyGaugeRoiStrategy)
+    private readonly curveRewardsOnlyGaugeRoiStrategy: CurveRewardsOnlyGaugeRoiStrategy,
+    @Inject(CurveRewardsOnlyGaugeRewardTokenStrategy)
+    private readonly curveRewardsOnlyGaugeRewardTokenStrategy: CurveRewardsOnlyGaugeRewardTokenStrategy,
     @Inject(CurveChildLiquidityGaugeFactoryAddressHelper)
     private readonly childGaugeAddressHelper: CurveChildLiquidityGaugeFactoryAddressHelper,
     @Inject(CurveChildLiquidityGaugeRoiStrategy)
@@ -50,9 +50,9 @@ export class ArbitrumCurveFarmContractPositionFetcher implements PositionFetcher
       resolveFarmContract: ({ address, network }) =>
         this.curveContractFactory.curveRewardsOnlyGauge({ address, network }),
       resolveStakedTokenAddress: ({ contract, multicall }) => multicall.wrap(contract).lp_token(),
-      resolveRewardTokenAddresses: this.curveGaugeV2RewardTokenStrategy.build(),
+      resolveRewardTokenAddresses: this.curveRewardsOnlyGaugeRewardTokenStrategy.build(),
       resolveIsActive: () => true,
-      resolveRois: this.curveGaugeV2RoiStrategy.build({
+      resolveRois: this.curveRewardsOnlyGaugeRoiStrategy.build({
         tokenDefinitions: definitions,
       }),
     });

--- a/src/apps/curve/avalanche/curve.farm.contract-position-fetcher.ts
+++ b/src/apps/curve/avalanche/curve.farm.contract-position-fetcher.ts
@@ -11,8 +11,8 @@ import { CURVE_DEFINITION } from '../curve.definition';
 import { CurveChildLiquidityGaugeFactoryAddressHelper } from '../helpers/curve.child-liquidity-gauge-factory.address-helper';
 import { CurveChildLiquidityGaugeRewardTokenStrategy } from '../helpers/curve.child-liquidity-gauge.reward-token-strategy';
 import { CurveChildLiquidityGaugeRoiStrategy } from '../helpers/curve.child-liquidity-gauge.roi-strategy';
-import { CurveGaugeV2RewardTokenStrategy } from '../helpers/curve.gauge-v2.reward-token-strategy';
-import { CurveGaugeV2RoiStrategy } from '../helpers/curve.gauge-v2.roi-strategy';
+import { CurveRewardsOnlyGaugeRewardTokenStrategy } from '../helpers/curve.rewards-only-gauge.reward-token-strategy';
+import { CurveRewardsOnlyGaugeRoiStrategy } from '../helpers/curve.rewards-only-gauge.roi-strategy';
 
 import { CURVE_V1_POOL_DEFINITIONS, CURVE_V2_POOL_DEFINITIONS } from './curve.pool.definitions';
 
@@ -26,10 +26,10 @@ export class AvalancheCurveFarmContractPositionFetcher implements PositionFetche
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
     @Inject(CurveContractFactory)
     private readonly curveContractFactory: CurveContractFactory,
-    @Inject(CurveGaugeV2RoiStrategy)
-    private readonly curveGaugeV2RoiStrategy: CurveGaugeV2RoiStrategy,
-    @Inject(CurveGaugeV2RewardTokenStrategy)
-    private readonly curveGaugeV2RewardTokenStrategy: CurveGaugeV2RewardTokenStrategy,
+    @Inject(CurveRewardsOnlyGaugeRoiStrategy)
+    private readonly curveRewardsOnlyGaugeRoiStrategy: CurveRewardsOnlyGaugeRoiStrategy,
+    @Inject(CurveRewardsOnlyGaugeRewardTokenStrategy)
+    private readonly curveRewardsOnlyGaugeRewardTokenStrategy: CurveRewardsOnlyGaugeRewardTokenStrategy,
     @Inject(CurveChildLiquidityGaugeFactoryAddressHelper)
     private readonly childGaugeAddressHelper: CurveChildLiquidityGaugeFactoryAddressHelper,
     @Inject(CurveChildLiquidityGaugeRoiStrategy)
@@ -51,8 +51,8 @@ export class AvalancheCurveFarmContractPositionFetcher implements PositionFetche
       resolveFarmContract: ({ address, network }) =>
         this.curveContractFactory.curveRewardsOnlyGauge({ address, network }),
       resolveStakedTokenAddress: ({ contract, multicall }) => multicall.wrap(contract).lp_token(),
-      resolveRewardTokenAddresses: this.curveGaugeV2RewardTokenStrategy.build(),
-      resolveRois: this.curveGaugeV2RoiStrategy.build({ tokenDefinitions: definitions }),
+      resolveRewardTokenAddresses: this.curveRewardsOnlyGaugeRewardTokenStrategy.build(),
+      resolveRois: this.curveRewardsOnlyGaugeRoiStrategy.build({ tokenDefinitions: definitions }),
       resolveIsActive: () => true,
     });
   }

--- a/src/apps/curve/curve.module.ts
+++ b/src/apps/curve/curve.module.ts
@@ -32,8 +32,6 @@ import { CurveCryptoFactoryPoolDefinitionStrategy } from './helpers/curve.crypto
 import { CurveFactoryGaugeAddressHelper } from './helpers/curve.factory-gauge.address-helper';
 import { CurveFactoryPoolTokenHelper } from './helpers/curve.factory-pool.token-helper';
 import { CurveFactoryPoolDefinitionStrategy } from './helpers/curve.factory.pool-definition-strategy';
-import { CurveGaugeV2RewardTokenStrategy } from './helpers/curve.gauge-v2.reward-token-strategy';
-import { CurveGaugeV2RoiStrategy } from './helpers/curve.gauge-v2.roi-strategy';
 import { CurveGaugeIsActiveStrategy } from './helpers/curve.gauge.is-active-strategy';
 import { CurveGaugeRoiStrategy } from './helpers/curve.gauge.roi-strategy';
 import { CurveLiquidityPriceStrategy } from './helpers/curve.liquidity.price-strategy';
@@ -41,6 +39,8 @@ import { CurveOnChainCoinStrategy } from './helpers/curve.on-chain.coin-strategy
 import { CurveOnChainReserveStrategy } from './helpers/curve.on-chain.reserve-strategy';
 import { CurveOnChainVolumeStrategy } from './helpers/curve.on-chain.volume-strategy';
 import { CurvePoolTokenHelper } from './helpers/curve.pool.token-helper';
+import { CurveRewardsOnlyGaugeRewardTokenStrategy } from './helpers/curve.rewards-only-gauge.reward-token-strategy';
+import { CurveRewardsOnlyGaugeRoiStrategy } from './helpers/curve.rewards-only-gauge.roi-strategy';
 import { CurveV1PoolTokenHelper } from './helpers/curve.v1-pool.token-helper';
 import { CurveV2PoolTokenHelper } from './helpers/curve.v2-pool.token-helper';
 import { CurveVestingEscrowContractPositionBalanceHelper } from './helpers/curve.vesting-escrow.contract-position-balance-helper';
@@ -114,8 +114,8 @@ import { PolygonCurvePoolTokenFetcher } from './polygon/curve.pool.token-fetcher
     CurveGaugeRoiStrategy,
     CurveFactoryGaugeAddressHelper,
     // Legacy Sidechain/L2 Gauges
-    CurveGaugeV2RoiStrategy,
-    CurveGaugeV2RewardTokenStrategy,
+    CurveRewardsOnlyGaugeRoiStrategy,
+    CurveRewardsOnlyGaugeRewardTokenStrategy,
     // Sidechain/L2 gauges
     CurveChildLiquidityGaugeRoiStrategy,
     CurveChildLiquidityGaugeRewardTokenStrategy,
@@ -146,8 +146,8 @@ import { PolygonCurvePoolTokenFetcher } from './polygon/curve.pool.token-fetcher
     // Gauge Helper Strategies
     CurveGaugeIsActiveStrategy,
     CurveGaugeRoiStrategy,
-    CurveGaugeV2RoiStrategy,
-    CurveGaugeV2RewardTokenStrategy,
+    CurveRewardsOnlyGaugeRoiStrategy,
+    CurveRewardsOnlyGaugeRewardTokenStrategy,
     CurveFactoryGaugeAddressHelper,
     // Voting Escrow Helpers
     CurveVotingEscrowContractPositionHelper,

--- a/src/apps/curve/fantom/curve.farm.contract-position-fetcher.ts
+++ b/src/apps/curve/fantom/curve.farm.contract-position-fetcher.ts
@@ -11,8 +11,8 @@ import { CURVE_DEFINITION } from '../curve.definition';
 import { CurveChildLiquidityGaugeFactoryAddressHelper } from '../helpers/curve.child-liquidity-gauge-factory.address-helper';
 import { CurveChildLiquidityGaugeRewardTokenStrategy } from '../helpers/curve.child-liquidity-gauge.reward-token-strategy';
 import { CurveChildLiquidityGaugeRoiStrategy } from '../helpers/curve.child-liquidity-gauge.roi-strategy';
-import { CurveGaugeV2RewardTokenStrategy } from '../helpers/curve.gauge-v2.reward-token-strategy';
-import { CurveGaugeV2RoiStrategy } from '../helpers/curve.gauge-v2.roi-strategy';
+import { CurveRewardsOnlyGaugeRewardTokenStrategy } from '../helpers/curve.rewards-only-gauge.reward-token-strategy';
+import { CurveRewardsOnlyGaugeRoiStrategy } from '../helpers/curve.rewards-only-gauge.roi-strategy';
 
 import {
   CURVE_V1_METAPOOL_DEFINITIONS,
@@ -30,10 +30,10 @@ export class FantomCurveFarmContractPositionFetcher implements PositionFetcher<C
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
     @Inject(CurveContractFactory)
     private readonly curveContractFactory: CurveContractFactory,
-    @Inject(CurveGaugeV2RoiStrategy)
-    private readonly curveGaugeV2RoiStrategy: CurveGaugeV2RoiStrategy,
-    @Inject(CurveGaugeV2RewardTokenStrategy)
-    private readonly curveGaugeV2RewardTokenStrategy: CurveGaugeV2RewardTokenStrategy,
+    @Inject(CurveRewardsOnlyGaugeRoiStrategy)
+    private readonly curveRewardsOnlyGaugeRoiStrategy: CurveRewardsOnlyGaugeRoiStrategy,
+    @Inject(CurveRewardsOnlyGaugeRewardTokenStrategy)
+    private readonly curveRewardsOnlyGaugeRewardTokenStrategy: CurveRewardsOnlyGaugeRewardTokenStrategy,
     @Inject(CurveChildLiquidityGaugeFactoryAddressHelper)
     private readonly childGaugeAddressHelper: CurveChildLiquidityGaugeFactoryAddressHelper,
     @Inject(CurveChildLiquidityGaugeRoiStrategy)
@@ -57,8 +57,8 @@ export class FantomCurveFarmContractPositionFetcher implements PositionFetcher<C
       resolveFarmContract: ({ address, network }) =>
         this.curveContractFactory.curveRewardsOnlyGauge({ address, network }),
       resolveStakedTokenAddress: ({ contract, multicall }) => multicall.wrap(contract).lp_token(),
-      resolveRewardTokenAddresses: this.curveGaugeV2RewardTokenStrategy.build(),
-      resolveRois: this.curveGaugeV2RoiStrategy.build({ tokenDefinitions: definitions }),
+      resolveRewardTokenAddresses: this.curveRewardsOnlyGaugeRewardTokenStrategy.build(),
+      resolveRois: this.curveRewardsOnlyGaugeRoiStrategy.build({ tokenDefinitions: definitions }),
       resolveIsActive: () => true,
     });
   }

--- a/src/apps/curve/gnosis/curve.farm.contract-position-fetcher.ts
+++ b/src/apps/curve/gnosis/curve.farm.contract-position-fetcher.ts
@@ -11,8 +11,8 @@ import { CURVE_DEFINITION } from '../curve.definition';
 import { CurveChildLiquidityGaugeFactoryAddressHelper } from '../helpers/curve.child-liquidity-gauge-factory.address-helper';
 import { CurveChildLiquidityGaugeRewardTokenStrategy } from '../helpers/curve.child-liquidity-gauge.reward-token-strategy';
 import { CurveChildLiquidityGaugeRoiStrategy } from '../helpers/curve.child-liquidity-gauge.roi-strategy';
-import { CurveGaugeV2RewardTokenStrategy } from '../helpers/curve.gauge-v2.reward-token-strategy';
-import { CurveGaugeV2RoiStrategy } from '../helpers/curve.gauge-v2.roi-strategy';
+import { CurveRewardsOnlyGaugeRewardTokenStrategy } from '../helpers/curve.rewards-only-gauge.reward-token-strategy';
+import { CurveRewardsOnlyGaugeRoiStrategy } from '../helpers/curve.rewards-only-gauge.roi-strategy';
 
 import { CURVE_V1_POOL_DEFINITIONS } from './curve.pool.definitions';
 
@@ -26,10 +26,10 @@ export class GnosisCurveFarmContractPositionFetcher implements PositionFetcher<C
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
     @Inject(CurveContractFactory)
     private readonly curveContractFactory: CurveContractFactory,
-    @Inject(CurveGaugeV2RoiStrategy)
-    private readonly curveGaugeV2RoiStrategy: CurveGaugeV2RoiStrategy,
-    @Inject(CurveGaugeV2RewardTokenStrategy)
-    private readonly curveGaugeV2RewardTokenStrategy: CurveGaugeV2RewardTokenStrategy,
+    @Inject(CurveRewardsOnlyGaugeRoiStrategy)
+    private readonly curveRewardsOnlyGaugeRoiStrategy: CurveRewardsOnlyGaugeRoiStrategy,
+    @Inject(CurveRewardsOnlyGaugeRewardTokenStrategy)
+    private readonly curveRewardsOnlyGaugeRewardTokenStrategy: CurveRewardsOnlyGaugeRewardTokenStrategy,
     @Inject(CurveChildLiquidityGaugeFactoryAddressHelper)
     private readonly childGaugeAddressHelper: CurveChildLiquidityGaugeFactoryAddressHelper,
     @Inject(CurveChildLiquidityGaugeRoiStrategy)
@@ -51,8 +51,8 @@ export class GnosisCurveFarmContractPositionFetcher implements PositionFetcher<C
       resolveFarmContract: ({ address, network }) =>
         this.curveContractFactory.curveRewardsOnlyGauge({ address, network }),
       resolveStakedTokenAddress: ({ contract, multicall }) => multicall.wrap(contract).lp_token(),
-      resolveRewardTokenAddresses: this.curveGaugeV2RewardTokenStrategy.build(),
-      resolveRois: this.curveGaugeV2RoiStrategy.build({ tokenDefinitions: definitions }),
+      resolveRewardTokenAddresses: this.curveRewardsOnlyGaugeRewardTokenStrategy.build(),
+      resolveRois: this.curveRewardsOnlyGaugeRoiStrategy.build({ tokenDefinitions: definitions }),
       resolveIsActive: () => true,
     });
   }

--- a/src/apps/curve/harmony/curve.farm.contract-position-fetcher.ts
+++ b/src/apps/curve/harmony/curve.farm.contract-position-fetcher.ts
@@ -11,8 +11,8 @@ import { CURVE_DEFINITION } from '../curve.definition';
 import { CurveChildLiquidityGaugeFactoryAddressHelper } from '../helpers/curve.child-liquidity-gauge-factory.address-helper';
 import { CurveChildLiquidityGaugeRewardTokenStrategy } from '../helpers/curve.child-liquidity-gauge.reward-token-strategy';
 import { CurveChildLiquidityGaugeRoiStrategy } from '../helpers/curve.child-liquidity-gauge.roi-strategy';
-import { CurveGaugeV2RewardTokenStrategy } from '../helpers/curve.gauge-v2.reward-token-strategy';
-import { CurveGaugeV2RoiStrategy } from '../helpers/curve.gauge-v2.roi-strategy';
+import { CurveRewardsOnlyGaugeRewardTokenStrategy } from '../helpers/curve.rewards-only-gauge.reward-token-strategy';
+import { CurveRewardsOnlyGaugeRoiStrategy } from '../helpers/curve.rewards-only-gauge.roi-strategy';
 
 import { CURVE_V1_POOL_DEFINITIONS, CURVE_V2_POOL_DEFINITIONS } from './curve.pool.definitions';
 
@@ -26,10 +26,10 @@ export class HarmonyCurveFarmContractPositionFetcher implements PositionFetcher<
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
     @Inject(CurveContractFactory)
     private readonly curveContractFactory: CurveContractFactory,
-    @Inject(CurveGaugeV2RoiStrategy)
-    private readonly curveGaugeV2RoiStrategy: CurveGaugeV2RoiStrategy,
-    @Inject(CurveGaugeV2RewardTokenStrategy)
-    private readonly curveGaugeV2RewardTokenStrategy: CurveGaugeV2RewardTokenStrategy,
+    @Inject(CurveRewardsOnlyGaugeRoiStrategy)
+    private readonly curveRewardsOnlyGaugeRoiStrategy: CurveRewardsOnlyGaugeRoiStrategy,
+    @Inject(CurveRewardsOnlyGaugeRewardTokenStrategy)
+    private readonly curveRewardsOnlyGaugeRewardTokenStrategy: CurveRewardsOnlyGaugeRewardTokenStrategy,
     @Inject(CurveChildLiquidityGaugeFactoryAddressHelper)
     private readonly childGaugeAddressHelper: CurveChildLiquidityGaugeFactoryAddressHelper,
     @Inject(CurveChildLiquidityGaugeRoiStrategy)
@@ -51,8 +51,8 @@ export class HarmonyCurveFarmContractPositionFetcher implements PositionFetcher<
       resolveFarmContract: ({ address, network }) =>
         this.curveContractFactory.curveRewardsOnlyGauge({ address, network }),
       resolveStakedTokenAddress: ({ contract, multicall }) => multicall.wrap(contract).lp_token(),
-      resolveRewardTokenAddresses: this.curveGaugeV2RewardTokenStrategy.build(),
-      resolveRois: this.curveGaugeV2RoiStrategy.build({ tokenDefinitions: definitions }),
+      resolveRewardTokenAddresses: this.curveRewardsOnlyGaugeRewardTokenStrategy.build(),
+      resolveRois: this.curveRewardsOnlyGaugeRoiStrategy.build({ tokenDefinitions: definitions }),
       resolveIsActive: () => true,
     });
   }

--- a/src/apps/curve/helpers/curve.rewards-only-gauge.reward-token-strategy.ts
+++ b/src/apps/curve/helpers/curve.rewards-only-gauge.reward-token-strategy.ts
@@ -4,11 +4,11 @@ import { range } from 'lodash';
 import { SingleStakingFarmContractPositionHelperParams } from '~app-toolkit';
 import { ZERO_ADDRESS } from '~app-toolkit/constants/address';
 
-import { CurveGaugeV2 } from '../contracts';
+import { CurveRewardsOnlyGauge } from '../contracts';
 
 @Injectable()
-export class CurveGaugeV2RewardTokenStrategy {
-  build(): SingleStakingFarmContractPositionHelperParams<CurveGaugeV2>['resolveRewardTokenAddresses'] {
+export class CurveRewardsOnlyGaugeRewardTokenStrategy {
+  build(): SingleStakingFarmContractPositionHelperParams<CurveRewardsOnlyGauge>['resolveRewardTokenAddresses'] {
     return async ({ contract, multicall }) => {
       // Gauge V2 supports up to 4 different reward tokens
       const MAX_REWARDS = 4;

--- a/src/apps/curve/helpers/curve.rewards-only-gauge.roi-strategy.ts
+++ b/src/apps/curve/helpers/curve.rewards-only-gauge.roi-strategy.ts
@@ -18,12 +18,12 @@ type GetRewardsInUsdOpts = {
   network: Network;
 };
 
-type CurveGaugeV2RoiStrategyParams = {
+type CurveRewardsOnlyGaugeRoiStrategyParams = {
   tokenDefinitions: CurvePoolDefinition[];
 };
 
 @Injectable()
-export class CurveGaugeV2RoiStrategy {
+export class CurveRewardsOnlyGaugeRoiStrategy {
   constructor(
     @Inject(CurveContractFactory)
     private readonly curveContractFactory: CurveContractFactory,
@@ -31,7 +31,7 @@ export class CurveGaugeV2RoiStrategy {
 
   build({
     tokenDefinitions,
-  }: CurveGaugeV2RoiStrategyParams): SingleStakingFarmContractPositionHelperParams<CurveGaugeV2>['resolveRois'] {
+  }: CurveRewardsOnlyGaugeRoiStrategyParams): SingleStakingFarmContractPositionHelperParams<CurveGaugeV2>['resolveRois'] {
     return async ({ multicall, address, stakedToken, rewardTokens, network }) => {
       // Get the TVL of the pool to calculate the APY as a fraction
       const tokenContract = this.curveContractFactory.erc20({ address: stakedToken.address, network });

--- a/src/apps/curve/index.ts
+++ b/src/apps/curve/index.ts
@@ -9,8 +9,8 @@ export { CurveCryptoFactoryPoolDefinitionStrategy } from './helpers/curve.crypto
 export { CurveFactoryGaugeAddressHelper } from './helpers/curve.factory-gauge.address-helper';
 export { CurveFactoryPoolTokenHelper } from './helpers/curve.factory-pool.token-helper';
 export { CurveFactoryPoolDefinitionStrategy } from './helpers/curve.factory.pool-definition-strategy';
-export { CurveGaugeV2RewardTokenStrategy } from './helpers/curve.gauge-v2.reward-token-strategy';
-export { CurveGaugeV2RoiStrategy } from './helpers/curve.gauge-v2.roi-strategy';
+export { CurveRewardsOnlyGaugeRewardTokenStrategy } from './helpers/curve.rewards-only-gauge.reward-token-strategy';
+export { CurveRewardsOnlyGaugeRoiStrategy } from './helpers/curve.rewards-only-gauge.roi-strategy';
 export { CurveGaugeIsActiveStrategy } from './helpers/curve.gauge.is-active-strategy';
 export { CurveGaugeRoiStrategy } from './helpers/curve.gauge.roi-strategy';
 export { CurveLiquidityPriceStrategy } from './helpers/curve.liquidity.price-strategy';

--- a/src/apps/curve/optimism/curve.farm.contract-position-fetcher.ts
+++ b/src/apps/curve/optimism/curve.farm.contract-position-fetcher.ts
@@ -11,8 +11,8 @@ import { CURVE_DEFINITION } from '../curve.definition';
 import { CurveChildLiquidityGaugeFactoryAddressHelper } from '../helpers/curve.child-liquidity-gauge-factory.address-helper';
 import { CurveChildLiquidityGaugeRewardTokenStrategy } from '../helpers/curve.child-liquidity-gauge.reward-token-strategy';
 import { CurveChildLiquidityGaugeRoiStrategy } from '../helpers/curve.child-liquidity-gauge.roi-strategy';
-import { CurveGaugeV2RewardTokenStrategy } from '../helpers/curve.gauge-v2.reward-token-strategy';
-import { CurveGaugeV2RoiStrategy } from '../helpers/curve.gauge-v2.roi-strategy';
+import { CurveRewardsOnlyGaugeRewardTokenStrategy } from '../helpers/curve.rewards-only-gauge.reward-token-strategy';
+import { CurveRewardsOnlyGaugeRoiStrategy } from '../helpers/curve.rewards-only-gauge.roi-strategy';
 
 import { CURVE_V1_POOL_DEFINITIONS } from './curve.pool.definitions';
 
@@ -26,10 +26,10 @@ export class OptimismCurveFarmContractPositionFetcher implements PositionFetcher
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
     @Inject(CurveContractFactory)
     private readonly curveContractFactory: CurveContractFactory,
-    @Inject(CurveGaugeV2RoiStrategy)
-    private readonly curveGaugeV2RoiStrategy: CurveGaugeV2RoiStrategy,
-    @Inject(CurveGaugeV2RewardTokenStrategy)
-    private readonly curveGaugeV2RewardTokenStrategy: CurveGaugeV2RewardTokenStrategy,
+    @Inject(CurveRewardsOnlyGaugeRoiStrategy)
+    private readonly curveRewardsOnlyGaugeRoiStrategy: CurveRewardsOnlyGaugeRoiStrategy,
+    @Inject(CurveRewardsOnlyGaugeRewardTokenStrategy)
+    private readonly curveRewardsOnlyGaugeRewardTokenStrategy: CurveRewardsOnlyGaugeRewardTokenStrategy,
     @Inject(CurveChildLiquidityGaugeFactoryAddressHelper)
     private readonly childGaugeAddressHelper: CurveChildLiquidityGaugeFactoryAddressHelper,
     @Inject(CurveChildLiquidityGaugeRoiStrategy)
@@ -51,9 +51,9 @@ export class OptimismCurveFarmContractPositionFetcher implements PositionFetcher
       resolveFarmContract: ({ address, network }) =>
         this.curveContractFactory.curveRewardsOnlyGauge({ address, network }),
       resolveStakedTokenAddress: ({ contract, multicall }) => multicall.wrap(contract).lp_token(),
-      resolveRewardTokenAddresses: this.curveGaugeV2RewardTokenStrategy.build(),
+      resolveRewardTokenAddresses: this.curveRewardsOnlyGaugeRewardTokenStrategy.build(),
       resolveIsActive: () => true,
-      resolveRois: this.curveGaugeV2RoiStrategy.build({
+      resolveRois: this.curveRewardsOnlyGaugeRoiStrategy.build({
         tokenDefinitions: definitions,
       }),
     });

--- a/src/apps/curve/polygon/curve.farm.contract-position-fetcher.ts
+++ b/src/apps/curve/polygon/curve.farm.contract-position-fetcher.ts
@@ -11,8 +11,8 @@ import { CURVE_DEFINITION } from '../curve.definition';
 import { CurveChildLiquidityGaugeFactoryAddressHelper } from '../helpers/curve.child-liquidity-gauge-factory.address-helper';
 import { CurveChildLiquidityGaugeRewardTokenStrategy } from '../helpers/curve.child-liquidity-gauge.reward-token-strategy';
 import { CurveChildLiquidityGaugeRoiStrategy } from '../helpers/curve.child-liquidity-gauge.roi-strategy';
-import { CurveGaugeV2RewardTokenStrategy } from '../helpers/curve.gauge-v2.reward-token-strategy';
-import { CurveGaugeV2RoiStrategy } from '../helpers/curve.gauge-v2.roi-strategy';
+import { CurveRewardsOnlyGaugeRewardTokenStrategy } from '../helpers/curve.rewards-only-gauge.reward-token-strategy';
+import { CurveRewardsOnlyGaugeRoiStrategy } from '../helpers/curve.rewards-only-gauge.roi-strategy';
 
 import { CURVE_V1_POOL_DEFINITIONS, CURVE_V2_POOL_DEFINITIONS } from './curve.pool.definitions';
 
@@ -26,10 +26,10 @@ export class PolygonCurveFarmContractPositionFetcher implements PositionFetcher<
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
     @Inject(CurveContractFactory)
     private readonly curveContractFactory: CurveContractFactory,
-    @Inject(CurveGaugeV2RoiStrategy)
-    private readonly curveGaugeV2RoiStrategy: CurveGaugeV2RoiStrategy,
-    @Inject(CurveGaugeV2RewardTokenStrategy)
-    private readonly curveGaugeV2RewardTokenStrategy: CurveGaugeV2RewardTokenStrategy,
+    @Inject(CurveRewardsOnlyGaugeRoiStrategy)
+    private readonly curveRewardsOnlyGaugeRoiStrategy: CurveRewardsOnlyGaugeRoiStrategy,
+    @Inject(CurveRewardsOnlyGaugeRewardTokenStrategy)
+    private readonly curveRewardsOnlyGaugeRewardTokenStrategy: CurveRewardsOnlyGaugeRewardTokenStrategy,
     @Inject(CurveChildLiquidityGaugeFactoryAddressHelper)
     private readonly childGaugeAddressHelper: CurveChildLiquidityGaugeFactoryAddressHelper,
     @Inject(CurveChildLiquidityGaugeRoiStrategy)
@@ -51,8 +51,8 @@ export class PolygonCurveFarmContractPositionFetcher implements PositionFetcher<
       resolveFarmContract: ({ address, network }) =>
         this.curveContractFactory.curveRewardsOnlyGauge({ address, network }),
       resolveStakedTokenAddress: ({ contract, multicall }) => multicall.wrap(contract).lp_token(),
-      resolveRewardTokenAddresses: this.curveGaugeV2RewardTokenStrategy.build(),
-      resolveRois: this.curveGaugeV2RoiStrategy.build({ tokenDefinitions: definitions }),
+      resolveRewardTokenAddresses: this.curveRewardsOnlyGaugeRewardTokenStrategy.build(),
+      resolveRois: this.curveRewardsOnlyGaugeRoiStrategy.build({ tokenDefinitions: definitions }),
       resolveIsActive: () => true,
     });
   }


### PR DESCRIPTION
## Description

Legacy sidechain/L2 Curve gauges were called "RewardsOnlyGauge". Do not confuse this with Liquidity Gauge V2.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

No regressions expected.