### PR TITLE
fix(positions): Move cache registration logic to position service

### DIFF
--- a/src/cache/cache-on-interval.service.ts
+++ b/src/cache/cache-on-interval.service.ts
@@ -53,7 +53,7 @@ export class CacheOnIntervalService implements OnModuleInit, OnModuleDestroy {
     this.registeredCacheKeys.push(cacheKey);
   }
 
-  private registerCache(instance: any, methodName: string) {
+  registerCache(instance: any, methodName: string) {
     const logger = this.logger;
     const methodRef = instance[methodName];
     const cacheKey: CacheOnIntervalOptions['key'] = this.reflector.get(CACHE_ON_INTERVAL_KEY, methodRef);

--- a/src/cache/cache.module.ts
+++ b/src/cache/cache.module.ts
@@ -7,5 +7,6 @@ import { CacheService } from './cache.service';
 @Module({
   imports: [DiscoveryModule, NestCacheModule.register({ ttl: 0, max: Number.MAX_SAFE_INTEGER, isGlobal: true })],
   providers: [CacheService, CacheOnIntervalService],
+  exports: [CacheService, CacheOnIntervalService],
 })
 export class CacheModule {}

--- a/src/position/position-fetcher.decorator.ts
+++ b/src/position/position-fetcher.decorator.ts
@@ -1,11 +1,8 @@
 import { applyDecorators, Injectable, SetMetadata } from '@nestjs/common';
 
-import { CacheOnIntervalBuilder } from '~cache/cache-on-interval.decorator';
 import { Network } from '~types/network.interface';
 
 import { ContractType } from './contract.interface';
-import { PositionFetcher as IPositionFetcher } from './position-fetcher.interface';
-import { Position } from './position.interface';
 
 export const POSITION_FETCHER_APP = 'POSITION_FETCHER_APP';
 export const POSITION_FETCHER_GROUP = 'POSITION_FETCHER_GROUP';
@@ -16,13 +13,6 @@ export const POSITION_FETCHER_OPTIONS = 'POSITION_FETCHER_OPTIONS';
 export type PositionOptions = {
   includeInTvl?: boolean;
 };
-
-export const buildAppPositionsCacheKey = (opts: {
-  type: ContractType;
-  network: Network;
-  appId: string;
-  groupId: string;
-}) => `apps-v3:${opts.type}:${opts.network}:${opts.appId}:${opts.groupId}`;
 
 export const PositionFetcher =
   (type: ContractType) =>
@@ -43,12 +33,6 @@ export const PositionFetcher =
       SetMetadata(POSITION_FETCHER_NETWORK, network),
       SetMetadata(POSITION_FETCHER_TYPE, type),
       SetMetadata(POSITION_FETCHER_OPTIONS, options),
-      CacheOnIntervalBuilder<IPositionFetcher<Position>>({
-        targetMethod: 'getPositions',
-        key: buildAppPositionsCacheKey({ type, network, appId, groupId }),
-        timeout: process.env.NODE_ENV === 'production' ? 45 * 1000 : 45 * 1000,
-        failOnMissingData: process.env.NODE_ENV === 'production',
-      }),
       Injectable,
     );
   };

--- a/src/position/position.module.ts
+++ b/src/position/position.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { DiscoveryModule } from '@nestjs/core';
 
+import { CacheModule } from '~cache/cache.module';
+
 import { PositionBalanceFetcherRegistry } from './position-balance-fetcher.registry';
 import { PositionFetcherRegistry } from './position-fetcher.registry';
 import { PositionSources } from './position-source';
@@ -8,7 +10,7 @@ import { PositionController } from './position.controller';
 import { PositionService } from './position.service';
 
 @Module({
-  imports: [DiscoveryModule],
+  imports: [DiscoveryModule, CacheModule],
   providers: [...PositionSources, PositionService, PositionFetcherRegistry, PositionBalanceFetcherRegistry],
   controllers: [PositionController],
   exports: [PositionService, PositionFetcherRegistry, PositionBalanceFetcherRegistry],


### PR DESCRIPTION
## Description

In the `PositionFetcherRegistry` initialization logic, register the `getPositions` method to the `CacheOnIntervalService`. This aligns the decorator with what we have in production so we don't double register the job.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
