### PR TITLE
feat(compound): Add resolver in helper method

### DIFF
--- a/src/apps/compound/helper/compound.borrow.contract-position-helper.ts
+++ b/src/apps/compound/helper/compound.borrow.contract-position-helper.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { BigNumberish } from 'ethers';
 import { isNumber } from 'lodash';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
@@ -7,12 +8,13 @@ import {
   buildPercentageDisplayItem,
 } from '~app-toolkit/helpers/presentation/display-item.present';
 import { getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
+import { EthersMulticall } from '~multicall';
 import { ContractType } from '~position/contract.interface';
 import { ContractPosition } from '~position/position.interface';
 import { borrowed } from '~position/position.utils';
 import { Network } from '~types/network.interface';
 
-import { CompoundContractFactory } from '../contracts';
+import { CompoundContractFactory, CompoundCToken } from '../contracts';
 
 import { CompoundSupplyTokenDataProps } from './compound.supply.token-helper';
 
@@ -26,6 +28,12 @@ type CompoundBorrowContractPositionHelperParams = {
   appId: string;
   groupId: string;
   supplyGroupId: string;
+  resolveCashRaw?: (opts: {
+    contract: CompoundCToken;
+    address: string;
+    network: Network;
+    multicall: EthersMulticall;
+  }) => Promise<BigNumberish>;
 };
 
 @Injectable()
@@ -35,7 +43,13 @@ export class CompoundBorrowContractPositionHelper {
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
   ) {}
 
-  async getPositions({ network, appId, groupId, supplyGroupId }: CompoundBorrowContractPositionHelperParams) {
+  async getPositions({
+    network,
+    appId,
+    groupId,
+    supplyGroupId,
+    resolveCashRaw = ({ contract, multicall }) => multicall.wrap(contract).getCash(),
+  }: CompoundBorrowContractPositionHelperParams) {
     const appTokens = await this.appToolkit.getAppTokenPositions<CompoundSupplyTokenDataProps>({
       appId,
       groupIds: [supplyGroupId],
@@ -49,13 +63,10 @@ export class CompoundBorrowContractPositionHelper {
       // Compound has a `getCash` method which returns the total liquidity
       // of a given borrowed contract position. This is typically what defilama
       // would use to display a TVL
-      const [cash] = await Promise.all([multicall.wrap(contract).getCash()]);
+      const cashRaw = await resolveCashRaw({ multicall, contract, address: appToken.address, network }).catch(() => 0);
       // The "cash" needs to be converted back into a proper number format.
       // We use the underlying token as the basis for the conversion.
-      const cashSupply = this.appToolkit
-        .getBigNumber(cash)
-        .div(10 ** appToken.tokens[0].decimals)
-        .toNumber();
+      const cashSupply = Number(cashRaw) / 10 ** appToken.tokens[0].decimals;
 
       const tokens = [borrowed(appToken.tokens[0])];
       // The underlying token liquidity actually represents the TOTAL SUPPLY of a borrowed

--- a/src/apps/impermax/arbitrum/impermax.borrow.contract-position-fetcher.ts
+++ b/src/apps/impermax/arbitrum/impermax.borrow.contract-position-fetcher.ts
@@ -1,12 +1,12 @@
 import { Inject } from '@nestjs/common';
 
 import { Register } from '~app-toolkit/decorators';
+import { CompoundBorrowContractPositionHelper } from '~apps/compound';
 import { PositionFetcher } from '~position/position-fetcher.interface';
 import { ContractPosition } from '~position/position.interface';
 import { Network } from '~types/network.interface';
 
-import { CompoundBorrowContractPositionHelper } from '../../tarot/helper/compound.borrow.contract-position-helper';
-import { ImpermaxContractFactory, Borrowable } from '../contracts';
+import { ImpermaxContractFactory } from '../contracts';
 import { IMPERMAX_DEFINITION } from '../impermax.definition';
 
 const appId = IMPERMAX_DEFINITION.id;
@@ -22,13 +22,13 @@ export class ArbitrumImpermaxBorrowContractPositionFetcher implements PositionFe
   ) {}
 
   async getPositions() {
-    return this.compoundBorrowContractPositionHelper.getPositions<Borrowable>({
+    return this.compoundBorrowContractPositionHelper.getPositions({
       network,
       appId,
       groupId,
       supplyGroupId: IMPERMAX_DEFINITION.groups.lend.id,
-      resolveContract: ({ address, network }) => this.contractFactory.borrowable({ address, network }),
-      resolveCashRaw: ({ multicall, contract }) => multicall.wrap(contract).totalBalance(),
+      resolveCashRaw: ({ multicall, address, network }) =>
+        multicall.wrap(this.contractFactory.borrowable({ address, network })).totalBalance(),
     });
   }
 }

--- a/src/apps/impermax/ethereum/impermax.borrow.contract-position-fetcher.ts
+++ b/src/apps/impermax/ethereum/impermax.borrow.contract-position-fetcher.ts
@@ -1,12 +1,12 @@
 import { Inject } from '@nestjs/common';
 
 import { Register } from '~app-toolkit/decorators';
+import { CompoundBorrowContractPositionHelper } from '~apps/compound';
 import { PositionFetcher } from '~position/position-fetcher.interface';
 import { ContractPosition } from '~position/position.interface';
 import { Network } from '~types/network.interface';
 
-import { CompoundBorrowContractPositionHelper } from '../../tarot/helper/compound.borrow.contract-position-helper'; // TODO: move to compound folder
-import { ImpermaxContractFactory, Borrowable } from '../contracts';
+import { ImpermaxContractFactory } from '../contracts';
 import { IMPERMAX_DEFINITION } from '../impermax.definition';
 
 const appId = IMPERMAX_DEFINITION.id;
@@ -22,13 +22,13 @@ export class EthereumImpermaxBorrowContractPositionFetcher implements PositionFe
   ) {}
 
   async getPositions() {
-    return this.compoundBorrowContractPositionHelper.getPositions<Borrowable>({
+    return this.compoundBorrowContractPositionHelper.getPositions({
       network,
       appId,
       groupId,
       supplyGroupId: IMPERMAX_DEFINITION.groups.lend.id,
-      resolveContract: ({ address, network }) => this.contractFactory.borrowable({ address, network }),
-      resolveCashRaw: ({ multicall, contract }) => multicall.wrap(contract).totalBalance(),
+      resolveCashRaw: ({ multicall, address, network }) =>
+        multicall.wrap(this.contractFactory.borrowable({ address, network })).totalBalance(),
     });
   }
 }

--- a/src/apps/impermax/impermax.module.ts
+++ b/src/apps/impermax/impermax.module.ts
@@ -4,7 +4,6 @@ import { CompoundAppModule } from '~apps/compound';
 
 import { CompoundBorrowBalanceHelper } from '../compound/helper/compound.borrow.balance-helper';
 import { CompoundSupplyBalanceHelper } from '../compound/helper/compound.supply.balance-helper';
-import { CompoundBorrowContractPositionHelper } from '../tarot/helper/compound.borrow.contract-position-helper'; // TODO: move to compound folder
 
 import { ArbitrumImpermaxBalanceFetcher } from './arbitrum/impermax.balance-fetcher';
 import { ArbitrumImpermaxBorrowContractPositionFetcher } from './arbitrum/impermax.borrow.contract-position-fetcher';
@@ -32,7 +31,6 @@ import { PolygonImpermaxLendTokenFetcher } from './polygon/impermax.lend.token-f
     ArbitrumImpermaxBorrowContractPositionFetcher,
     ArbitrumImpermaxCollateralTokenFetcher,
     ArbitrumImpermaxLendTokenFetcher,
-    CompoundBorrowContractPositionHelper,
     CompoundBorrowBalanceHelper,
     CompoundSupplyBalanceHelper,
     EthereumImpermaxBalanceFetcher,

--- a/src/apps/impermax/polygon/impermax.borrow.contract-position-fetcher.ts
+++ b/src/apps/impermax/polygon/impermax.borrow.contract-position-fetcher.ts
@@ -1,12 +1,12 @@
 import { Inject } from '@nestjs/common';
 
 import { Register } from '~app-toolkit/decorators';
+import { CompoundBorrowContractPositionHelper } from '~apps/compound';
 import { PositionFetcher } from '~position/position-fetcher.interface';
 import { ContractPosition } from '~position/position.interface';
 import { Network } from '~types/network.interface';
 
-import { CompoundBorrowContractPositionHelper } from '../../tarot/helper/compound.borrow.contract-position-helper';
-import { ImpermaxContractFactory, Borrowable } from '../contracts';
+import { ImpermaxContractFactory } from '../contracts';
 import { IMPERMAX_DEFINITION } from '../impermax.definition';
 
 const appId = IMPERMAX_DEFINITION.id;
@@ -22,13 +22,13 @@ export class PolygonImpermaxBorrowContractPositionFetcher implements PositionFet
   ) {}
 
   async getPositions() {
-    return this.compoundBorrowContractPositionHelper.getPositions<Borrowable>({
+    return this.compoundBorrowContractPositionHelper.getPositions({
       network,
       appId,
       groupId,
       supplyGroupId: IMPERMAX_DEFINITION.groups.lend.id,
-      resolveContract: ({ address, network }) => this.contractFactory.borrowable({ address, network }),
-      resolveCashRaw: ({ multicall, contract }) => multicall.wrap(contract).totalBalance(),
+      resolveCashRaw: ({ multicall, address, network }) =>
+        multicall.wrap(this.contractFactory.borrowable({ address, network })).totalBalance(),
     });
   }
 }


### PR DESCRIPTION
## Description
Make a resolver for the `cash` contract call. For some protocol using the helper, the `getCash` method does not exist on the borrowable token contract. 

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?
[http://localhost:5001/apps/impermax/positions?groupIds%5B%5D=borrow&network=ethereum](http://localhost:5001/apps/impermax/positions?groupIds%5B%5D=borrow&network=ethereum)
[http://localhost:5001/apps/compound/positions?groupIds%5B%5D=borrow&network=ethereum](http://localhost:5001/apps/compound/positions?groupIds%5B%5D=borrow&network=ethereum)
