### PR TITLE
fix(iron-bank): Set borrow rate label

### DIFF
--- a/src/apps/iron-bank/avalanche/iron-bank.supply.token-fetcher.ts
+++ b/src/apps/iron-bank/avalanche/iron-bank.supply.token-fetcher.ts
@@ -33,6 +33,7 @@ export class AvalancheIronBankSupplyTokenFetcher implements PositionFetcher<AppT
       getExchangeRate: ({ contract, multicall }) => multicall.wrap(contract).exchangeRateCurrent(),
       getSupplyRate: ({ contract, multicall }) => multicall.wrap(contract).supplyRatePerBlock(),
       getBorrowRate: ({ contract, multicall }) => multicall.wrap(contract).borrowRatePerBlock(),
+      getBorrowRateLabel: () => 'Borrow APY',
       getUnderlyingAddress: ({ contract, multicall }) => multicall.wrap(contract).underlying(),
       getExchangeRateMantissa: ({ underlyingTokenDecimals }) => underlyingTokenDecimals + 10,
     });

--- a/src/apps/iron-bank/ethereum/iron-bank.supply.token-fetcher.ts
+++ b/src/apps/iron-bank/ethereum/iron-bank.supply.token-fetcher.ts
@@ -33,6 +33,7 @@ export class EthereumIronBankSupplyTokenFetcher implements PositionFetcher<AppTo
       getExchangeRate: ({ contract, multicall }) => multicall.wrap(contract).exchangeRateCurrent(),
       getSupplyRate: ({ contract, multicall }) => multicall.wrap(contract).supplyRatePerBlock(),
       getBorrowRate: ({ contract, multicall }) => multicall.wrap(contract).borrowRatePerBlock(),
+      getBorrowRateLabel: () => 'Borrow APY',
       getUnderlyingAddress: ({ contract, multicall }) => multicall.wrap(contract).underlying(),
       getExchangeRateMantissa: ({ underlyingTokenDecimals }) => underlyingTokenDecimals + 10,
     });

--- a/src/apps/iron-bank/fantom/iron-bank.supply.token-fetcher.ts
+++ b/src/apps/iron-bank/fantom/iron-bank.supply.token-fetcher.ts
@@ -33,6 +33,7 @@ export class FantomIronBankSupplyTokenFetcher implements PositionFetcher<AppToke
       getExchangeRate: ({ contract, multicall }) => multicall.wrap(contract).exchangeRateCurrent(),
       getSupplyRate: ({ contract, multicall }) => multicall.wrap(contract).supplyRatePerBlock(),
       getBorrowRate: ({ contract, multicall }) => multicall.wrap(contract).borrowRatePerBlock(),
+      getBorrowRateLabel: () => 'Borrow APY',
       getUnderlyingAddress: ({ contract, multicall }) => multicall.wrap(contract).underlying(),
       getExchangeRateMantissa: ({ underlyingTokenDecimals }) => underlyingTokenDecimals + 10,
     });


### PR DESCRIPTION
## Description
Iron Bank uses `Borrow APY` instead of `Borrow APR`

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?
[http://localhost:5001/apps/iron-bank/tokens?groupIds%5B%5D=supply&network=ethereum](http://localhost:5001/apps/iron-bank/tokens?groupIds%5B%5D=supply&network=ethereum)
