### PR TITLE
fix(compound): Create resolver for Supply/Borrow rate label

### DIFF
--- a/src/apps/compound/helper/compound.supply.token-helper.ts
+++ b/src/apps/compound/helper/compound.supply.token-helper.ts
@@ -42,6 +42,8 @@ type CompoundSupplyTokenHelperParams<T = CompoundComptroller, V = CompoundCToken
   getExchangeRate: (opts: { contract: V; multicall: Multicall }) => Promise<BigNumberish>;
   getSupplyRate: (opts: { contract: V; multicall: Multicall }) => Promise<BigNumberish>;
   getBorrowRate: (opts: { contract: V; multicall: Multicall }) => Promise<BigNumberish>;
+  getSupplyRateLabel?: () => string;
+  getBorrowRateLabel?: () => string;
   getUnderlyingAddress: (opts: { contract: V; multicall: Multicall }) => Promise<string>;
   getExchangeRateMantissa: (opts: { tokenDecimals: number; underlyingTokenDecimals: number }) => number;
   getDisplayLabel?: (opts: { contract: V; multicall: Multicall; underlyingToken: Token }) => Promise<string>;
@@ -71,6 +73,8 @@ export class CompoundSupplyTokenHelper {
     getExchangeRate,
     getSupplyRate,
     getBorrowRate,
+    getSupplyRateLabel = () => 'Supply APY',
+    getBorrowRateLabel = () => 'Borrow APR',
     getUnderlyingAddress,
     getExchangeRateMantissa,
     getDisplayLabel,
@@ -140,8 +144,8 @@ export class CompoundSupplyTokenHelper {
         const images = [getTokenImg(underlyingToken.address, network)];
         const balanceDisplayMode = BalanceDisplayMode.UNDERLYING;
         const statsItems = [
-          { label: 'Supply APY', value: buildPercentageDisplayItem(supplyApy) },
-          { label: 'Borrow APR', value: buildPercentageDisplayItem(borrowApy) },
+          { label: getSupplyRateLabel(), value: buildPercentageDisplayItem(supplyApy) },
+          { label: getBorrowRateLabel(), value: buildPercentageDisplayItem(borrowApy) },
           { label: 'Liquidity', value: buildDollarDisplayItem(liquidity) },
         ];
 


### PR DESCRIPTION
## Description

Making a resolver in Compound helper to allow app using it to be able to set a different label for the supply/borrow rate.

## Checklist
- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
