### PR TITLE
fix: Added liquidity on a Maple position + Umami TVL

### DIFF
--- a/src/apps/maple/ethereum/maple.staked-bpt.token-fetcher.ts
+++ b/src/apps/maple/ethereum/maple.staked-bpt.token-fetcher.ts
@@ -66,6 +66,7 @@ export class EthereumMapleStakedBptTokenFetcher implements PositionFetcher<AppTo
         const supply = Number(supplyRaw) / 10 ** decimals;
         const pricePerShare = 1;
         const price = mplUsdcAppToken.price;
+        const liquidity = supply * price;
         const tokens = [mplUsdcAppToken];
 
         // Display Props
@@ -86,7 +87,9 @@ export class EthereumMapleStakedBptTokenFetcher implements PositionFetcher<AppTo
           price,
           tokens,
 
-          dataProps: {},
+          dataProps: {
+            liquidity,
+          },
 
           displayProps: {
             label,

--- a/src/apps/umami/arbitrum/umami.balance-fetcher.ts
+++ b/src/apps/umami/arbitrum/umami.balance-fetcher.ts
@@ -20,13 +20,13 @@ export class ArbitrumUmamiBalanceFetcher implements BalanceFetcher {
   ) {}
 
   async getMarinatedBalance(address: string) {
-    const wETH_ADDRESS = '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'.toLowerCase();
-    const mUMAMI_ADDRESS = '0x2AdAbD6E8Ce3e82f52d9998a7f64a90d294A92A4'.toLowerCase();
+    const wETH_ADDRESS = '0x82af49447d8a07e3bd95bd0d56f35241523fbab1';
+    const mUMAMI_ADDRESS = '0x2adabd6e8ce3e82f52d9998a7f64a90d294a92a4';
     return this.appToolkit.helpers.contractPositionBalanceHelper.getContractPositionBalances({
       address,
       appId: UMAMI_DEFINITION.id,
       groupId: UMAMI_DEFINITION.groups.marinate.id,
-      network: Network.ARBITRUM_MAINNET,
+      network,
       resolveBalances: async ({ address, contractPosition, multicall }) => {
         const stakedToken = contractPosition.tokens.find(item => item.address === mUMAMI_ADDRESS)!;
         const rewardToken = contractPosition.tokens.find(item => item.address === wETH_ADDRESS)!;
@@ -48,7 +48,7 @@ export class ArbitrumUmamiBalanceFetcher implements BalanceFetcher {
       address,
       appId: UMAMI_DEFINITION.id,
       groupId: UMAMI_DEFINITION.groups.compound.id,
-      network: Network.ARBITRUM_MAINNET,
+      network,
     });
   }
 

--- a/src/apps/umami/arbitrum/umami.compound.token-fetcher.ts
+++ b/src/apps/umami/arbitrum/umami.compound.token-fetcher.ts
@@ -34,7 +34,7 @@ export type UmamiApiDatas = {
   mUmamiCompounder: UmamiCompounderApiObject;
 };
 
-@Register.TokenPositionFetcher({ appId, groupId, network })
+@Register.TokenPositionFetcher({ appId, groupId, network, options: { includeInTvl: true } })
 export class ArbitrumUmamiCompoundTokenFetcher implements PositionFetcher<AppTokenPosition> {
   constructor(
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
@@ -48,18 +48,14 @@ export class ArbitrumUmamiCompoundTokenFetcher implements PositionFetcher<AppTok
   async getUmamiInformations() {
     const data = await axios.get<UmamiApiDatas>('https://horseysauce.xyz/').then(v => v.data);
 
-    const { marinate, mUmamiCompounder } = data;
+    const { marinate } = data;
     const { apy } = marinate;
-    const { tvl } = mUmamiCompounder;
-    return {
-      apy,
-      tvl,
-    };
+    return apy;
   }
 
   async getPositions() {
-    const mUMAMI_ADDRESS = '0x2AdAbD6E8Ce3e82f52d9998a7f64a90d294A92A4'.toLowerCase();
-    const cmUMAMI_ADDRESS = '0x1922C36F3bc762Ca300b4a46bB2102F84B1684aB'.toLowerCase();
+    const mUMAMI_ADDRESS = '0x2adabd6e8ce3e82f52d9998a7f64a90d294a92a4';
+    const cmUMAMI_ADDRESS = '0x1922c36f3bc762ca300b4a46bb2102f84b1684ab';
     const multicall = this.appToolkit.getMulticall(network);
 
     const underlyingTokenContract = this.umamiContractFactory.umamiMarinate({
@@ -72,26 +68,28 @@ export class ArbitrumUmamiCompoundTokenFetcher implements PositionFetcher<AppTok
     });
 
     const appTokens = await this.appToolkit.getAppTokenPositions({
-      appId: 'umami',
-      groupIds: ['marinate'],
+      appId: UMAMI_DEFINITION.id,
+      groupIds: [UMAMI_DEFINITION.groups.marinate.id],
       network,
     });
+
     const [symbol, decimals, supplyRaw, balanceRaw] = await Promise.all([
       multicall.wrap(contract).symbol(),
       multicall.wrap(contract).decimals(),
       multicall.wrap(contract).totalSupply(),
       multicall.wrap(underlyingTokenContract).balanceOf(cmUMAMI_ADDRESS),
     ]);
-    const underlyingToken = appTokens.find(v => v.address === mUMAMI_ADDRESS);
 
+    const underlyingToken = appTokens.find(v => v.address === mUMAMI_ADDRESS);
     if (!underlyingToken) return [];
 
-    const { apy, tvl } = await this.getUmamiInformations();
+    const apy = await this.getUmamiInformations();
 
     const supply = Number(supplyRaw) / 10 ** decimals;
     const reserve = Number(balanceRaw) / 10 ** decimals;
     const pricePerShare = reserve / supply;
     const price = pricePerShare * underlyingToken.price;
+    const liquidity = supply * price;
     const tokens = [underlyingToken];
     const label = `Compounding Marinating UMAMI`;
     const images = getImagesFromToken(underlyingToken);
@@ -100,7 +98,7 @@ export class ArbitrumUmamiCompoundTokenFetcher implements PositionFetcher<AppTok
     const statsItems = [
       {
         label: 'Liquidity',
-        value: buildDollarDisplayItem(tvl),
+        value: buildDollarDisplayItem(liquidity),
       },
       {
         label: 'APY',
@@ -120,7 +118,9 @@ export class ArbitrumUmamiCompoundTokenFetcher implements PositionFetcher<AppTok
       pricePerShare,
       price,
       tokens,
-      dataProps: {},
+      dataProps: {
+        liquidity,
+      },
       displayProps: {
         label,
         images,

--- a/src/apps/umami/arbitrum/umami.marinate.contract-position-fetcher.ts
+++ b/src/apps/umami/arbitrum/umami.marinate.contract-position-fetcher.ts
@@ -10,7 +10,6 @@ import { ContractPosition } from '~position/position.interface';
 import { claimable, supplied } from '~position/position.utils';
 import { Network } from '~types/network.interface';
 
-import { UmamiContractFactory } from '../contracts';
 import { UMAMI_DEFINITION } from '../umami.definition';
 
 const appId = UMAMI_DEFINITION.id;
@@ -19,19 +18,16 @@ const network = Network.ARBITRUM_MAINNET;
 
 @Register.ContractPositionFetcher({ appId, groupId, network })
 export class ArbitrumUmamiMarinateContractPositionFetcher implements PositionFetcher<ContractPosition> {
-  constructor(
-    @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
-    @Inject(UmamiContractFactory) private readonly umamiContractFactory: UmamiContractFactory,
-  ) {}
+  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
 
   async getPositions() {
-    const wETH_ADDRESS = '0x82af49447d8a07e3bd95bd0d56f35241523fbab1'.toLowerCase();
-    const mUMAMI_ADDRESS = '0x2AdAbD6E8Ce3e82f52d9998a7f64a90d294A92A4'.toLowerCase();
+    const wETH_ADDRESS = '0x82af49447d8a07e3bd95bd0d56f35241523fbab1';
+    const mUMAMI_ADDRESS = '0x2adabd6e8ce3e82f52d9998a7f64a90d294a92a4';
 
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
     const appTokens = await this.appToolkit.getAppTokenPositions({
-      appId: 'umami',
-      groupIds: ['marinate'],
+      appId: UMAMI_DEFINITION.id,
+      groupIds: [UMAMI_DEFINITION.groups.marinate.id],
       network,
     });
 
@@ -42,7 +38,7 @@ export class ArbitrumUmamiMarinateContractPositionFetcher implements PositionFet
     if (!stakedToken || !rewardToken) return [];
 
     const tokens = [supplied(stakedToken), claimable(rewardToken)];
-    const label = `Staked ${getLabelFromToken(stakedToken)}`;
+    const label = getLabelFromToken(stakedToken);
     const images = getImagesFromToken(stakedToken);
     const secondaryLabel = buildDollarDisplayItem(stakedToken.price);
 


### PR DESCRIPTION
## Description

- Added liquidity on staked balancer pool token contract position (maple apps)
- Enabled Umami TVL using on chain data (it's more accurate by ~2% in the case of compound and marinate tokens)
- Cleaned up umami apps

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
