### PR TITLE
fix(olympus): Fix wrong groups on Ethereum

### DIFF
--- a/src/apps/olympus/ethereum/olympus.g-ohm.token-fetcher.ts
+++ b/src/apps/olympus/ethereum/olympus.g-ohm.token-fetcher.ts
@@ -28,9 +28,9 @@ export class EthereumOlympusGOhmTokenFetcher implements PositionFetcher<AppToken
 
   async getPositions() {
     return this.appToolkit.helpers.vaultTokenHelper.getTokens<OlympusGOhmToken>({
-      appId: OLYMPUS_DEFINITION.id,
-      groupId: OLYMPUS_DEFINITION.groups.gOhm.id,
-      network: Network.ETHEREUM_MAINNET,
+      appId,
+      groupId,
+      network,
       dependencies: [{ appId, groupIds: [OLYMPUS_DEFINITION.groups.sOhm.id], network }],
       resolveVaultAddresses: () => ['0x0ab87046fbb341d058f17cbc4c1133f25a20a52f'], // gOHM
       resolveContract: ({ address, network }) => this.contractFactory.olympusGOhmToken({ address, network }),

--- a/src/apps/olympus/ethereum/olympus.s-ohm-v1.token-fetcher.ts
+++ b/src/apps/olympus/ethereum/olympus.s-ohm-v1.token-fetcher.ts
@@ -27,9 +27,9 @@ export class EthereumOlympusSOhmV1TokenFetcher implements PositionFetcher<AppTok
 
   getPositions(): Promise<AppTokenPosition[]> {
     return this.appToolkit.helpers.vaultTokenHelper.getTokens<OlympusSOhmV1Token>({
-      appId: OLYMPUS_DEFINITION.id,
-      groupId: OLYMPUS_DEFINITION.groups.gOhm.id,
-      network: Network.ETHEREUM_MAINNET,
+      appId,
+      groupId,
+      network,
       resolveContract: ({ address, network }) => this.contractFactory.olympusSOhmV1Token({ address, network }),
       resolveVaultAddresses: () => ['0x04f2694c8fcee23e8fd0dfea1d4f5bb8c352111f'], // sOHMv1
       resolveUnderlyingTokenAddress: () => '0x383518188c0c6d7730d91b2c03a03c837814a899', // OHMv1

--- a/src/apps/olympus/ethereum/olympus.s-ohm.token-fetcher.ts
+++ b/src/apps/olympus/ethereum/olympus.s-ohm.token-fetcher.ts
@@ -27,9 +27,9 @@ export class EthereumOlympusSOhmTokenFetcher implements PositionFetcher<AppToken
 
   getPositions(): Promise<AppTokenPosition[]> {
     return this.appToolkit.helpers.vaultTokenHelper.getTokens<OlympusSOhmToken>({
-      appId: OLYMPUS_DEFINITION.id,
-      groupId: OLYMPUS_DEFINITION.groups.gOhm.id,
-      network: Network.ETHEREUM_MAINNET,
+      appId,
+      groupId,
+      network,
       resolveContract: ({ address, network }) => this.contractFactory.olympusSOhmToken({ address, network }),
       resolveVaultAddresses: () => ['0x04906695d6d12cf5459975d7c3c03356e4ccd460'], // sOHM
       resolveUnderlyingTokenAddress: () => '0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5', // OHM


### PR DESCRIPTION
## Description

Wrong group were set for sOhm and sOhm v1 on Ethereum

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
