### PR TITLE
fix: yield protocol lend tertiary label

### DIFF
--- a/src/apps/yield-protocol/arbitrum/yield-protocol.lend.token-fetcher.ts
+++ b/src/apps/yield-protocol/arbitrum/yield-protocol.lend.token-fetcher.ts
@@ -151,7 +151,7 @@ export class ArbitrumYieldProtocolLendTokenFetcher implements PositionFetcher<Ap
         const displayProps: DisplayProps = {
           label: `fy${underlyingToken.symbol}`,
           secondaryLabel: displayName,
-          tertiaryLabel: matured ? 'Matured' : '',
+          tertiaryLabel: matured ? 'Matured' : undefined,
           images: getImagesFromToken(underlyingToken),
         };
 

--- a/src/apps/yield-protocol/ethereum/yield-protocol.lend.token-fetcher.ts
+++ b/src/apps/yield-protocol/ethereum/yield-protocol.lend.token-fetcher.ts
@@ -155,7 +155,7 @@ export class EthereumYieldProtocolLendTokenFetcher implements PositionFetcher<Ap
         const displayProps: DisplayProps = {
           label: `fy${underlyingToken.symbol}`,
           secondaryLabel: displayName,
-          tertiaryLabel: matured ? 'Matured' : '',
+          tertiaryLabel: matured ? 'Matured' : undefined,
           images: getImagesFromToken(underlyingToken),
         };
 


### PR DESCRIPTION
## Description

Really small fix to try to prevent the "-" from rendering before maturity for fyTokens (`lend` group id).

<img width="415" alt="Screen Shot 2022-06-06 at 12 58 38 PM" src="https://user-images.githubusercontent.com/42938673/172211389-94c79f75-fce1-4231-b525-dacd1e631929.png">

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)