### PR TITLE
fix(beethoven-x): Update Farm APR label

### DIFF
--- a/src/app-toolkit/helpers/master-chef/master-chef.contract-position-helper.ts
+++ b/src/app-toolkit/helpers/master-chef/master-chef.contract-position-helper.ts
@@ -105,6 +105,7 @@ type MasterChefContractPositionHelperParams<T> = {
   resolveRewardRate?: MasterChefRewardRateStrategy<T>;
   resolveLiquidity?: MasterChefLiquidityStrategy<T>;
   resolveLabel?: MasterChefLabelStrategy;
+  resolveReturnOnInvestmentLabel?: () => string;
 };
 
 export type MasterChefContractPositionDataProps = {
@@ -145,6 +146,7 @@ export class MasterChefContractPositionHelper {
         .balanceOf(address),
     resolveAddress = async ({ contract }) => (contract as unknown as Contract).address,
     resolveLabel = ({ stakedToken }) => `Staked ${getLabelFromToken(stakedToken)}`,
+    resolveReturnOnInvestmentLabel = () => 'APY',
   }: MasterChefContractPositionHelperParams<T>): Promise<ContractPosition<MasterChefContractPositionDataProps>[]> {
     const provider = this.appToolkit.getNetworkProvider(network);
     const multicall = this.appToolkit.getMulticall(network);
@@ -282,7 +284,7 @@ export class MasterChefContractPositionHelper {
         const secondaryLabel = buildDollarDisplayItem(stakedToken.price);
         const images = getImagesFromToken(stakedToken);
         const statsItems = [
-          { label: 'APY', value: buildPercentageDisplayItem(yearlyROI) },
+          { label: resolveReturnOnInvestmentLabel(), value: buildPercentageDisplayItem(yearlyROI) },
           { label: 'Liquidity', value: buildDollarDisplayItem(liquidity) },
         ];
         const displayProps = {

--- a/src/apps/beethoven-x/fantom/beethoven-x.farm.contract-position-fetcher.ts
+++ b/src/apps/beethoven-x/fantom/beethoven-x.farm.contract-position-fetcher.ts
@@ -56,6 +56,7 @@ export class FantomBeethovenXFarmContractPositionFetcher implements PositionFetc
           resolveTotalAllocPoints: ({ multicall, contract }) => multicall.wrap(contract).totalAllocPoint(),
           resolveTotalRewardRate: ({ multicall, contract }) => multicall.wrap(contract).beetsPerBlock(),
         }),
+        resolveReturnOnInvestmentLabel: () => 'APR',
       });
 
     return compact(contractPositions);


### PR DESCRIPTION
## Description

Change the farm return on investment label to reflect `APR` from beethoven-x app

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

