### PR TITLE
build(lint): Lint only changed files between branch and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,4 +85,4 @@ jobs:
           run_install: true
 
       - name: Studio linting tests
-        run: pnpm lint
+        run: pnpm lint:ci

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
+    "lint:ci": "eslint $(git diff --name-only --diff-filter=ACMRTUXB main | grep -E \"(.js$|.ts$|.tsx$)\")",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "start": "nest start",
     "studio": "node ./scripts/run-cli.js",


### PR DESCRIPTION
## Description

Run lint faster on CI by only linting files changed between the feature branch and `main`.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
