### PR TITLE
feat(qi-dao): add gnosis chain support

### DIFF
--- a/src/apps/qi-dao/gnosis/qi-dao.balance-fetcher.ts
+++ b/src/apps/qi-dao/gnosis/qi-dao.balance-fetcher.ts
@@ -1,0 +1,43 @@
+import { Inject } from '@nestjs/common';
+
+import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
+import { Register } from '~app-toolkit/decorators';
+import { presentBalanceFetcherResponse } from '~app-toolkit/helpers/presentation/balance-fetcher-response.present';
+import { BalanceFetcher } from '~balance/balance-fetcher.interface';
+import { Network } from '~types/network.interface';
+
+import { QiDaoContractFactory } from '../contracts';
+import { QiDaoVaultPositionBalanceHelper } from '../helpers/qi-dao.vault.position-balance-helper';
+import { QI_DAO_DEFINITION } from '../qi-dao.definition';
+
+const network = Network.GNOSIS_MAINNET;
+
+@Register.BalanceFetcher(QI_DAO_DEFINITION.id, Network.GNOSIS_MAINNET)
+export class GnosisQiDaoBalanceFetcher implements BalanceFetcher {
+  constructor(
+    @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
+    @Inject(QiDaoVaultPositionBalanceHelper)
+    private readonly qiDaoVaultTokenBalanceHelper: QiDaoVaultPositionBalanceHelper,
+    @Inject(QiDaoContractFactory) private readonly contractFactory: QiDaoContractFactory,
+  ) { }
+
+  async getVaultTokenBalances(address: string) {
+    return this.qiDaoVaultTokenBalanceHelper.getPositionBalances({
+      address,
+      network,
+    });
+  }
+
+  async getBalances(address: string) {
+    const [vaultTokenBalances] = await Promise.all([
+      this.getVaultTokenBalances(address),
+    ]);
+
+    return presentBalanceFetcherResponse([
+      {
+        label: 'Vaults',
+        assets: vaultTokenBalances,
+      }
+    ]);
+  }
+}

--- a/src/apps/qi-dao/gnosis/qi-dao.vault.position-fetcher.ts
+++ b/src/apps/qi-dao/gnosis/qi-dao.vault.position-fetcher.ts
@@ -1,0 +1,35 @@
+import { Inject } from '@nestjs/common';
+
+import { Register } from '~app-toolkit/decorators';
+import { PositionFetcher } from '~position/position-fetcher.interface';
+import { ContractPosition } from '~position/position.interface';
+import { Network } from '~types/network.interface';
+
+import { QiDaoVaultPositionDataProps, QiDaoVaultPositionHelper } from '../helpers/qi-dao.vault.position-helper';
+import { QI_DAO_DEFINITION } from '../qi-dao.definition';
+
+const appId = QI_DAO_DEFINITION.id;
+const groupId = QI_DAO_DEFINITION.groups.vault.id;
+const network = Network.GNOSIS_MAINNET;
+
+@Register.ContractPositionFetcher({ appId, groupId, network, options: { includeInTvl: true } })
+export class GnosisQiDaoVaultPositionFetcher implements PositionFetcher<ContractPosition<QiDaoVaultPositionDataProps>> {
+  constructor(@Inject(QiDaoVaultPositionHelper) private readonly qiDaoVaultPositionHelper: QiDaoVaultPositionHelper) { }
+
+  getPositions() {
+    return this.qiDaoVaultPositionHelper.getPositions({
+      network,
+      debtTokenAddress: '0x3F56e0c36d275367b8C502090EDF38289b3dEa0d',
+      vaults: [
+        {
+          nftAddress: '0x5c49b268c9841AFF1Cc3B0a418ff5c3442eE3F3b', // WETH
+          vaultInfoAddress: '0x5c49b268c9841AFF1Cc3B0a418ff5c3442eE3F3b',
+        },
+        {
+          nftAddress: '0x014a177e9642d1b4e970418f894985dc1b85657f', // GNO
+          vaultInfoAddress: '0x014a177e9642d1b4e970418f894985dc1b85657f',
+        }
+      ],
+    });
+  }
+}

--- a/src/apps/qi-dao/helpers/qi-dao.vault.position-helper.ts
+++ b/src/apps/qi-dao/helpers/qi-dao.vault.position-helper.ts
@@ -37,7 +37,7 @@ export class QiDaoVaultPositionHelper {
   constructor(
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
     @Inject(QiDaoContractFactory) protected readonly contractFactory: QiDaoContractFactory,
-  ) {}
+  ) { }
 
   async getPositions({ network, vaults, debtTokenAddress, dependencies = [] }: QiDaoVaultPositionHelperParams) {
     const multicall = this.appToolkit.getMulticall(network);

--- a/src/apps/qi-dao/qi-dao.definition.ts
+++ b/src/apps/qi-dao/qi-dao.definition.ts
@@ -26,6 +26,7 @@ export const QI_DAO_DEFINITION = appDefinition({
   supportedNetworks: {
     [Network.FANTOM_OPERA_MAINNET]: [AppAction.VIEW],
     [Network.POLYGON_MAINNET]: [AppAction.VIEW],
+    [Network.GNOSIS_MAINNET]: [AppAction.VIEW],
   },
 });
 

--- a/src/apps/qi-dao/qi-dao.module.ts
+++ b/src/apps/qi-dao/qi-dao.module.ts
@@ -5,6 +5,8 @@ import { QiDaoContractFactory } from './contracts';
 import { FantomQiDaoBalanceFetcher } from './fantom/qi-dao.balance-fetcher';
 import { FantomQiDaoFarmContractPositionFetcher } from './fantom/qi-dao.farm.contract-position-fetcher';
 import { FantomQiDaoVaultPositionFetcher } from './fantom/qi-dao.vault.position-fetcher';
+import { GnosisQiDaoBalanceFetcher } from './gnosis/qi-dao.balance-fetcher';
+import { GnosisQiDaoVaultPositionFetcher } from './gnosis/qi-dao.vault.position-fetcher';
 import { QiDaoVaultPositionBalanceHelper } from './helpers/qi-dao.vault.position-balance-helper';
 import { QiDaoVaultPositionHelper } from './helpers/qi-dao.vault.position-helper';
 import { PolygonQiDaoAnchorVaultPositionFetcher } from './polygon/qi-dao.anchor-vault.contract-position-fetcher';
@@ -33,6 +35,9 @@ import { QiDaoAppDefinition, QI_DAO_DEFINITION } from './qi-dao.definition';
     PolygonQiDaoVaultPositionFetcher,
     PolygonQiDaoYieldTokenFetcher,
     PolygonQiDaoAnchorVaultPositionFetcher,
+    // Gnosis
+    GnosisQiDaoBalanceFetcher,
+    GnosisQiDaoVaultPositionFetcher,
   ],
 })
-export class QiDaoAppModule extends AbstractApp() {}
+export class QiDaoAppModule extends AbstractApp() { }


### PR DESCRIPTION
## Description
- Add support for Gnosis Chain for Qi DAO (mai.finance)

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Twitter handle is: th3_emerald

## How to test?

Note: `/v2/prices` does not return the price of MAI on Gnosis Chain yet (address is `0x3F56e0c36d275367b8C502090EDF38289b3dEa0d`).

This is a straightforward copy-paste of existing code, it should work as is!
