### PR TITLE
chore: Add presentation config to App definition interface

### DIFF
--- a/src/app/app.definition.ts
+++ b/src/app/app.definition.ts
@@ -4,7 +4,15 @@ import { uniq, keys, mapValues, zipObject } from 'lodash';
 import { Network } from '~types/network.interface';
 import { ArrayOfOneOrMore } from '~types/utils';
 
-import { AddressFormat, AppDefinitionObject, AppGroup, AppLinks, AppAction, AppTag } from './app.interface';
+import {
+  AddressFormat,
+  AppDefinitionObject,
+  AppGroup,
+  AppLinks,
+  AppAction,
+  AppTag,
+  PresentationConfig,
+} from './app.interface';
 
 function toNetworkWithActionsArray(
   supportedNetworks: Record<string, AppAction[]>,
@@ -48,6 +56,7 @@ export class AppDefinition {
     this.links = definitionRaw.links;
     this.description = definitionRaw.description ?? '';
     this.groups = definitionRaw.groups;
+    this.presentationConfig = definitionRaw.presentationConfig;
     this.supportedNetworks = toNetworkWithActionsArray(definitionRaw.supportedNetworks);
     this.primaryColor = definitionRaw.primaryColor ?? '';
     this.token = definitionRaw.token ?? null;
@@ -68,6 +77,7 @@ export class AppDefinition {
   readonly name: string;
   readonly description?: string;
   readonly groups: Record<string, AppGroup>;
+  readonly presentationConfig?: PresentationConfig;
   readonly url: string;
   readonly links: AppLinks;
   readonly deprecated?: boolean;

--- a/src/app/app.interface.ts
+++ b/src/app/app.interface.ts
@@ -72,6 +72,31 @@ export type AppLinks = {
   medium?: string;
 };
 
+export type PresentationConfig = {
+  tabs: (
+    | { viewType: 'list'; label: string; groupIds: string[] }
+    | {
+        viewType: 'split';
+        label: string;
+        views: (
+          | {
+              viewType: 'list';
+              label: string;
+              groupIds: string[];
+            }
+          | {
+              viewType: 'split';
+              label: string;
+              views: {
+                label: string;
+                groupIds: string[];
+              }[];
+            }
+        )[];
+      }
+  )[];
+};
+
 export type AppDefinitionObject = {
   id: string;
   name: string;
@@ -79,6 +104,7 @@ export type AppDefinitionObject = {
   keywords?: string[];
   description: string;
   groups: Record<string, AppGroup>;
+  presentationConfig?: PresentationConfig;
   supportedNetworks: { [N in Network]?: AppAction[] };
   primaryColor?: string;
   url: string;


### PR DESCRIPTION
## Description

Add the presentation config to the App definition interface.
This will allow to group certain asset like Supply/Borrow into to the same presentation section

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
