### PR TITLE
fix(curve): Use virtual price in v2 Pools price calculation

### DIFF
--- a/src/apps/curve/curve.module.ts
+++ b/src/apps/curve/curve.module.ts
@@ -34,6 +34,7 @@ import { CurveFactoryPoolTokenHelper } from './helpers/curve.factory-pool.token-
 import { CurveFactoryPoolDefinitionStrategy } from './helpers/curve.factory.pool-definition-strategy';
 import { CurveGaugeIsActiveStrategy } from './helpers/curve.gauge.is-active-strategy';
 import { CurveGaugeRoiStrategy } from './helpers/curve.gauge.roi-strategy';
+import { CurveLiquidityAndVirtualPriceStrategy } from './helpers/curve.liquidity-and-virtual.price-strategy';
 import { CurveLiquidityPriceStrategy } from './helpers/curve.liquidity.price-strategy';
 import { CurveOnChainCoinStrategy } from './helpers/curve.on-chain.coin-strategy';
 import { CurveOnChainReserveStrategy } from './helpers/curve.on-chain.reserve-strategy';
@@ -107,6 +108,7 @@ import { PolygonCurvePoolTokenFetcher } from './polygon/curve.pool.token-fetcher
     CurveOnChainReserveStrategy,
     CurveVirtualPriceStrategy,
     CurveLiquidityPriceStrategy,
+    CurveLiquidityAndVirtualPriceStrategy,
     CurveFactoryPoolDefinitionStrategy,
     CurveCryptoFactoryPoolDefinitionStrategy,
     // Gauge Helper Strategies
@@ -141,6 +143,7 @@ import { PolygonCurvePoolTokenFetcher } from './polygon/curve.pool.token-fetcher
     CurveOnChainReserveStrategy,
     CurveVirtualPriceStrategy,
     CurveLiquidityPriceStrategy,
+    CurveLiquidityAndVirtualPriceStrategy,
     CurveFactoryPoolDefinitionStrategy,
     CurveCryptoFactoryPoolDefinitionStrategy,
     // Gauge Helper Strategies

--- a/src/apps/curve/helpers/curve.crypto-factory-pool.token-helper.ts
+++ b/src/apps/curve/helpers/curve.crypto-factory-pool.token-helper.ts
@@ -7,7 +7,7 @@ import { Network } from '~types/network.interface';
 import { CurveContractFactory, CurveFactoryPool } from '../contracts';
 
 import { CurveCryptoFactoryPoolDefinitionStrategy } from './curve.crypto-factory.pool-definition-strategy';
-import { CurveLiquidityPriceStrategy } from './curve.liquidity.price-strategy';
+import { CurveLiquidityAndVirtualPriceStrategy } from './curve.liquidity-and-virtual.price-strategy';
 import { CurveOnChainCoinStrategy } from './curve.on-chain.coin-strategy';
 import { CurveOnChainReserveStrategy } from './curve.on-chain.reserve-strategy';
 import { CurveOnChainVolumeStrategy } from './curve.on-chain.volume-strategy';
@@ -34,8 +34,8 @@ export class CurveCryptoFactoryPoolTokenHelper {
     private readonly curveOnChainReserveStrategy: CurveOnChainReserveStrategy,
     @Inject(CurveCryptoFactoryPoolDefinitionStrategy)
     private readonly curveCryptoFactoryPoolDefinitionStrategy: CurveCryptoFactoryPoolDefinitionStrategy,
-    @Inject(CurveLiquidityPriceStrategy)
-    private readonly curveLiquidityPriceStrategy: CurveLiquidityPriceStrategy,
+    @Inject(CurveLiquidityAndVirtualPriceStrategy)
+    private readonly curveLiquidityAndVirtualPriceStrategy: CurveLiquidityAndVirtualPriceStrategy,
     @Inject(CurveContractFactory)
     private readonly curveContractFactory: CurveContractFactory,
     @Inject(CurveOnChainVolumeStrategy)
@@ -71,7 +71,13 @@ export class CurveCryptoFactoryPoolTokenHelper {
           .wrap(poolContract)
           .fee()
           .catch(() => '0'),
-      resolvePoolTokenPrice: this.curveLiquidityPriceStrategy.build(),
+      resolvePoolTokenPrice: this.curveLiquidityAndVirtualPriceStrategy.build({
+        resolveVirtualPrice: ({ multicall, poolContract }) =>
+          multicall
+            .wrap(poolContract)
+            .get_virtual_price()
+            .catch(() => '0'),
+      }),
       resolvePoolTokenSymbol: ({ multicall, poolTokenContract }) => multicall.wrap(poolTokenContract).symbol(),
       resolvePoolTokenSupply: ({ multicall, poolTokenContract }) => multicall.wrap(poolTokenContract).totalSupply(),
     });

--- a/src/apps/curve/helpers/curve.liquidity-and-virtual.price-strategy.ts
+++ b/src/apps/curve/helpers/curve.liquidity-and-virtual.price-strategy.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { BigNumberish } from 'ethers';
+
+import { EthersMulticall as Multicall } from '~multicall/multicall.ethers';
+import { Token } from '~position/position.interface';
+
+@Injectable()
+export class CurveLiquidityAndVirtualPriceStrategy {
+  build<T>({
+    resolveVirtualPrice,
+  }: {
+    resolveVirtualPrice: (opts: { multicall: Multicall; poolContract: T }) => Promise<BigNumberish>;
+  }) {
+    return async ({
+      tokens,
+      reserves,
+      supply,
+      multicall,
+      poolContract,
+    }: {
+      tokens: Token[];
+      reserves: number[];
+      supply: number;
+      multicall: Multicall;
+      poolContract: T;
+    }) => {
+      const virtualPriceRaw = await resolveVirtualPrice({ multicall, poolContract });
+      const virtualPrice = Number(virtualPriceRaw) / 10 ** 18;
+      const reservesUSD = tokens.map((t, i) => reserves[i] * t.price);
+      const liquidity = reservesUSD.reduce((total, r) => total + r, 0);
+      return virtualPrice > 0 ? virtualPrice * (liquidity / supply) : liquidity / supply;
+    };
+  }
+}


### PR DESCRIPTION
## Description
Fix for this [issue](https://github.com/Zapper-fi/support/issues/226). For TriCrypto2 and other v2 Pools, we are using a liquidity based price calculation (`liquidity / supply`). The pool virtual price ignored. The right calculation should be `virtual price * LP token price`.

## Checklist
- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?
[http://localhost:5001/apps/curve/tokens?groupIds%5B%5D=pool&network=ethereum](http://localhost:5001/apps/curve/tokens?groupIds%5B%5D=pool&network=ethereum)
