### PR TITLE
fix(impermax): Fix wrong Network in fetcher

### DIFF
--- a/src/apps/impermax/ethereum/impermax.collateral.token-fetcher.ts
+++ b/src/apps/impermax/ethereum/impermax.collateral.token-fetcher.ts
@@ -13,7 +13,7 @@ import { address } from './impermax.lend.token-fetcher';
 
 const appId = IMPERMAX_DEFINITION.id;
 const groupId = IMPERMAX_DEFINITION.groups.collateral.id;
-const network = Network.ARBITRUM_MAINNET;
+const network = Network.ETHEREUM_MAINNET;
 
 @Register.TokenPositionFetcher({ appId, groupId, network })
 export class EthereumImpermaxCollateralTokenFetcher implements PositionFetcher<AppTokenPosition> {


### PR DESCRIPTION
## Description

Fix a typo with `Arbitrum` instead of `Ethereum` in the fetcher.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

