### PR TITLE
feat(mean-finance): improve mean finance label to show position info

### DIFF
--- a/src/apps/mean-finance/helpers/intervals.ts
+++ b/src/apps/mean-finance/helpers/intervals.ts
@@ -27,12 +27,36 @@ const ONE_DAY = FOUR_HOURS * 6;
 const ONE_WEEK = ONE_DAY * 7;
 
 export const STRING_SWAP_INTERVALS = {
-  [ONE_MINUTE]: (left: number) => `${toReadable(left, ONE_MINUTE)} (${left} swaps)`,
-  [FIVE_MINUTES]: (left: number) => `${toReadable(left, FIVE_MINUTES)} (${left} swaps)`,
-  [FIFTEEN_MINUTES]: (left: number) => `${toReadable(left, FIFTEEN_MINUTES)} (${left} swaps)`,
-  [THIRTY_MINUTES]: (left: number) => `${toReadable(left, THIRTY_MINUTES)} (${left} swaps)`,
-  [ONE_HOUR]: (left: number) => `${toReadable(left, ONE_HOUR)} (${left} swaps)`,
-  [FOUR_HOURS]: (left: number) => `${toReadable(left, FOUR_HOURS)} (${left} swaps)`,
-  [ONE_DAY]: (left: number) => `${toReadable(left, ONE_DAY)} (${left} swaps)`,
-  [ONE_WEEK]: (left: number) => `${toReadable(left, ONE_WEEK)} (${left} swaps)`,
+  [ONE_MINUTE]: {
+    plural: (left: number) => `${toReadable(left, ONE_MINUTE)} (${left} swaps)`,
+    adverb: 'every 1 minute',
+  },
+  [FIVE_MINUTES]: {
+    plural: (left: number) => `${toReadable(left, FIVE_MINUTES)} (${left} swaps)`,
+    adverb: 'every 5 minutes',
+  },
+  [FIFTEEN_MINUTES]: {
+    plural: (left: number) => `${toReadable(left, FIFTEEN_MINUTES)} (${left} swaps)`,
+    adverb: 'every 15 minutes',
+  },
+  [THIRTY_MINUTES]: {
+    plural: (left: number) => `${toReadable(left, THIRTY_MINUTES)} (${left} swaps)`,
+    adverb: 'every 30 minutes',
+  },
+  [ONE_HOUR]: {
+    plural: (left: number) => `${toReadable(left, ONE_HOUR)} (${left} swaps)`,
+    adverb: 'every hour',
+  },
+  [FOUR_HOURS]: {
+    plural: (left: number) => `${toReadable(left, FOUR_HOURS)} (${left} swaps)`,
+    adverb: 'every 4 hours',
+  },
+  [ONE_DAY]: {
+    plural: (left: number) => `${toReadable(left, ONE_DAY)} (${left} swaps)`,
+    adverb: 'every day',
+  },
+  [ONE_WEEK]: {
+    plural: (left: number) => `${toReadable(left, ONE_WEEK)} (${left} swaps)`,
+    adverb: 'every week',
+  },
 };

