### PR TITLE
fix(uniswap-v2): Fix silently failing pool addresses

### DIFF
--- a/src/apps/uniswap-v2/helpers/uniswap-v2.pool.token-helper.ts
+++ b/src/apps/uniswap-v2/helpers/uniswap-v2.pool.token-helper.ts
@@ -114,7 +114,7 @@ export class UniswapV2PoolTokenHelper {
       factoryAddress,
       resolveFactoryContract,
       resolvePoolContract,
-    }).catch(() => []);
+    });
 
     const poolVolumes: ResolvePoolVolumesResponse = await resolvePoolVolumes({
       appId,


### PR DESCRIPTION
## Description

If pool addresses resolver silently fails, we end up seeing no pools in production. This is currently happening for Spookyswap. Instead, fail loud so we can see the failing fetchers, and prevent our system from removing all stale pool tokens  (i.e.: its better to keep the stale tokens so that we can at least show balances, even though the prices might be delayed due to the failing fetcher).

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
