### PR TITLE
chore: Remove Staked prefix label on Masterchef helper

### DIFF
--- a/src/app-toolkit/helpers/master-chef/master-chef.contract-position-helper.ts
+++ b/src/app-toolkit/helpers/master-chef/master-chef.contract-position-helper.ts
@@ -144,7 +144,7 @@ export class MasterChefContractPositionHelper {
         .wrap(this.appToolkit.globalContracts.erc20({ network, address: depositTokenAddress }))
         .balanceOf(address),
     resolveAddress = async ({ contract }) => (contract as unknown as Contract).address,
-    resolveLabel = ({ stakedToken }) => `Staked ${getLabelFromToken(stakedToken)}`,
+    resolveLabel = ({ stakedToken }) => `${getLabelFromToken(stakedToken)}`,
   }: MasterChefContractPositionHelperParams<T>): Promise<ContractPosition<MasterChefContractPositionDataProps>[]> {
     const provider = this.appToolkit.getNetworkProvider(network);
     const multicall = this.appToolkit.getMulticall(network);


### PR DESCRIPTION
## Description

Removing the `Staked` prefix from the label in the Masterchef helper

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
