### PR TITLE
polynomial: track vault balances in withdrawal

### DIFF
--- a/src/apps/polynomial/optimism/polynomial.balance-fetcher.ts
+++ b/src/apps/polynomial/optimism/polynomial.balance-fetcher.ts
@@ -29,8 +29,10 @@ export class OptimismPolynomialBalanceFetcher implements BalanceFetcher {
       resolveBalances: async ({ address, network, multicall, contractPosition: position }) => {
         const token = position.tokens[0];
         const contract = this.contractFactory.vaults({ address: resolverAddress, network });
-        const balances = await multicall.wrap(contract).getAllBalances(address, [position.address], [token.address]);
-        return [drillBalance(token, Number(balances._vaultBalances[0]).toString())];
+        const balances = await multicall.wrap(contract).getUserBalance(address, position.address);
+        const totalBalance =
+          Number(balances._balance) + Number(balances._withdrawToComplete) + Number(balances._cancellableWithdraw);
+        return [drillBalance(token, totalBalance.toString())];
       },
     });
   }


### PR DESCRIPTION
## Description

Did some more operations on polynomial vaults since the pr to do more testing - found that balances pending withdrawal are not being tracked.

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

curl -X 'GET' \
  'http://localhost:5001/apps/polynomial/positions?network=optimism&groupIds%5B%5D=vaults' \
  -H 'accept: */*'