### PR TITLE
fix: escrowed qi-dao position should be shown in explorer

### DIFF
--- a/src/apps/qi-dao/qi-dao.definition.ts
+++ b/src/apps/qi-dao/qi-dao.definition.ts
@@ -8,7 +8,7 @@ export const QI_DAO_DEFINITION = appDefinition({
   name: 'Qi Dao',
   description: `Qi Dao is a lending and stablecoin protocol native to Polygon.`,
   groups: {
-    escrowedQi: { id: 'escrowed-qi', type: GroupType.POSITION, label: 'Escrowed QI', isHiddenFromExplore: true },
+    escrowedQi: { id: 'escrowed-qi', type: GroupType.POSITION, label: 'Escrowed QI' },
     farm: { id: 'farm', type: GroupType.POSITION, label: 'Staking' },
     anchorVault: { id: 'anchor-vault', type: GroupType.POSITION, label: 'Anchor Vaults' },
     vault: { id: 'vault', type: GroupType.POSITION, label: 'Vaults' },


### PR DESCRIPTION
## Description

- Added liquidity on escrowed QI DAO position but forgot to removed the hiddenFromExplorer option 😬 

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
