### PR TITLE
fix(uniswap-v2): Make cache key generic in helper

### DIFF
--- a/src/apps/uniswap-v2/helpers/uniswap-v2.the-graph.pool-token-address-strategy.ts
+++ b/src/apps/uniswap-v2/helpers/uniswap-v2.the-graph.pool-token-address-strategy.ts
@@ -46,7 +46,8 @@ export class UniswapV2TheGraphPoolTokenAddressStrategy {
   constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
 
   @Cache({
-    key: (network: Network) => `studio-uniswap-v2-the-graph-pool-token-addresses:${network}:uniswap-v2`,
+    key: (network: Network, appId: string, groupId: string) =>
+      `studio-the-graph-pool-token-addresses:${network}:${appId}:${groupId}`,
     ttl: 5 * 60,
   })
   async getPoolAddresses(


### PR DESCRIPTION
## Description

Some apps are using the `UniswapV2TheGraphPoolTokenAddressStrategy` helper to perform external query to The Graph. The result is cached for 5 minutes. The problem is the cache has only the `Network` as dynamic parameter, meaning multiple Apps using that helper might have collisions.
I am changing the cache key building strategy to prevent that. Now the network, appId and groupId will be used as part of the cache key.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

[http://localhost:5001/apps/uniswap-v2/tokens?network=ethereum&groupIds%5B%5D=pool&api_key=562eee97-e90e-42ac-8e7b-363cdff5cdaa](http://localhost:5001/apps/uniswap-v2/tokens?network=ethereum&groupIds%5B%5D=pool&api_key=562eee97-e90e-42ac-8e7b-363cdff5cdaa)
