### PR TITLE
feat(uniswap-v2): Build cache key from subgraph URL

### DIFF
--- a/src/apps/uniswap-v2/helpers/uniswap-v2.the-graph.pool-token-address-strategy.ts
+++ b/src/apps/uniswap-v2/helpers/uniswap-v2.the-graph.pool-token-address-strategy.ts
@@ -4,7 +4,6 @@ import { range, uniq } from 'lodash';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { Cache } from '~cache/cache.decorator';
-import { Network } from '~types/network.interface';
 
 import { UniswapFactory, UniswapPair } from '../contracts';
 
@@ -46,8 +45,10 @@ export class UniswapV2TheGraphPoolTokenAddressStrategy {
   constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
 
   @Cache({
-    key: (network: Network, appId: string, groupId: string) =>
-      `studio-the-graph-pool-token-addresses:${network}:${appId}:${groupId}`,
+    key: (subgraphUrl: string) => {
+      const [namespace, name] = subgraphUrl.split('/').slice(-2);
+      return `studio:uniswap-v2-fork:pool-token-addresses:${namespace}:${name}`;
+    },
     ttl: 5 * 60,
   })
   async getPoolAddresses(


### PR DESCRIPTION
## Description

Cache key builder does not have app ID, network, or group ID. Instead, just use the subgraph URL as the differentiator.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
