### PR TITLE
fix(aave-v2): Fix APY statsItem in helper

### DIFF
--- a/src/apps/aave-v2/helpers/aave-v2.lending.token-helper.ts
+++ b/src/apps/aave-v2/helpers/aave-v2.lending.token-helper.ts
@@ -157,7 +157,7 @@ export class AaveV2LendingTokenHelper {
         const tertiaryLabel = resolveApyLabel({ apy });
         const images = getImagesFromToken(reserveToken);
         const statsItems = [
-          { label: 'APY', value: buildPercentageDisplayItem(apy * 100) },
+          { label: 'APY', value: buildPercentageDisplayItem(apy) },
           { label: 'Liquidity', value: buildDollarDisplayItem(liquidity) },
         ];
 


### PR DESCRIPTION
## Description
The AAVE-V2 lending helper is multiplying the APY by 100 when adding it the statsItems list. This is causing the value to be off by 100x on the UI because the Frontend is already making that calculation. The value is off on AAVE-V2 and GEIST.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

