### PR TITLE
fix: removed 'borrow' prefix on aave-v2 positions

### DIFF
--- a/src/apps/aave-v2/avalanche/aave-v2.stable-debt.token-fetcher.ts
+++ b/src/apps/aave-v2/avalanche/aave-v2.stable-debt.token-fetcher.ts
@@ -26,7 +26,7 @@ export class AvalancheAaveV2StableDebtTokenFetcher implements PositionFetcher<Ap
       protocolDataProviderAddress: '0x65285e9dfab318f57051ab2b139cccf232945451',
       resolveTokenAddress: ({ reserveTokenAddressesData }) => reserveTokenAddressesData.stableDebtTokenAddress,
       resolveLendingRate: ({ reserveData }) => reserveData.stableBorrowRate,
-      resolveLabel: ({ reserveToken }) => `Borrowed ${getLabelFromToken(reserveToken)}`,
+      resolveLabel: ({ reserveToken }) => getLabelFromToken(reserveToken),
       resolveApyLabel: ({ apy }) => `${(apy * 100).toFixed(3)}% APR (stable)`,
     });
   }

--- a/src/apps/aave-v2/avalanche/aave-v2.variable-debt.token-fetcher.ts
+++ b/src/apps/aave-v2/avalanche/aave-v2.variable-debt.token-fetcher.ts
@@ -15,10 +15,7 @@ const network = Network.AVALANCHE_MAINNET;
 
 @Register.TokenPositionFetcher({ appId, groupId, network, options: { includeInTvl: true } })
 export class AvalancheAaveV2VariableDebtTokenFetcher implements PositionFetcher<AppTokenPosition> {
-  constructor(
-    @Inject(AaveV2LendingTokenHelper)
-    private readonly aaveV2LendingTokenHelper: AaveV2LendingTokenHelper,
-  ) {}
+  constructor(@Inject(AaveV2LendingTokenHelper) private readonly aaveV2LendingTokenHelper: AaveV2LendingTokenHelper) {}
 
   async getPositions() {
     return this.aaveV2LendingTokenHelper.getTokens({
@@ -29,7 +26,7 @@ export class AvalancheAaveV2VariableDebtTokenFetcher implements PositionFetcher<
       protocolDataProviderAddress: '0x65285e9dfab318f57051ab2b139cccf232945451',
       resolveTokenAddress: ({ reserveTokenAddressesData }) => reserveTokenAddressesData.variableDebtTokenAddress,
       resolveLendingRate: ({ reserveData }) => reserveData.variableBorrowRate,
-      resolveLabel: ({ reserveToken }) => `Borrowed ${getLabelFromToken(reserveToken)}`,
+      resolveLabel: ({ reserveToken }) => getLabelFromToken(reserveToken),
       resolveApyLabel: ({ apy }) => `${(apy * 100).toFixed(3)}% APR (variable)`,
     });
   }

--- a/src/apps/aave-v2/ethereum/aave-v2.variable-debt.token-fetcher.ts
+++ b/src/apps/aave-v2/ethereum/aave-v2.variable-debt.token-fetcher.ts
@@ -15,10 +15,7 @@ const network = Network.ETHEREUM_MAINNET;
 
 @Register.TokenPositionFetcher({ appId, groupId, network, options: { includeInTvl: true } })
 export class EthereumAaveV2VariableDebtTokenFetcher implements PositionFetcher<AppTokenPosition> {
-  constructor(
-    @Inject(AaveV2LendingTokenHelper)
-    private readonly aaveV2LendingTokenHelper: AaveV2LendingTokenHelper,
-  ) {}
+  constructor(@Inject(AaveV2LendingTokenHelper) private readonly aaveV2LendingTokenHelper: AaveV2LendingTokenHelper) {}
 
   async getPositions() {
     return await this.aaveV2LendingTokenHelper.getTokens({

--- a/src/apps/aave-v2/polygon/aave-v2.stable-debt.token-fetcher.ts
+++ b/src/apps/aave-v2/polygon/aave-v2.stable-debt.token-fetcher.ts
@@ -26,7 +26,7 @@ export class PolygonAaveV2StableDebtTokenFetcher implements PositionFetcher<AppT
       protocolDataProviderAddress: '0x7551b5d2763519d4e37e8b81929d336de671d46d',
       resolveTokenAddress: ({ reserveTokenAddressesData }) => reserveTokenAddressesData.stableDebtTokenAddress,
       resolveLendingRate: ({ reserveData }) => reserveData.stableBorrowRate,
-      resolveLabel: ({ reserveToken }) => `Borrowed ${getLabelFromToken(reserveToken)}`,
+      resolveLabel: ({ reserveToken }) => getLabelFromToken(reserveToken),
       resolveApyLabel: ({ apy }) => `${(apy * 100).toFixed(3)}% APR (stable)`,
     });
   }

--- a/src/apps/aave-v2/polygon/aave-v2.variable-debt.token-fetcher.ts
+++ b/src/apps/aave-v2/polygon/aave-v2.variable-debt.token-fetcher.ts
@@ -15,10 +15,7 @@ const network = Network.POLYGON_MAINNET;
 
 @Register.TokenPositionFetcher({ appId, groupId, network, options: { includeInTvl: true } })
 export class PolygonAaveV2VariableDebtTokenFetcher implements PositionFetcher<AppTokenPosition> {
-  constructor(
-    @Inject(AaveV2LendingTokenHelper)
-    private readonly aaveV2LendingTokenHelper: AaveV2LendingTokenHelper,
-  ) {}
+  constructor(@Inject(AaveV2LendingTokenHelper) private readonly aaveV2LendingTokenHelper: AaveV2LendingTokenHelper) {}
 
   async getPositions() {
     return this.aaveV2LendingTokenHelper.getTokens({
@@ -29,7 +26,7 @@ export class PolygonAaveV2VariableDebtTokenFetcher implements PositionFetcher<Ap
       protocolDataProviderAddress: '0x7551b5d2763519d4e37e8b81929d336de671d46d',
       resolveTokenAddress: ({ reserveTokenAddressesData }) => reserveTokenAddressesData.variableDebtTokenAddress,
       resolveLendingRate: ({ reserveData }) => reserveData.variableBorrowRate,
-      resolveLabel: ({ reserveToken }) => `Borrowed ${getLabelFromToken(reserveToken)}`,
+      resolveLabel: ({ reserveToken }) => getLabelFromToken(reserveToken),
       resolveApyLabel: ({ apy }) => `${(apy * 100).toFixed(3)}% APR (variable)`,
     });
   }


### PR DESCRIPTION
## Description

- Removed borrow prefix on aave-v2 position's label

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
