### PR TITLE
fix: bunch of smol fixes (trader-joe, across, qiDao, maple)

### DIFF
--- a/src/apps/across/ethereum/across.pool.token-fetcher.ts
+++ b/src/apps/across/ethereum/across.pool.token-fetcher.ts
@@ -4,7 +4,7 @@ import { compact } from 'lodash';
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { Register } from '~app-toolkit/decorators';
 import { buildDollarDisplayItem } from '~app-toolkit/helpers/presentation/display-item.present';
-import { getAppImg } from '~app-toolkit/helpers/presentation/image.present';
+import { getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
 import { ContractType } from '~position/contract.interface';
 import { PositionFetcher } from '~position/position-fetcher.interface';
 import { AppTokenPosition } from '~position/position.interface';
@@ -51,7 +51,7 @@ export class EthereumAcrossPoolTokenFetcher implements PositionFetcher<AppTokenP
         const price = underlyingToken.price * pricePerShare;
         const tokens = [underlyingToken];
         const secondaryLabel = buildDollarDisplayItem(price);
-        const images = [getAppImg(ACROSS_DEFINITION.id)];
+        const images = [getTokenImg(underlyingToken.address, network)];
         const liquidity = price * supply;
         const dataProps = { liquidity };
         const label = labelRaw.slice(7);

--- a/src/apps/maple/ethereum/maple.staked-bpt.token-fetcher.ts
+++ b/src/apps/maple/ethereum/maple.staked-bpt.token-fetcher.ts
@@ -33,7 +33,7 @@ const appId = MAPLE_DEFINITION.id;
 const groupId = MAPLE_DEFINITION.groups.stakedBpt.id;
 const network = Network.ETHEREUM_MAINNET;
 
-@Register.TokenPositionFetcher({ appId, groupId, network, options: { includeInTvl: true } })
+@Register.TokenPositionFetcher({ appId, groupId, network })
 export class EthereumMapleStakedBptTokenFetcher implements PositionFetcher<AppTokenPosition> {
   constructor(
     @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,

--- a/src/apps/maple/maple.definition.ts
+++ b/src/apps/maple/maple.definition.ts
@@ -21,6 +21,7 @@ export const MAPLE_DEFINITION = appDefinition({
       type: GroupType.TOKEN,
       label: 'Staked BPT',
       groupLabel: 'Farms',
+      isHiddenFromExplore: true,
     },
 
     pool: {

--- a/src/apps/qi-dao/polygon/qi-dao.escrowed-qi.contract-position-fetcher.ts
+++ b/src/apps/qi-dao/polygon/qi-dao.escrowed-qi.contract-position-fetcher.ts
@@ -9,21 +9,37 @@ import { PositionFetcher } from '~position/position-fetcher.interface';
 import { ContractPosition } from '~position/position.interface';
 import { Network } from '~types/network.interface';
 
+import { QiDaoContractFactory } from '../contracts';
 import { QI_DAO_DEFINITION } from '../qi-dao.definition';
 
 const appId = QI_DAO_DEFINITION.id;
 const groupId = QI_DAO_DEFINITION.groups.escrowedQi.id;
 const network = Network.POLYGON_MAINNET;
 
-@Register.ContractPositionFetcher({ appId, groupId, network })
+@Register.ContractPositionFetcher({ appId, groupId, network, options: { includeInTvl: true } })
 export class PolygonQiDaoEscrowedQiContractPositionFetcher implements PositionFetcher<ContractPosition> {
-  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
+  constructor(
+    @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
+    @Inject(QiDaoContractFactory) private readonly qiDaoContractFactory: QiDaoContractFactory,
+  ) {}
 
   async getPositions() {
+    const multicall = this.appToolkit.getMulticall(network);
+
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
     const address = '0x880decade22ad9c58a8a4202ef143c4f305100b3';
     const qiToken = baseTokens.find(v => v.symbol === 'QI')!;
     const tokens = [qiToken];
+
+    const qiTokencontract = this.qiDaoContractFactory.erc20({ address: qiToken.address, network });
+
+    const [decimals, balanceRaw] = await Promise.all([
+      multicall.wrap(qiTokencontract).decimals(),
+      multicall.wrap(qiTokencontract).balanceOf(address),
+    ]);
+
+    const balance = Number(balanceRaw) / 10 ** decimals;
+    const liquidity = balance * qiToken.price;
 
     const contractPosition: ContractPosition = {
       type: ContractType.POSITION,
@@ -31,11 +47,14 @@ export class PolygonQiDaoEscrowedQiContractPositionFetcher implements PositionFe
       appId,
       groupId,
       network,
-      dataProps: {},
+      dataProps: {
+        liquidity,
+      },
       displayProps: {
         label: 'Escrowed QI',
         secondaryLabel: buildDollarDisplayItem(qiToken.price),
         images: [getTokenImg(qiToken.address, network)],
+        statsItems: [{ label: 'Liquidity', value: buildDollarDisplayItem(liquidity) }],
       },
       tokens,
     };

--- a/src/apps/trader-joe/avalanche/trader-joe.balance-fetcher.ts
+++ b/src/apps/trader-joe/avalanche/trader-joe.balance-fetcher.ts
@@ -69,7 +69,7 @@ export class AvalancheTraderJoeBalanceFetcher implements BalanceFetcher {
       address,
       appId,
       network,
-      groupId: TRADER_JOE_DEFINITION.groups.veJoeFarm.id,
+      groupId: TRADER_JOE_DEFINITION.groups.veJoe.id,
       resolveContract: opts => this.traderJoeContractFactory.traderJoeVeJoeStaking(opts),
       resolveStakedTokenBalance: ({ multicall, contract }) =>
         multicall
@@ -202,7 +202,7 @@ export class AvalancheTraderJoeBalanceFetcher implements BalanceFetcher {
         assets: [...sJoeBalances],
       },
       {
-        label: 'veJOE Staking',
+        label: 'veJOE',
         assets: [...veJoeBalances],
       },
       {

--- a/src/apps/trader-joe/avalanche/trader-joe.s-joe.contract-position-fetcher.ts
+++ b/src/apps/trader-joe/avalanche/trader-joe.s-joe.contract-position-fetcher.ts
@@ -18,8 +18,7 @@ const network = Network.AVALANCHE_MAINNET;
 export class AvalancheTraderJoeSJoeContractPositionFetcher implements PositionFetcher<ContractPosition> {
   constructor(
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
-    @Inject(TraderJoeContractFactory)
-    private readonly contractFactory: TraderJoeContractFactory,
+    @Inject(TraderJoeContractFactory) private readonly contractFactory: TraderJoeContractFactory,
   ) {}
 
   async getPositions() {

--- a/src/apps/trader-joe/avalanche/trader-joe.ve-joe-farm.contract-position-fetcher.ts
+++ b/src/apps/trader-joe/avalanche/trader-joe.ve-joe-farm.contract-position-fetcher.ts
@@ -10,11 +10,11 @@ import { TraderJoeVeJoeStaking, TraderJoeContractFactory } from '../contracts';
 import { TRADER_JOE_DEFINITION } from '../trader-joe.definition';
 
 const appId = TRADER_JOE_DEFINITION.id;
-const groupId = TRADER_JOE_DEFINITION.groups.veJoeFarm.id;
+const groupId = TRADER_JOE_DEFINITION.groups.veJoe.id;
 const network = Network.AVALANCHE_MAINNET;
 
 @Register.ContractPositionFetcher({ appId, groupId, network })
-export class AvalancheTraderJoeVeJoeFarmContractPositionFetcher implements PositionFetcher<ContractPosition> {
+export class AvalancheTraderJoeVeJoeContractPositionFetcher implements PositionFetcher<ContractPosition> {
   constructor(
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
     @Inject(TraderJoeContractFactory) private readonly contractFactory: TraderJoeContractFactory,

--- a/src/apps/trader-joe/trader-joe.definition.ts
+++ b/src/apps/trader-joe/trader-joe.definition.ts
@@ -12,7 +12,7 @@ export const TRADER_JOE_DEFINITION = appDefinition({
     pool: { id: 'pool', type: GroupType.TOKEN, label: 'Pools', groupLabel: 'Pools' },
     xJoe: { id: 'x-joe', type: GroupType.TOKEN, label: 'xJoe' },
     sJoe: { id: 's-joe', type: GroupType.POSITION, label: 'sJoe' },
-    veJoeFarm: { id: 've-joe-farm', type: GroupType.POSITION, label: 'Farms', groupLabel: 'Farms' },
+    veJoe: { id: 've-joe', type: GroupType.POSITION, label: 'veJoe' },
     chefV2Farm: { id: 'chef-v2-farm', type: GroupType.POSITION, label: 'Farms', groupLabel: 'Farms' },
     chefV3Farm: { id: 'chef-v3-farm', type: GroupType.POSITION, label: 'Farms', groupLabel: 'Farms' },
     chefBoostedFarm: { id: 'chef-boosted-farm', type: GroupType.POSITION, label: 'Boost', groupLabel: 'Farms' },

--- a/src/apps/trader-joe/trader-joe.module.ts
+++ b/src/apps/trader-joe/trader-joe.module.ts
@@ -8,7 +8,7 @@ import { AvalancheTraderJoeChefV2FarmContractPositionFetcher } from './avalanche
 import { AvalancheTraderJoeChefV3FarmContractPositionFetcher } from './avalanche/trader-joe.chef-v3-farm.contract-position-fetcher';
 import { AvalancheTraderJoePoolTokenFetcher } from './avalanche/trader-joe.pool.token-fetcher';
 import { AvalancheTraderJoeSJoeContractPositionFetcher } from './avalanche/trader-joe.s-joe.contract-position-fetcher';
-import { AvalancheTraderJoeVeJoeFarmContractPositionFetcher } from './avalanche/trader-joe.ve-joe-farm.contract-position-fetcher';
+import { AvalancheTraderJoeVeJoeContractPositionFetcher } from './avalanche/trader-joe.ve-joe-farm.contract-position-fetcher';
 import { AvalancheTraderJoeXJoeTokenFetcher } from './avalanche/trader-joe.x-joe.token-fetcher';
 import { TraderJoeContractFactory } from './contracts';
 import { TraderJoeAppDefinition, TRADER_JOE_DEFINITION } from './trader-joe.definition';
@@ -26,7 +26,7 @@ import { TraderJoeAppDefinition, TRADER_JOE_DEFINITION } from './trader-joe.defi
     AvalancheTraderJoePoolTokenFetcher,
     AvalancheTraderJoeXJoeTokenFetcher,
     AvalancheTraderJoeSJoeContractPositionFetcher,
-    AvalancheTraderJoeVeJoeFarmContractPositionFetcher,
+    AvalancheTraderJoeVeJoeContractPositionFetcher,
   ],
 })
 export class TraderJoeAppModule extends AbstractApp() {}


### PR DESCRIPTION
## Description

- fixed across pool token images
- renamed veJoeFarm to veJoe
- Added liquidity to qiDAO escrowed position
- Hide maple bpt position from explorer

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
