### PR TITLE
fix: split ticket and sponsorship liquidity (pool-together)

### DIFF
--- a/src/apps/pool-together/helpers/pool-together-v3.prize-pool.token-helper.ts
+++ b/src/apps/pool-together/helpers/pool-together-v3.prize-pool.token-helper.ts
@@ -70,6 +70,8 @@ export class PoolTogetherV3PrizePoolTokenHelper {
         const pricePerShare = 1; // Minted 1:1
         const price = underlyingToken.price * pricePerShare;
         const liquidity = totalSupply * underlyingToken.price;
+        const liquidityTicket = ticketSupply * underlyingToken.price;
+        const liquiditySponsorship = sponsorshipSupply * underlyingToken.price;
         const tokens = [underlyingToken];
 
         // Display Props
@@ -136,7 +138,7 @@ export class PoolTogetherV3PrizePoolTokenHelper {
 
           dataProps: {
             apy,
-            liquidity,
+            liquidity: liquidityTicket,
             faucetAddresses,
           },
 
@@ -151,7 +153,7 @@ export class PoolTogetherV3PrizePoolTokenHelper {
               },
               {
                 label: 'Liquidity',
-                value: buildDollarDisplayItem(liquidity),
+                value: buildDollarDisplayItem(liquidityTicket),
               },
             ],
           },
@@ -172,7 +174,7 @@ export class PoolTogetherV3PrizePoolTokenHelper {
 
           dataProps: {
             apy,
-            liquidity,
+            liquidity: liquiditySponsorship,
             faucetAddresses,
           },
 
@@ -187,7 +189,7 @@ export class PoolTogetherV3PrizePoolTokenHelper {
               },
               {
                 label: 'Liquidity',
-                value: buildDollarDisplayItem(liquidity),
+                value: buildDollarDisplayItem(liquiditySponsorship),
               },
             ],
           },

--- a/src/apps/pool-together/pool-together.definition.ts
+++ b/src/apps/pool-together/pool-together.definition.ts
@@ -16,8 +16,8 @@ export const POOL_TOGETHER_DEFINITION = appDefinition({
     medium: 'https://medium.com/pooltogether',
   },
   groups: {
-    v3: { id: 'v3', type: GroupType.TOKEN, label: 'Prize Pools', groupLabel: 'Pools' },
-    v4: { id: 'v4', type: GroupType.TOKEN, label: 'PoolTogether', groupLabel: 'Pools' },
+    v3: { id: 'v3', type: GroupType.TOKEN, label: 'Prize Pools', groupLabel: 'Deposit' },
+    v4: { id: 'v4', type: GroupType.TOKEN, label: 'PoolTogether', groupLabel: 'Deposit' },
     claimable: { id: 'claimable', type: GroupType.TOKEN, label: 'Rewards', isHiddenFromExplore: true },
     v3Pod: { id: 'v3-pod', type: GroupType.POSITION, label: 'Prize Pods' },
   },


### PR DESCRIPTION
## Description

- Split ticket and sponsorship liquidity (pool-together)
- Renamed "Pools" group label to "Deposit" matching Pool-Together's UI

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
