### PR TITLE
fix(aave-v2): Fix displayed APY

### DIFF
--- a/src/apps/aave-v2/helpers/aave-v2.lending.token-helper.ts
+++ b/src/apps/aave-v2/helpers/aave-v2.lending.token-helper.ts
@@ -158,7 +158,7 @@ export class AaveV2LendingTokenHelper {
         const tertiaryLabel = resolveApyLabel({ apy });
         const images = getImagesFromToken(reserveToken);
         const statsItems = [
-          { label: 'APY', value: buildPercentageDisplayItem(apy) },
+          { label: 'APY', value: buildPercentageDisplayItem(apy * 100) },
           { label: 'Liquidity', value: buildDollarDisplayItem(liquidityAmount) },
         ];
 


### PR DESCRIPTION
## Description

Reverting a previous change that removed the `* 100` on the displayed APY. That was happening somewhere else. Now we can properly set the behaviour at the source when building the position.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
