### PR TITLE
feat(qi-dao): Add assetStandard to vault dataProps

### DIFF
--- a/src/apps/qi-dao/helpers/qi-dao.vault.position-helper.ts
+++ b/src/apps/qi-dao/helpers/qi-dao.vault.position-helper.ts
@@ -6,7 +6,7 @@ import { ZERO_ADDRESS } from '~app-toolkit/constants/address';
 import { buildDollarDisplayItem } from '~app-toolkit/helpers/presentation/display-item.present';
 import { getImagesFromToken, getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
 import { ContractType } from '~position/contract.interface';
-import { ContractPosition } from '~position/position.interface';
+import { ContractPosition, Standard } from '~position/position.interface';
 import { AppGroupsDefinition } from '~position/position.service';
 import { borrowed, supplied } from '~position/position.utils';
 import { Network } from '~types/network.interface';
@@ -15,6 +15,7 @@ import { QiDaoContractFactory } from '../contracts';
 import { QI_DAO_DEFINITION } from '../qi-dao.definition';
 
 export type QiDaoVaultPositionDataProps = {
+  assetStandard: Standard;
   liquidity: number;
   vaultInfoAddress: string;
 };
@@ -83,6 +84,7 @@ export class QiDaoVaultPositionHelper {
           tokens,
 
           dataProps: {
+            assetStandard: Standard.ERC_721,
             liquidity,
             vaultInfoAddress,
           },

--- a/src/position/position.interface.ts
+++ b/src/position/position.interface.ts
@@ -12,6 +12,12 @@ export enum MetaType {
   NFT = 'nft',
 }
 
+export enum Standard {
+  ERC_20 = 'erc20',
+  ERC_721 = 'erc721',
+  ERC_1155 = 'erc1155',
+}
+
 export interface AbstractPosition<T = DefaultDataProps> extends Contract {
   tokens: WithMetaType<Token>[];
   dataProps: T;


### PR DESCRIPTION
## Description
Adding a dataProps to qi-dao vault position to specify the underlying asset standard. In this case we want to expose that the underlying asset is of an ERC721 (NFT) type.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