--- a/src/apps/mean-finance/optimism/mean-finance.balance-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.balance-fetcher.ts
@@ -42,6 +42,11 @@ export class OptimismMeanFinanceBalanceFetcher implements BalanceFetcher {
       const swapInterval = Number(dcaPosition.swapInterval.interval) as keyof typeof STRING_SWAP_INTERVALS;
       const rawRate = dcaPosition.current.rate;
       const rate = Number(rawRate) / 10 ** Number(dcaPosition.from.decimals);
+      let formattedRate = rate.toFixed(3);
+
+      if (rate < 0.001) {
+        formattedRate = '<0.001'
+      }
 
       const from = baseTokens.find(v => v.address === dcaPosition.from.address);
       const to = baseTokens.find(v => v.address === dcaPosition.to.address);
@@ -71,7 +76,7 @@ export class OptimismMeanFinanceBalanceFetcher implements BalanceFetcher {
       let label = '';
 
       if (remainingSwaps > 0) {
-        label = `Swapping ${rate} ${from?.symbol || dcaPosition.from.symbol} ${swapIntervalAdverb} to ${to?.symbol || dcaPosition.from.symbol}`;
+        label = `Swapping ~${formattedRate} ${from?.symbol || dcaPosition.from.symbol} ${swapIntervalAdverb} to ${to?.symbol || dcaPosition.from.symbol}`;
       } else {
         label = `Swapping ${from?.symbol || dcaPosition.from.symbol} to ${to?.symbol || dcaPosition.from.symbol}`;
       }

--- a/src/apps/mean-finance/optimism/mean-finance.balance-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.balance-fetcher.ts
@@ -10,7 +10,8 @@ import { BalanceFetcher } from '~balance/balance-fetcher.interface';
 import { ContractType } from '~position/contract.interface';
 import { WithMetaType } from '~position/display.interface';
 import { BaseTokenBalance, ContractPositionBalance } from '~position/position-balance.interface';
-import { MetaType } from '~position/position.interface';
+import { claimable } from '~position/position.utils';
+import { BaseToken } from '~position/token.interface';
 import { Network } from '~types/network.interface';
 
 import { getUserPositions } from '../helpers/graph';
@@ -57,10 +58,8 @@ export class OptimismMeanFinanceBalanceFetcher implements BalanceFetcher {
       }
       if (to) {
         to.network = network;
-        tokens.push({
-          ...drillBalance(to, toWithdraw),
-          metaType: MetaType.CLAIMABLE,
-        });
+        const claimableTo = claimable(to) as WithMetaType<BaseToken>;
+        tokens.push(drillBalance(claimableTo, toWithdraw));
         images = [
           ...images,
           ...getImagesFromToken(to),

--- a/src/apps/mean-finance/optimism/mean-finance.balance-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.balance-fetcher.ts
@@ -63,8 +63,7 @@ export class OptimismMeanFinanceBalanceFetcher implements BalanceFetcher {
       }
       if (to) {
         to.network = network;
-        const claimableTo = claimable(to) as WithMetaType<BaseToken>;
-        tokens.push(drillBalance(claimableTo, toWithdraw));
+        tokens.push(drillBalance(claimable(to), toWithdraw));
         images = [
           ...images,
           ...getImagesFromToken(to),

--- a/src/apps/mean-finance/optimism/mean-finance.balance-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.balance-fetcher.ts
@@ -10,6 +10,7 @@ import { BalanceFetcher } from '~balance/balance-fetcher.interface';
 import { ContractType } from '~position/contract.interface';
 import { WithMetaType } from '~position/display.interface';
 import { BaseTokenBalance, ContractPositionBalance } from '~position/position-balance.interface';
+import { MetaType } from '~position/position.interface';
 import { Network } from '~types/network.interface';
 
 import { getUserPositions } from '../helpers/graph';
@@ -36,8 +37,10 @@ export class OptimismMeanFinanceBalanceFetcher implements BalanceFetcher {
     const contractPositionBalances: ContractPositionBalance[] = positions.map(dcaPosition => {
       const toWithdraw = dcaPosition.current.idleSwapped;
       const remainingLiquidity = dcaPosition.current.remainingLiquidity;
-      const remainingSwaps = dcaPosition.current.remainingSwaps;
-      const swapInterval = dcaPosition.swapInterval.interval;
+      const remainingSwaps = Number(dcaPosition.current.remainingSwaps);
+      const swapInterval = Number(dcaPosition.swapInterval.interval) as keyof typeof STRING_SWAP_INTERVALS;
+      const rawRate = dcaPosition.current.rate;
+      const rate = Number(rawRate) / 10 ** Number(dcaPosition.from.decimals);
 
       const from = baseTokens.find(v => v.address === dcaPosition.from.address);
       const to = baseTokens.find(v => v.address === dcaPosition.to.address);
@@ -54,7 +57,10 @@ export class OptimismMeanFinanceBalanceFetcher implements BalanceFetcher {
       }
       if (to) {
         to.network = network;
-        tokens.push(drillBalance(to, toWithdraw));
+        tokens.push({
+          ...drillBalance(to, toWithdraw),
+          metaType: MetaType.CLAIMABLE,
+        });
         images = [
           ...images,
           ...getImagesFromToken(to),
@@ -62,9 +68,15 @@ export class OptimismMeanFinanceBalanceFetcher implements BalanceFetcher {
       }
 
       const balanceUSD = sumBy(tokens, t => t.balanceUSD);
+      const swapIntervalAdverb = STRING_SWAP_INTERVALS[swapInterval].adverb;
+      let label = '';
 
-      const label = `Swapping ${from?.symbol} to ${to?.symbol}`;
-      const secondaryLabel = parseInt(remainingSwaps, 10) && STRING_SWAP_INTERVALS[swapInterval] ? `${STRING_SWAP_INTERVALS[swapInterval](remainingSwaps)} left` : 'Position finished';
+      if (remainingSwaps > 0) {
+        label = `Swapping ${rate} ${from?.symbol || dcaPosition.from.symbol} ${swapIntervalAdverb} to ${to?.symbol || dcaPosition.from.symbol}`;
+      } else {
+        label = `Swapping ${from?.symbol || dcaPosition.from.symbol} to ${to?.symbol || dcaPosition.from.symbol}`;
+      }
+      const secondaryLabel = remainingSwaps && STRING_SWAP_INTERVALS[swapInterval] ? `${STRING_SWAP_INTERVALS[swapInterval].plural(remainingSwaps)} left` : 'Position finished';
 
       return {
         type: ContractType.POSITION,

--- a/src/apps/mean-finance/optimism/mean-finance.dca-position.contract-position-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.dca-position.contract-position-fetcher.ts
@@ -10,7 +10,8 @@ import { WithMetaType } from '~position/display.interface';
 import { BaseTokenBalance } from '~position/position-balance.interface';
 import { PositionFetcher } from '~position/position-fetcher.interface';
 import { ContractPosition } from '~position/position.interface';
-import { MetaType } from '~position/position.interface';
+import { claimable } from '~position/position.utils';
+import { BaseToken } from '~position/token.interface';
 import { Network } from '~types/network.interface';
 
 import { MeanFinanceContractFactory } from '../contracts';
@@ -58,10 +59,8 @@ export class OptimismMeanFinanceDcaPositionContractPositionFetcher implements Po
       }
       if (to) {
         to.network = network;
-        tokens.push({
-          ...drillBalance(to, toWithdraw),
-          metaType: MetaType.CLAIMABLE,
-        });
+        const claimableTo = claimable(to) as WithMetaType<BaseToken>;
+        tokens.push(drillBalance(claimableTo, toWithdraw));
         images = [
           ...images,
           ...getImagesFromToken(to),

--- a/src/apps/mean-finance/optimism/mean-finance.dca-position.contract-position-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.dca-position.contract-position-fetcher.ts
@@ -64,8 +64,7 @@ export class OptimismMeanFinanceDcaPositionContractPositionFetcher implements Po
       }
       if (to) {
         to.network = network;
-        const claimableTo = claimable(to) as WithMetaType<BaseToken>;
-        tokens.push(drillBalance(claimableTo, toWithdraw));
+        tokens.push(drillBalance(claimable(to), toWithdraw));
         images = [
           ...images,
           ...getImagesFromToken(to),

--- a/src/apps/mean-finance/optimism/mean-finance.dca-position.contract-position-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.dca-position.contract-position-fetcher.ts
@@ -10,6 +10,7 @@ import { WithMetaType } from '~position/display.interface';
 import { BaseTokenBalance } from '~position/position-balance.interface';
 import { PositionFetcher } from '~position/position-fetcher.interface';
 import { ContractPosition } from '~position/position.interface';
+import { MetaType } from '~position/position.interface';
 import { Network } from '~types/network.interface';
 
 import { MeanFinanceContractFactory } from '../contracts';
@@ -37,8 +38,10 @@ export class OptimismMeanFinanceDcaPositionContractPositionFetcher implements Po
     const contractPositions: ContractPosition[] = positions.map(dcaPosition => {
       const toWithdraw = dcaPosition.current.idleSwapped;
       const remainingLiquidity = dcaPosition.current.remainingLiquidity;
-      const remainingSwaps = dcaPosition.current.remainingSwaps;
-      const swapInterval = dcaPosition.swapInterval.interval;
+      const remainingSwaps = Number(dcaPosition.current.remainingSwaps);
+      const swapInterval = Number(dcaPosition.swapInterval.interval) as keyof typeof STRING_SWAP_INTERVALS;
+      const rawRate = dcaPosition.current.rate;
+      const rate = Number(rawRate) / 10 ** Number(dcaPosition.from.decimals);
 
       const from = baseTokens.find(v => v.address === dcaPosition.from.address);
       const to = baseTokens.find(v => v.address === dcaPosition.to.address);
@@ -55,7 +58,10 @@ export class OptimismMeanFinanceDcaPositionContractPositionFetcher implements Po
       }
       if (to) {
         to.network = network;
-        tokens.push(drillBalance(to, toWithdraw));
+        tokens.push({
+          ...drillBalance(to, toWithdraw),
+          metaType: MetaType.CLAIMABLE,
+        });
         images = [
           ...images,
           ...getImagesFromToken(to),
@@ -63,10 +69,16 @@ export class OptimismMeanFinanceDcaPositionContractPositionFetcher implements Po
       }
 
       const balanceUSD = sumBy(tokens, t => t.balanceUSD);
+      const swapIntervalAdverb = STRING_SWAP_INTERVALS[swapInterval].adverb;
+      let label = '';
 
-      const label = `Swapping ${from?.symbol} to ${to?.symbol}`;
-      const secondaryLabel = parseInt(remainingSwaps, 10) && STRING_SWAP_INTERVALS[swapInterval] ? `${STRING_SWAP_INTERVALS[swapInterval](remainingSwaps)} left` : 'Position finished';
+      if (remainingSwaps > 0) {
+        label = `Swapping ${rate} ${from?.symbol || dcaPosition.from.symbol} ${swapIntervalAdverb} to ${to?.symbol || dcaPosition.from.symbol}`;
+      } else {
+        label = `Swapping ${from?.symbol || dcaPosition.from.symbol} to ${to?.symbol || dcaPosition.from.symbol}`;
+      }
 
+      const secondaryLabel = remainingSwaps && STRING_SWAP_INTERVALS[swapInterval] ? `${STRING_SWAP_INTERVALS[swapInterval].plural(remainingSwaps)} left` : 'Position finished';
       return {
         type: ContractType.POSITION,
         address: dcaPosition.id,

--- a/src/apps/mean-finance/optimism/mean-finance.dca-position.contract-position-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.dca-position.contract-position-fetcher.ts
@@ -43,6 +43,11 @@ export class OptimismMeanFinanceDcaPositionContractPositionFetcher implements Po
       const swapInterval = Number(dcaPosition.swapInterval.interval) as keyof typeof STRING_SWAP_INTERVALS;
       const rawRate = dcaPosition.current.rate;
       const rate = Number(rawRate) / 10 ** Number(dcaPosition.from.decimals);
+      let formattedRate = rate.toFixed(3);
+
+      if (rate < 0.001) {
+        formattedRate = '<0.001'
+      }
 
       const from = baseTokens.find(v => v.address === dcaPosition.from.address);
       const to = baseTokens.find(v => v.address === dcaPosition.to.address);
@@ -72,7 +77,7 @@ export class OptimismMeanFinanceDcaPositionContractPositionFetcher implements Po
       let label = '';
 
       if (remainingSwaps > 0) {
-        label = `Swapping ${rate} ${from?.symbol || dcaPosition.from.symbol} ${swapIntervalAdverb} to ${to?.symbol || dcaPosition.from.symbol}`;
+        label = `Swapping ~${formattedRate} ${from?.symbol || dcaPosition.from.symbol} ${swapIntervalAdverb} to ${to?.symbol || dcaPosition.from.symbol}`;
       } else {
         label = `Swapping ${from?.symbol || dcaPosition.from.symbol} to ${to?.symbol || dcaPosition.from.symbol}`;
       }

--- a/src/apps/mean-finance/optimism/mean-finance.tvl-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.tvl-fetcher.ts
@@ -41,8 +41,7 @@ export class OptimismMeanFinanceTvlFetcher implements TvlFetcher {
       }
       if (to) {
         to.network = network;
-        const claimableTo = claimable(to) as WithMetaType<BaseToken>;
-        tokens.push(drillBalance(claimableTo, toWithdraw));
+        tokens.push(drillBalance(claimable(to), toWithdraw));
       }
 
       const balanceUSD = sumBy(tokens, t => t.balanceUSD);

--- a/src/apps/mean-finance/optimism/mean-finance.tvl-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.tvl-fetcher.ts
@@ -7,6 +7,7 @@ import { drillBalance } from '~app-toolkit/helpers/balance/token-balance.helper'
 import { WithMetaType } from '~position/display.interface';
 import { BaseTokenBalance } from '~position/position-balance.interface';
 import { TvlFetcher } from '~stats/tvl/tvl-fetcher.interface';
+import { MetaType } from '~position/position.interface';
 import { Network } from '~types/network.interface';
 import { getPositions } from '../helpers/graph';
 
@@ -39,7 +40,10 @@ export class OptimismMeanFinanceTvlFetcher implements TvlFetcher {
       }
       if (to) {
         to.network = network;
-        tokens.push(drillBalance(to, toWithdraw));
+        tokens.push({
+          ...drillBalance(to, toWithdraw),
+          metaType: MetaType.CLAIMABLE,
+        });
       }
 
       const balanceUSD = sumBy(tokens, t => t.balanceUSD);

--- a/src/apps/mean-finance/optimism/mean-finance.tvl-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.tvl-fetcher.ts
@@ -7,11 +7,12 @@ import { drillBalance } from '~app-toolkit/helpers/balance/token-balance.helper'
 import { WithMetaType } from '~position/display.interface';
 import { BaseTokenBalance } from '~position/position-balance.interface';
 import { TvlFetcher } from '~stats/tvl/tvl-fetcher.interface';
-import { MetaType } from '~position/position.interface';
 import { Network } from '~types/network.interface';
 import { getPositions } from '../helpers/graph';
 
 import { MEAN_FINANCE_DEFINITION } from '../mean-finance.definition';
+import { claimable } from '~position/position.utils';
+import { BaseToken } from '~position/token.interface';
 
 const appId = MEAN_FINANCE_DEFINITION.id;
 const network = Network.OPTIMISM_MAINNET;
@@ -40,10 +41,8 @@ export class OptimismMeanFinanceTvlFetcher implements TvlFetcher {
       }
       if (to) {
         to.network = network;
-        tokens.push({
-          ...drillBalance(to, toWithdraw),
-          metaType: MetaType.CLAIMABLE,
-        });
+        const claimableTo = claimable(to) as WithMetaType<BaseToken>;
+        tokens.push(drillBalance(claimableTo, toWithdraw));
       }
 
       const balanceUSD = sumBy(tokens, t => t.balanceUSD);

--- a/src/apps/mean-finance/polygon/mean-finance.balance-fetcher.ts
+++ b/src/apps/mean-finance/polygon/mean-finance.balance-fetcher.ts
@@ -10,7 +10,8 @@ import { BalanceFetcher } from '~balance/balance-fetcher.interface';
 import { ContractType } from '~position/contract.interface';
 import { WithMetaType } from '~position/display.interface';
 import { BaseTokenBalance, ContractPositionBalance } from '~position/position-balance.interface';
-import { MetaType } from '~position/position.interface';
+import { claimable } from '~position/position.utils';
+import { BaseToken } from '~position/token.interface';
 import { Network } from '~types/network.interface';
 
 import { getUserPositions } from '../helpers/graph';
@@ -57,10 +58,8 @@ export class PolygonMeanFinanceBalanceFetcher implements BalanceFetcher {
       }
       if (to) {
         to.network = network;
-        tokens.push({
-          ...drillBalance(to, toWithdraw),
-          metaType: MetaType.CLAIMABLE,
-        });
+        const claimableTo = claimable(to) as WithMetaType<BaseToken>;
+        tokens.push(drillBalance(claimableTo, toWithdraw));
         images = [
           ...images,
           ...getImagesFromToken(to),

--- a/src/apps/mean-finance/polygon/mean-finance.balance-fetcher.ts
+++ b/src/apps/mean-finance/polygon/mean-finance.balance-fetcher.ts
@@ -63,8 +63,7 @@ export class PolygonMeanFinanceBalanceFetcher implements BalanceFetcher {
       }
       if (to) {
         to.network = network;
-        const claimableTo = claimable(to) as WithMetaType<BaseToken>;
-        tokens.push(drillBalance(claimableTo, toWithdraw));
+        tokens.push(drillBalance(claimable(to), toWithdraw));
         images = [
           ...images,
           ...getImagesFromToken(to),

--- a/src/apps/mean-finance/polygon/mean-finance.balance-fetcher.ts
+++ b/src/apps/mean-finance/polygon/mean-finance.balance-fetcher.ts
@@ -42,6 +42,11 @@ export class PolygonMeanFinanceBalanceFetcher implements BalanceFetcher {
       const swapInterval = Number(dcaPosition.swapInterval.interval) as keyof typeof STRING_SWAP_INTERVALS;
       const rawRate = dcaPosition.current.rate;
       const rate = Number(rawRate) / 10 ** Number(dcaPosition.from.decimals);
+      let formattedRate = rate.toFixed(3);
+
+      if (rate < 0.001) {
+        formattedRate = '<0.001'
+      }
 
       const from = baseTokens.find(v => v.address === dcaPosition.from.address);
       const to = baseTokens.find(v => v.address === dcaPosition.to.address);
@@ -72,7 +77,7 @@ export class PolygonMeanFinanceBalanceFetcher implements BalanceFetcher {
       let label = '';
 
       if (remainingSwaps > 0) {
-        label = `Swapping ${rate} ${from?.symbol || dcaPosition.from.symbol} ${swapIntervalAdverb} to ${to?.symbol || dcaPosition.from.symbol}`;
+        label = `Swapping ~${formattedRate} ${from?.symbol || dcaPosition.from.symbol} ${swapIntervalAdverb} to ${to?.symbol || dcaPosition.from.symbol}`;
       } else {
         label = `Swapping ${from?.symbol || dcaPosition.from.symbol} to ${to?.symbol || dcaPosition.from.symbol}`;
       }

--- a/src/apps/mean-finance/polygon/mean-finance.balance-fetcher.ts
+++ b/src/apps/mean-finance/polygon/mean-finance.balance-fetcher.ts
@@ -10,6 +10,7 @@ import { BalanceFetcher } from '~balance/balance-fetcher.interface';
 import { ContractType } from '~position/contract.interface';
 import { WithMetaType } from '~position/display.interface';
 import { BaseTokenBalance, ContractPositionBalance } from '~position/position-balance.interface';
+import { MetaType } from '~position/position.interface';
 import { Network } from '~types/network.interface';
 
 import { getUserPositions } from '../helpers/graph';
@@ -36,8 +37,10 @@ export class PolygonMeanFinanceBalanceFetcher implements BalanceFetcher {
     const contractPositionBalances: ContractPositionBalance[] = positions.map(dcaPosition => {
       const toWithdraw = dcaPosition.current.idleSwapped;
       const remainingLiquidity = dcaPosition.current.remainingLiquidity;
-      const remainingSwaps = dcaPosition.current.remainingSwaps;
-      const swapInterval = dcaPosition.swapInterval.interval;
+      const remainingSwaps = Number(dcaPosition.current.remainingSwaps);
+      const swapInterval = Number(dcaPosition.swapInterval.interval) as keyof typeof STRING_SWAP_INTERVALS;
+      const rawRate = dcaPosition.current.rate;
+      const rate = Number(rawRate) / 10 ** Number(dcaPosition.from.decimals);
 
       const from = baseTokens.find(v => v.address === dcaPosition.from.address);
       const to = baseTokens.find(v => v.address === dcaPosition.to.address);
@@ -54,7 +57,10 @@ export class PolygonMeanFinanceBalanceFetcher implements BalanceFetcher {
       }
       if (to) {
         to.network = network;
-        tokens.push(drillBalance(to, toWithdraw));
+        tokens.push({
+          ...drillBalance(to, toWithdraw),
+          metaType: MetaType.CLAIMABLE,
+        });
         images = [
           ...images,
           ...getImagesFromToken(to),
@@ -63,8 +69,16 @@ export class PolygonMeanFinanceBalanceFetcher implements BalanceFetcher {
 
       const balanceUSD = sumBy(tokens, t => t.balanceUSD);
 
-      const label = `Swapping ${from?.symbol} to ${to?.symbol}`;
-      const secondaryLabel = parseInt(remainingSwaps, 10) && STRING_SWAP_INTERVALS[swapInterval] ? `${STRING_SWAP_INTERVALS[swapInterval](remainingSwaps)} left` : 'Position finished';
+      const swapIntervalAdverb = STRING_SWAP_INTERVALS[swapInterval].adverb;
+      let label = '';
+
+      if (remainingSwaps > 0) {
+        label = `Swapping ${rate} ${from?.symbol || dcaPosition.from.symbol} ${swapIntervalAdverb} to ${to?.symbol || dcaPosition.from.symbol}`;
+      } else {
+        label = `Swapping ${from?.symbol || dcaPosition.from.symbol} to ${to?.symbol || dcaPosition.from.symbol}`;
+      }
+
+      const secondaryLabel = remainingSwaps && STRING_SWAP_INTERVALS[swapInterval] ? `${STRING_SWAP_INTERVALS[swapInterval].plural(remainingSwaps)} left` : 'Position finished';
 
       return {
         type: ContractType.POSITION,

--- a/src/apps/mean-finance/polygon/mean-finance.dca-position.contract-position-fetcher.ts
+++ b/src/apps/mean-finance/polygon/mean-finance.dca-position.contract-position-fetcher.ts
@@ -42,6 +42,11 @@ export class PolygonMeanFinanceDcaPositionContractPositionFetcher implements Pos
       const swapInterval = Number(dcaPosition.swapInterval.interval) as keyof typeof STRING_SWAP_INTERVALS;
       const rawRate = dcaPosition.current.rate;
       const rate = Number(rawRate) / 10 ** Number(dcaPosition.from.decimals);
+      let formattedRate = rate.toFixed(3);
+
+      if (rate < 0.001) {
+        formattedRate = '<0.001'
+      }
 
       const from = baseTokens.find(v => v.address === dcaPosition.from.address);
       const to = baseTokens.find(v => v.address === dcaPosition.to.address);
@@ -72,7 +77,7 @@ export class PolygonMeanFinanceDcaPositionContractPositionFetcher implements Pos
       let label = '';
 
       if (remainingSwaps > 0) {
-        label = `Swapping ${rate} ${from?.symbol || dcaPosition.from.symbol} ${swapIntervalAdverb} to ${to?.symbol || dcaPosition.from.symbol}`;
+        label = `Swapping ~${formattedRate} ${from?.symbol || dcaPosition.from.symbol} ${swapIntervalAdverb} to ${to?.symbol || dcaPosition.from.symbol}`;
       } else {
         label = `Swapping ${from?.symbol || dcaPosition.from.symbol} to ${to?.symbol || dcaPosition.from.symbol}`;
       }

--- a/src/apps/mean-finance/polygon/mean-finance.dca-position.contract-position-fetcher.ts
+++ b/src/apps/mean-finance/polygon/mean-finance.dca-position.contract-position-fetcher.ts
@@ -9,7 +9,8 @@ import { WithMetaType } from '~position/display.interface';
 import { BaseTokenBalance } from '~position/position-balance.interface';
 import { PositionFetcher } from '~position/position-fetcher.interface';
 import { ContractPosition } from '~position/position.interface';
-import { MetaType } from '~position/position.interface';
+import { claimable } from '~position/position.utils';
+import { BaseToken } from '~position/token.interface';
 import { Network } from '~types/network.interface';
 
 import { MeanFinanceContractFactory } from '../contracts';
@@ -57,10 +58,8 @@ export class PolygonMeanFinanceDcaPositionContractPositionFetcher implements Pos
       }
       if (to) {
         to.network = network;
-        tokens.push({
-          ...drillBalance(to, toWithdraw),
-          metaType: MetaType.CLAIMABLE,
-        });
+        const claimableTo = claimable(to) as WithMetaType<BaseToken>;
+        tokens.push(drillBalance(claimableTo, toWithdraw));
         images = [
           ...images,
           ...getImagesFromToken(to),

--- a/src/apps/mean-finance/polygon/mean-finance.dca-position.contract-position-fetcher.ts
+++ b/src/apps/mean-finance/polygon/mean-finance.dca-position.contract-position-fetcher.ts
@@ -63,8 +63,7 @@ export class PolygonMeanFinanceDcaPositionContractPositionFetcher implements Pos
       }
       if (to) {
         to.network = network;
-        const claimableTo = claimable(to) as WithMetaType<BaseToken>;
-        tokens.push(drillBalance(claimableTo, toWithdraw));
+        tokens.push(drillBalance(claimable(to), toWithdraw));
         images = [
           ...images,
           ...getImagesFromToken(to),

--- a/src/apps/mean-finance/polygon/mean-finance.tvl-fetcher.ts
+++ b/src/apps/mean-finance/polygon/mean-finance.tvl-fetcher.ts
@@ -41,8 +41,7 @@ export class PolygonMeanFinanceTvlFetcher implements TvlFetcher {
       }
       if (to) {
         to.network = network;
-        const claimableTo = claimable(to) as WithMetaType<BaseToken>;
-        tokens.push(drillBalance(claimableTo, toWithdraw));
+        tokens.push(drillBalance(claimable(to), toWithdraw));
       }
 
       const balanceUSD = sumBy(tokens, t => t.balanceUSD);

--- a/src/apps/mean-finance/polygon/mean-finance.tvl-fetcher.ts
+++ b/src/apps/mean-finance/polygon/mean-finance.tvl-fetcher.ts
@@ -7,11 +7,12 @@ import { drillBalance } from '~app-toolkit/helpers/balance/token-balance.helper'
 import { WithMetaType } from '~position/display.interface';
 import { BaseTokenBalance } from '~position/position-balance.interface';
 import { TvlFetcher } from '~stats/tvl/tvl-fetcher.interface';
-import { MetaType } from '~position/position.interface';
 import { Network } from '~types/network.interface';
 import { getPositions } from '../helpers/graph';
 
 import { MEAN_FINANCE_DEFINITION } from '../mean-finance.definition';
+import { claimable } from '~position/position.utils';
+import { BaseToken } from '~position/token.interface';
 
 const appId = MEAN_FINANCE_DEFINITION.id;
 const network = Network.POLYGON_MAINNET;
@@ -40,10 +41,8 @@ export class PolygonMeanFinanceTvlFetcher implements TvlFetcher {
       }
       if (to) {
         to.network = network;
-        tokens.push({
-          ...drillBalance(to, toWithdraw),
-          metaType: MetaType.CLAIMABLE,
-        });
+        const claimableTo = claimable(to) as WithMetaType<BaseToken>;
+        tokens.push(drillBalance(claimableTo, toWithdraw));
       }
 
       const balanceUSD = sumBy(tokens, t => t.balanceUSD);

--- a/src/apps/mean-finance/polygon/mean-finance.tvl-fetcher.ts
+++ b/src/apps/mean-finance/polygon/mean-finance.tvl-fetcher.ts
@@ -7,6 +7,7 @@ import { drillBalance } from '~app-toolkit/helpers/balance/token-balance.helper'
 import { WithMetaType } from '~position/display.interface';
 import { BaseTokenBalance } from '~position/position-balance.interface';
 import { TvlFetcher } from '~stats/tvl/tvl-fetcher.interface';
+import { MetaType } from '~position/position.interface';
 import { Network } from '~types/network.interface';
 import { getPositions } from '../helpers/graph';
 
@@ -39,7 +40,10 @@ export class PolygonMeanFinanceTvlFetcher implements TvlFetcher {
       }
       if (to) {
         to.network = network;
-        tokens.push(drillBalance(to, toWithdraw));
+        tokens.push({
+          ...drillBalance(to, toWithdraw),
+          metaType: MetaType.CLAIMABLE,
+        });
       }
 
       const balanceUSD = sumBy(tokens, t => t.balanceUSD);

--- a/src/position/position.utils.ts
+++ b/src/position/position.utils.ts
@@ -8,9 +8,9 @@ export const isClaimable = (token: WithMetaType<Token>) => token.metaType === Me
 export const isVesting = (token: WithMetaType<Token>) => token.metaType === MetaType.VESTING;
 export const isLocked = (token: WithMetaType<Token>) => token.metaType === MetaType.LOCKED;
 
-export const wallet = <T>(token: T): WithMetaType<T> => ({ metaType: MetaType.WALLET, ...token });
-export const supplied = <T>(token: T): WithMetaType<T> => ({ metaType: MetaType.SUPPLIED, ...token });
-export const borrowed = <T>(token: T): WithMetaType<T> => ({ metaType: MetaType.BORROWED, ...token });
-export const claimable = <T>(token: T): WithMetaType<T> => ({ metaType: MetaType.CLAIMABLE, ...token });
-export const vesting = <T>(token: T): WithMetaType<T> => ({ metaType: MetaType.VESTING, ...token });
-export const locked = <T>(token: T): WithMetaType<T> => ({ metaType: MetaType.LOCKED, ...token });
+export const wallet = <T extends Token>(token: T): WithMetaType<T> => ({ metaType: MetaType.WALLET, ...token });
+export const supplied = <T extends Token>(token: T): WithMetaType<T> => ({ metaType: MetaType.SUPPLIED, ...token });
+export const borrowed = <T extends Token>(token: T): WithMetaType<T> => ({ metaType: MetaType.BORROWED, ...token });
+export const claimable = <T extends Token>(token: T): WithMetaType<T> => ({ metaType: MetaType.CLAIMABLE, ...token });
+export const vesting = <T extends Token>(token: T): WithMetaType<T> => ({ metaType: MetaType.VESTING, ...token });
+export const locked = <T extends Token>(token: T): WithMetaType<T> => ({ metaType: MetaType.LOCKED, ...token });


### PR DESCRIPTION
## Description

- Changes the label for active Mean Finance positions (meaning the have swaps left) from "Swapping WMATIC to USDC" to "Swapping 0.008321 USDC every day to OP". These would 100% be better as a secondary or tertiary label, until there is support for those we would like to show this info on the label. Once tertiary/secondary are enabled we'll move them.
- Adds the "CLAIMABLE" metaType to the "To" token to which you are DCA'ing (basically what we have swapped for the user and they can withdraw on Mean Finance)

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: fiboape.eth
- [X] (optional) As a contributor, my Twitter handle is: @fiboape

## How to test?
http://localhost:5001/apps/mean-finance/balances?addresses[]=0x7AfB052ae7B80aAc6e559281cC261089738b66F6&network=polygon
http://localhost:5001/apps/mean-finance/balances?addresses[]=0xf488aaf75D987cC30a84A2c3b6dA72bd17A0a555&network=optimism