### PR TITLE
fix(aave-v2): Fix isActive dataProps

### DIFF
--- a/src/apps/aave-v2/helpers/aave-v2.lending.token-helper.ts
+++ b/src/apps/aave-v2/helpers/aave-v2.lending.token-helper.ts
@@ -149,7 +149,7 @@ export class AaveV2LendingTokenHelper {
           enabledAsCollateral,
           liquidity,
           liquidationThreshold,
-          isActive: Boolean(liquidity < 0),
+          isActive: Boolean(liquidityAmount > 0),
         };
 
         // Display Props


### PR DESCRIPTION
## Description

The flag was inverted and was using a variable that was negated. 

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
