### PR TITLE
fix: filtered out uniswap-v2 pool with absurd price and supply + bump the amount of enzyme finance vault fetched

### DIFF
--- a/src/apps/enzyme-finance/ethereum/enzyme-finance.vault.token-fetcher.ts
+++ b/src/apps/enzyme-finance/ethereum/enzyme-finance.vault.token-fetcher.ts
@@ -23,7 +23,7 @@ type EnzymeFinanceVaultsResponse = {
 
 const query = gql`
   query fetchEnzymeVaults {
-    funds(first: 100, orderBy: investmentCount, orderDirection: desc) {
+    funds(first: 250, orderBy: investmentCount, orderDirection: desc) {
       id
     }
   }

--- a/src/apps/pika-protocol/optimism/pika-protocol.balance-fetcher.ts
+++ b/src/apps/pika-protocol/optimism/pika-protocol.balance-fetcher.ts
@@ -40,10 +40,10 @@ export class OptimismPikaProtocolBalanceFetcher implements BalanceFetcher {
       address,
       appId: PIKA_PROTOCOL_DEFINITION.id,
       groupId: PIKA_PROTOCOL_DEFINITION.groups.vault.id,
-      network: Network.OPTIMISM_MAINNET,
+      network,
 
       resolveBalances: async ({ address, contractPosition, multicall }) => {
-        const rewardAddress = '0x58488bB666d2da33F8E8938Dbdd582D2481D4183'.toLowerCase();
+        const rewardAddress = '0x58488bb666d2da33f8e8938dbdd582d2481d4183';
         const contract = this.pikaProtocolContractFactory.pikaProtocolVault({
           address: contractPosition.address,
           network,

--- a/src/apps/uniswap-v2/ethereum/uniswap-v2.pool.token-fetcher.ts
+++ b/src/apps/uniswap-v2/ethereum/uniswap-v2.pool.token-fetcher.ts
@@ -37,7 +37,11 @@ export class EthereumUniswapV2PoolTokenFetcher implements PositionFetcher<AppTok
       appId,
       groupId: UNISWAP_V2_DEFINITION.groups.pool.id,
       factoryAddress: '0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f',
-      hiddenTokens: ['0x62359ed7505efc61ff1d56fef82158ccaffa23d7', '0x35bd01fc9d6d5d81ca9e055db88dc49aa2c699a8'],
+      hiddenTokens: [
+        '0x62359ed7505efc61ff1d56fef82158ccaffa23d7',
+        '0x35bd01fc9d6d5d81ca9e055db88dc49aa2c699a8',
+        '0x6adb2e268de2aa1abf6578e4a8119b960e02928f',
+      ],
       blockedPools: ['0x9cbfb60a09a9a33a10312da0f39977cbdb7fde23'], // Uniswap V2: SAITAMA - has a transfer fee (not supported by our zap)
       appTokenDependencies: [{ appId: 'alpha-v1', groupIds: ['lending'], network }],
       resolveFactoryContract: ({ address, network }) =>


### PR DESCRIPTION
## Description

- Filtered out uniswap-v2 pool with absurd price/supply
- Bump the number of enzyme-finance's vaults fetched

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
