### PR TITLE
fix: update polynomial vault name

### DIFF
--- a/src/app-toolkit/helpers/position/single-staking-farm.contract-position-helper.ts
+++ b/src/app-toolkit/helpers/position/single-staking-farm.contract-position-helper.ts
@@ -76,6 +76,7 @@ export type SingleStakingFarmContractPositionHelperParams<T> = {
     network: Network;
   }) => SingleStakingFarmDefinition[] | Promise<SingleStakingFarmDefinition[]>;
   resolveImplementation?: () => string;
+  resolveLabel?: (definition: string | SingleStakingFarmDefinition) => string;
   resolveFarmAddresses?: (opts: { network: Network }) => (string | null)[] | Promise<(string | null)[]>;
   resolveStakedTokenAddress?: (opts: { contract: T; multicall: Multicall; index: number }) => Promise<string>;
   resolveRewardTokenAddresses?: (opts: { contract: T; multicall: Multicall }) => Promise<string | string[]>;
@@ -98,6 +99,7 @@ export class SingleStakingFarmContractPositionHelper {
     resolveFarmAddresses,
     resolveFarmDefinitions,
     resolveImplementation,
+    resolveLabel,
     resolveStakedTokenAddress = async () => '',
     resolveRewardTokenAddresses = async () => [],
     resolveIsActive = async () => true,
@@ -197,7 +199,7 @@ export class SingleStakingFarmContractPositionHelper {
           // Display Properties
           const underlyingLabel =
             stakedToken.type === ContractType.APP_TOKEN ? stakedToken.displayProps.label : stakedToken.symbol;
-          const label = `Staked ${underlyingLabel}`;
+          const label = resolveLabel ? resolveLabel(definitionOrAddress) : `Staked ${underlyingLabel}`;
           const secondaryLabel = buildDollarDisplayItem(stakedToken.price);
           const images = [getTokenImg(stakedToken.address, network)];
           const statsItems = [

--- a/src/apps/polynomial/optimism/polynomial.vaults.contract-position-fetcher.ts
+++ b/src/apps/polynomial/optimism/polynomial.vaults.contract-position-fetcher.ts
@@ -1,5 +1,6 @@
 import { Inject } from '@nestjs/common';
 import Axios from 'axios';
+import _ from 'lodash';
 
 import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
 import { Register } from '~app-toolkit/decorators';
@@ -13,6 +14,8 @@ import { POLYNOMIAL_DEFINITION } from '../polynomial.definition';
 const appId = POLYNOMIAL_DEFINITION.id;
 const groupId = POLYNOMIAL_DEFINITION.groups.vaults.id;
 const network = Network.OPTIMISM_MAINNET;
+
+const resolveTitle = (title: string) => _.startCase(_.toLower(title));
 
 @Register.ContractPositionFetcher({ appId, groupId, network })
 export class OptimismPolynomialVaultsContractPositionFetcher implements PositionFetcher<ContractPosition> {
@@ -36,6 +39,8 @@ export class OptimismPolynomialVaultsContractPositionFetcher implements Position
           resolveStakedTokenAddress: async ({ multicall, contract }) => multicall.wrap(contract).UNDERLYING(),
           resolveFarmContract: ({ address }) => this.contractFactory.polynomialCoveredCall({ address, network }),
           resolveTotalValueLocked: ({ multicall, contract }) => multicall.wrap(contract).totalFunds(),
+          resolveLabel: address =>
+            resolveTitle(vaults.find(vault => vault.contractAddress.toLowerCase() === address).type),
           resolveRois: () => ({
             dailyROI: 0,
             weeklyROI: 0,
@@ -54,6 +59,8 @@ export class OptimismPolynomialVaultsContractPositionFetcher implements Position
         resolveStakedTokenAddress: async ({ multicall, contract }) => multicall.wrap(contract).COLLATERAL(),
         resolveFarmContract: ({ address }) => this.contractFactory.polynomialPutSelling({ address, network }),
         resolveTotalValueLocked: ({ multicall, contract }) => multicall.wrap(contract).totalFunds(),
+        resolveLabel: address =>
+          resolveTitle(vaults.find(vault => vault.contractAddress.toLowerCase() === address).type),
         resolveRois: () => ({
           dailyROI: 0,
           weeklyROI: 0,


### PR DESCRIPTION
## Description

sorry, another polynomial small fix

```
gautham — Today at 4:33 AM
Ser nice job on the zapper pr
Is there anyway we can change the name of the vault from staked sETH to Eth covered call
Image
gautham — Today at 4:43 AM
The image is also a bit low resolution
tonz — Today at 11:59 AM
i think every image is 150x150, but you can submit a pr to update this image if you have a better one https://github.com/Zapper-fi/studio/blob/main/src/apps/polynomial/assets/logo.png
GitHub
[studio/logo.png at main · Zapper-fi/studio](https://github.com/Zapper-fi/studio/blob/main/src/apps/polynomial/assets/logo.png)
Zapper App Integrations. Contribute to Zapper-fi/studio development by creating an account on GitHub.
studio/logo.png at main · Zapper-fi/studio
ill submit a pr to change the name from staked to Covered Call/Put Selling sEth
```

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: 0x4E190B3D31d96e0cD11a1520185a77b57A0182f2

## How to test?


