### PR TITLE
chore: added liquidity dataPropps with same value as TotalValueLocked in order to rename/remove TotalValueLocked in zapper-api and studio

### DIFF
--- a/src/app-toolkit/helpers/master-chef/master-chef.contract-position-helper.ts
+++ b/src/app-toolkit/helpers/master-chef/master-chef.contract-position-helper.ts
@@ -110,6 +110,7 @@ type MasterChefContractPositionHelperParams<T> = {
 export type MasterChefContractPositionDataProps = {
   poolIndex: number;
   totalValueLocked: number;
+  liquidity: number;
   isActive: boolean;
   dailyROI: number;
   weeklyROI: number;
@@ -268,7 +269,15 @@ export class MasterChefContractPositionHelper {
         }
 
         // Resolve data properties
-        const dataProps = { poolIndex, totalValueLocked, isActive, dailyROI, weeklyROI, yearlyROI };
+        const dataProps = {
+          poolIndex,
+          totalValueLocked,
+          liquidity: totalValueLocked,
+          isActive,
+          dailyROI,
+          weeklyROI,
+          yearlyROI,
+        };
 
         // Resolve display properties
         const label = resolveLabel({ stakedToken, rewardTokens });

--- a/src/app-toolkit/helpers/position/single-staking-farm.contract-position-helper.ts
+++ b/src/app-toolkit/helpers/position/single-staking-farm.contract-position-helper.ts
@@ -31,6 +31,7 @@ export type SingleStakingFarmRois = {
 
 export type SingleStakingFarmDataProps = {
   totalValueLocked: number;
+  liquidity: number;
   isActive: boolean;
   dailyROI: number;
   weeklyROI: number;
@@ -63,6 +64,7 @@ export type SingleStakingFarmResolveRoisParams<T> = (opts: {
   stakedToken: WithMetaType<Token>;
   rewardTokens: WithMetaType<Token>[];
   totalValueLocked: number;
+  liquidity: number;
 }) => SingleStakingFarmRois | Promise<SingleStakingFarmRois>;
 
 export type SingleStakingFarmContractPositionHelperParams<T> = {
@@ -191,10 +193,11 @@ export class SingleStakingFarmContractPositionHelper {
             stakedToken,
             rewardTokens: rewardTokenMatches,
             totalValueLocked,
+            liquidity: totalValueLocked,
           });
 
           const otherProps = resolveImplementation ? { implementation: resolveImplementation() } : {};
-          const dataProps = { totalValueLocked, isActive, ...rois, ...otherProps };
+          const dataProps = { totalValueLocked, liquidity: totalValueLocked, isActive, ...rois, ...otherProps };
 
           // Display Properties
           const underlyingLabel =

--- a/src/apps/dfx/ethereum/dfx.staking.contract-position-fetcher.ts
+++ b/src/apps/dfx/ethereum/dfx.staking.contract-position-fetcher.ts
@@ -20,7 +20,7 @@ const groupId = DFX_DEFINITION.groups.staking.id;
 const network = Network.ETHEREUM_MAINNET;
 
 type DfxCurveContractPositionDataProps = {
-  totalValueLocked: number;
+  liquidity: number;
 };
 
 @Register.ContractPositionFetcher({ appId, groupId, network })
@@ -61,7 +61,7 @@ export class EthereumDfxStakingContractPositionFetcher implements PositionFetche
         const [balanceRaw] = await Promise.all([multicall.wrap(contract).balanceOf(address)]);
 
         // Denormalize the balance as the TVL
-        const totalValueLocked = Number(balanceRaw) / 10 ** stakedToken.decimals;
+        const liquidity = Number(balanceRaw) / 10 ** stakedToken.decimals;
 
         // Prepare display props
         const label = `Staked ${getLabelFromToken(stakedToken)}`;
@@ -76,7 +76,7 @@ export class EthereumDfxStakingContractPositionFetcher implements PositionFetche
           network,
           tokens,
           dataProps: {
-            totalValueLocked,
+            liquidity,
           },
           displayProps: {
             label,

--- a/src/apps/dfx/polygon/dfx.staking.contract-position-fetcher.ts
+++ b/src/apps/dfx/polygon/dfx.staking.contract-position-fetcher.ts
@@ -20,7 +20,7 @@ const groupId = DFX_DEFINITION.groups.staking.id;
 const network = Network.POLYGON_MAINNET;
 
 type DfxCurveContractPositionDataProps = {
-  totalValueLocked: number;
+  liquidity: number;
 };
 
 @Register.ContractPositionFetcher({ appId, groupId, network })
@@ -61,7 +61,7 @@ export class PolygonDfxStakingContractPositionFetcher implements PositionFetcher
         const [balanceRaw] = await Promise.all([multicall.wrap(contract).balanceOf(address)]);
 
         // Denormalize the balance as the TVL
-        const totalValueLocked = Number(balanceRaw) / 10 ** stakedToken.decimals;
+        const liquidity = Number(balanceRaw) / 10 ** stakedToken.decimals;
 
         // Prepare display props
         const label = `Staked ${getLabelFromToken(stakedToken)}`;
@@ -76,7 +76,7 @@ export class PolygonDfxStakingContractPositionFetcher implements PositionFetcher
           network,
           tokens,
           dataProps: {
-            totalValueLocked,
+            liquidity,
           },
           displayProps: {
             label,

--- a/src/apps/symphony/avalanche/symphony.tvl-fetcher.ts
+++ b/src/apps/symphony/avalanche/symphony.tvl-fetcher.ts
@@ -23,6 +23,6 @@ export class AvalancheSymphonyTvlFetcher implements TvlFetcher {
       network,
     });
 
-    return sumBy(tokens, v => v.dataProps.totalValueLocked);
+    return sumBy(tokens, v => v.dataProps.liquidity);
   }
 }

--- a/src/apps/symphony/avalanche/symphony.yolo.contract-position-fetcher.ts
+++ b/src/apps/symphony/avalanche/symphony.yolo.contract-position-fetcher.ts
@@ -74,7 +74,7 @@ export class AvalancheSymphonyYoloContractPositionFetcher implements PositionFet
           network,
           tokens: [supplied(tokenData)],
           dataProps: {
-            totalValueLocked: tokenBalanceUSD,
+            liquidity: tokenBalanceUSD,
           },
           displayProps: {
             label,

--- a/src/apps/symphony/helpers/types.ts
+++ b/src/apps/symphony/helpers/types.ts
@@ -1,5 +1,5 @@
 export type SymphonyYoloTokenDataProps = {
-  totalValueLocked: number;
+  liquidity: number;
 };
 
 export type Token = {

--- a/src/apps/symphony/polygon/symphony.tvl-fetcher.ts
+++ b/src/apps/symphony/polygon/symphony.tvl-fetcher.ts
@@ -23,6 +23,6 @@ export class PolygonSymphonyTvlFetcher implements TvlFetcher {
       network,
     });
 
-    return sumBy(tokens, v => v.dataProps.totalValueLocked);
+    return sumBy(tokens, v => v.dataProps.liquidity);
   }
 }

--- a/src/apps/symphony/polygon/symphony.yolo.contract-position-fetcher.ts
+++ b/src/apps/symphony/polygon/symphony.yolo.contract-position-fetcher.ts
@@ -74,7 +74,7 @@ export class PolygonSymphonyYoloContractPositionFetcher implements PositionFetch
           network,
           tokens: [supplied(tokenData)],
           dataProps: {
-            totalValueLocked: tokenBalanceUSD,
+            liquidity: tokenBalanceUSD,
           },
           displayProps: {
             label,

--- a/src/apps/thales/optimism/thales.escrow.contract-position-fetcher.ts
+++ b/src/apps/thales/optimism/thales.escrow.contract-position-fetcher.ts
@@ -15,7 +15,7 @@ import { ThalesContractFactory } from '../contracts';
 import { THALES_DEFINITION } from '../thales.definition';
 
 export type ThalesStakingContractPositionDataProps = {
-  totalValueLocked: number;
+  liquidity: number;
 };
 
 const appId = THALES_DEFINITION.id;
@@ -24,9 +24,9 @@ const network = Network.OPTIMISM_MAINNET;
 
 const farmDefinitions = [
   {
-    address: '0xa25816b9605009aa446d4d597F0AA46FD828f056'.toLowerCase(),
-    stakedTokenAddress: '0x217d47011b23bb961eb6d93ca9945b7501a5bb11'.toLowerCase(),
-    rewardTokenAddress: '0x217d47011b23bb961eb6d93ca9945b7501a5bb11'.toLowerCase(),
+    address: '0xa25816b9605009aa446d4d597F0AA46FD828f056',
+    stakedTokenAddress: '0x217d47011b23bb961eb6d93ca9945b7501a5bb11',
+    rewardTokenAddress: '0x217d47011b23bb961eb6d93ca9945b7501a5bb11',
   },
 ];
 
@@ -51,7 +51,7 @@ export class OptimismThalesEscrowContractPositionFetcher implements PositionFetc
         const tokens = [supplied(stakedToken as Token), claimable(rewardToken)];
         const contract = this.thalesContractFactory.escrowThales({ address: farmDefinitions[0].address, network });
         const [balanceRaw] = await Promise.all([multicall.wrap(contract).totalEscrowBalanceNotIncludedInStaking()]);
-        const totalValueLocked = Number(balanceRaw) / 10 ** stakedToken.decimals;
+        const liquidity = Number(balanceRaw) / 10 ** stakedToken.decimals;
 
         const label = `Escrowed ${getLabelFromToken(stakedToken)}`;
         // For images, we'll use the underlying token images as well
@@ -67,7 +67,7 @@ export class OptimismThalesEscrowContractPositionFetcher implements PositionFetc
           network,
           tokens,
           dataProps: {
-            totalValueLocked,
+            liquidity,
           },
           displayProps: {
             label,

--- a/src/apps/thales/optimism/thales.pool2.contract-position-fetcher.ts
+++ b/src/apps/thales/optimism/thales.pool2.contract-position-fetcher.ts
@@ -15,7 +15,7 @@ import { ThalesContractFactory } from '../contracts';
 import { THALES_DEFINITION } from '../thales.definition';
 
 export type ThalesStakingContractPositionDataProps = {
-  totalValueLocked: number;
+  liquidity: number;
 };
 
 const appId = THALES_DEFINITION.id;
@@ -52,7 +52,7 @@ export class OptimismThalesPool2ContractPositionFetcher implements PositionFetch
         const tokens = [supplied(stakedToken as Token), claimable(rewardToken)];
         const contract = this.thalesContractFactory.lpStaking({ address: farmDefinitions[0].address, network });
         const [balanceRaw] = await Promise.all([multicall.wrap(contract).totalSupply()]);
-        const totalValueLocked = Number(balanceRaw) / 10 ** stakedToken.decimals;
+        const liquidity = Number(balanceRaw) / 10 ** stakedToken.decimals;
         const label = `Staked ${getLabelFromToken(stakedToken)}`;
         // For images, we'll use the underlying token images as well
         const images = getImagesFromToken(stakedToken);
@@ -67,7 +67,7 @@ export class OptimismThalesPool2ContractPositionFetcher implements PositionFetch
           network,
           tokens,
           dataProps: {
-            totalValueLocked,
+            liquidity,
           },
           displayProps: {
             label,

--- a/src/apps/thales/optimism/thales.staking.contract-position-fetcher.ts
+++ b/src/apps/thales/optimism/thales.staking.contract-position-fetcher.ts
@@ -19,7 +19,7 @@ const groupId = THALES_DEFINITION.groups.staking.id;
 const network = Network.OPTIMISM_MAINNET;
 
 export type ThalesStakingContractPositionDataProps = {
-  totalValueLocked: number;
+  liquidity: number;
 };
 
 const farmDefinitions = [
@@ -51,7 +51,7 @@ export class OptimismThalesStakingContractPositionFetcher implements PositionFet
         const tokens = [supplied(stakedToken as Token), claimable(rewardToken)];
         const contract = this.thalesContractFactory.stakingThales({ address: farmDefinitions[0].address, network });
         const [balanceRaw] = await Promise.all([multicall.wrap(contract).totalStakedAmount()]);
-        const totalValueLocked = Number(balanceRaw) / 10 ** stakedToken.decimals;
+        const liquidity = Number(balanceRaw) / 10 ** stakedToken.decimals;
 
         const label = `Staked ${getLabelFromToken(stakedToken)}`;
         // For images, we'll use the underlying token images as well
@@ -67,7 +67,7 @@ export class OptimismThalesStakingContractPositionFetcher implements PositionFet
           network,
           tokens,
           dataProps: {
-            totalValueLocked,
+            liquidity,
           },
           displayProps: {
             label,

--- a/src/apps/tokemak/ethereum/tokemak.tvl-fetcher.ts
+++ b/src/apps/tokemak/ethereum/tokemak.tvl-fetcher.ts
@@ -16,12 +16,10 @@ export class EthereumTokemakTvlFetcher implements TvlFetcher {
   async getTvl() {
     const farmPositions = await this.appToolkit.getAppContractPositions<SingleStakingFarmDataProps>({
       appId: TOKEMAK_DEFINITION.id,
-      network: Network.ETHEREUM_MAINNET,
       groupIds: [TOKEMAK_DEFINITION.groups.farm.id],
+      network: Network.ETHEREUM_MAINNET,
     });
 
-    const farmTvl = sumBy(farmPositions, position => position.dataProps.totalValueLocked);
-
-    return farmTvl;
+    return sumBy(farmPositions, position => position.dataProps.liquidity);
   }
 }


### PR DESCRIPTION
## Description

Added a liquidity dataProps which holds the same value as TotalValueLocked. It will be easier to rename/remove TotalValueLocked in studio and in api. 

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
