### PR TITLE
feat(aave-v2): Split out helpers into injectable module

### DIFF
--- a/src/app/app.dynamic-module.ts
+++ b/src/app/app.dynamic-module.ts
@@ -23,6 +23,11 @@ export const AbstractApp = () =>
     providers: DYNAMIC_PROVIDERS,
   });
 
+export const AbstractAppHelper = () =>
+  createConfigurableDynamicRootModule<Type, AppModuleOptions>(APP_OPTIONS, {
+    providers: DYNAMIC_PROVIDERS,
+  });
+
 export const DynamicApps = ({
   apps,
   imports,

--- a/src/apps/aave-v2/aave-v2.helper.module.ts
+++ b/src/apps/aave-v2/aave-v2.helper.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+
+import { AbstractAppHelper } from '~app/app.dynamic-module';
+
+import { AaveV2ContractFactory } from './contracts';
+import { AaveV2ClaimableBalanceHelper } from './helpers/aave-v2.claimable.balance-helper';
+import { AaveV2ClaimableContractPositionHelper } from './helpers/aave-v2.claimable.contract-position-helper';
+import { AaveV2HealthFactorMetaHelper } from './helpers/aave-v2.health-factor-meta-helper';
+import { AaveV2LendingBalanceHelper } from './helpers/aave-v2.lending.balance-helper';
+import { AaveV2LendingTokenHelper } from './helpers/aave-v2.lending.token-helper';
+
+Module({
+  providers: [
+    AaveV2ContractFactory,
+    AaveV2ClaimableBalanceHelper,
+    AaveV2ClaimableContractPositionHelper,
+    AaveV2HealthFactorMetaHelper,
+    AaveV2LendingBalanceHelper,
+    AaveV2LendingTokenHelper,
+  ],
+  exports: [
+    AaveV2ContractFactory,
+    AaveV2ClaimableBalanceHelper,
+    AaveV2ClaimableContractPositionHelper,
+    AaveV2HealthFactorMetaHelper,
+    AaveV2LendingBalanceHelper,
+    AaveV2LendingTokenHelper,
+  ],
+});
+export class AaveV2AppHelperModule extends AbstractAppHelper() {}

--- a/src/apps/aave-v2/aave-v2.module.ts
+++ b/src/apps/aave-v2/aave-v2.module.ts
@@ -2,23 +2,18 @@ import { Register } from '~app-toolkit/decorators';
 import { AbstractApp } from '~app/app.dynamic-module';
 
 import { AaveV2AppDefinition, AAVE_V2_DEFINITION } from './aave-v2.definition';
+import { AaveV2AppHelperModule } from './aave-v2.helper.module';
 import { AvalancheAaveV2BalanceFetcher } from './avalanche/aave-v2.balance-fetcher';
 import { AvalancheAaveV2ClaimableContractPositionFetcher } from './avalanche/aave-v2.claimable.contract-position-fetcher';
 import { AvalancheAaveV2StableDebtTokenFetcher } from './avalanche/aave-v2.stable-debt.token-fetcher';
 import { AvalancheAaveV2SupplyTokenFetcher } from './avalanche/aave-v2.supply.token-fetcher';
 import { AvalancheAaveV2VariableDebtTokenFetcher } from './avalanche/aave-v2.variable-debt.token-fetcher';
-import { AaveV2ContractFactory } from './contracts';
 import { EthereumAaveV2BalanceFetcher } from './ethereum/aave-v2.balance-fetcher';
 import { EthereumAaveV2ClaimableContractPositionFetcher } from './ethereum/aave-v2.claimable.contract-position-fetcher';
 import { EthereumAaveV2StableDebtTokenFetcher } from './ethereum/aave-v2.stable-debt.token-fetcher';
 import { EthereumAaveV2SupplyTokenFetcher } from './ethereum/aave-v2.supply.token-fetcher';
 import { EthereumAaveV2TvlFetcher } from './ethereum/aave-v2.tvl-fetcher';
 import { EthereumAaveV2VariableDebtTokenFetcher } from './ethereum/aave-v2.variable-debt.token-fetcher';
-import { AaveV2ClaimableBalanceHelper } from './helpers/aave-v2.claimable.balance-helper';
-import { AaveV2ClaimableContractPositionHelper } from './helpers/aave-v2.claimable.contract-position-helper';
-import { AaveV2HealthFactorMetaHelper } from './helpers/aave-v2.health-factor-meta-helper';
-import { AaveV2LendingBalanceHelper } from './helpers/aave-v2.lending.balance-helper';
-import { AaveV2LendingTokenHelper } from './helpers/aave-v2.lending.token-helper';
 import { PolygonAaveV2BalanceFetcher } from './polygon/aave-v2.balance-fetcher';
 import { PolygonAaveV2ClaimableContractPositionFetcher } from './polygon/aave-v2.claimable.contract-position-fetcher';
 import { PolygonAaveV2StableDebtTokenFetcher } from './polygon/aave-v2.stable-debt.token-fetcher';
@@ -27,14 +22,9 @@ import { PolygonAaveV2VariableDebtTokenFetcher } from './polygon/aave-v2.variabl
 
 @Register.AppModule({
   appId: AAVE_V2_DEFINITION.id,
+  imports: [AaveV2AppHelperModule],
   providers: [
     AaveV2AppDefinition,
-    AaveV2ClaimableBalanceHelper,
-    AaveV2ClaimableContractPositionHelper,
-    AaveV2ContractFactory,
-    AaveV2HealthFactorMetaHelper,
-    AaveV2LendingBalanceHelper,
-    AaveV2LendingTokenHelper,
     AvalancheAaveV2BalanceFetcher,
     AvalancheAaveV2ClaimableContractPositionFetcher,
     AvalancheAaveV2StableDebtTokenFetcher,
@@ -51,14 +41,6 @@ import { PolygonAaveV2VariableDebtTokenFetcher } from './polygon/aave-v2.variabl
     PolygonAaveV2StableDebtTokenFetcher,
     PolygonAaveV2SupplyTokenFetcher,
     PolygonAaveV2VariableDebtTokenFetcher,
-  ],
-  exports: [
-    AaveV2ContractFactory,
-    AaveV2ClaimableBalanceHelper,
-    AaveV2ClaimableContractPositionHelper,
-    AaveV2HealthFactorMetaHelper,
-    AaveV2LendingBalanceHelper,
-    AaveV2LendingTokenHelper,
   ],
 })
 export class AaveV2AppModule extends AbstractApp() {}


### PR DESCRIPTION
## Description

- Employing a new pattern to split helpers from the app module
- This enables other apps to consume helper classes from one app module without activating all the features of that app module

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
