### PR TITLE
fix(cache): Clean up cache metadata by removing defaults

### DIFF
--- a/src/apps/badger/helpers/badger.claimable.balance-helper.ts
+++ b/src/apps/badger/helpers/badger.claimable.balance-helper.ts
@@ -35,6 +35,7 @@ export class BadgerClaimableContractPositionBalanceHelper {
   ) {}
 
   @Cache({
+    instance: 'user',
     key: ({ address, network }: BadgerClaimableContractPositionBalanceHelperParams) =>
       `apps-v3:${BADGER_DEFINITION.id}:${network}:accumulated-rewards:${address}`,
     ttl: 5 * 60, // 5 minutes

--- a/src/apps/curve/helpers/curve.on-chain.volume-strategy.ts
+++ b/src/apps/curve/helpers/curve.on-chain.volume-strategy.ts
@@ -20,6 +20,7 @@ type GetBlockResponse = {
 @Injectable()
 export class CurveOnChainVolumeStrategy {
   @Cache({
+    instance: 'business',
     key: daysAgo => `curve:block-from-days-ago:${daysAgo}`,
     ttl: 60,
   })

--- a/src/apps/uniswap-v2/helpers/uniswap-v2.the-graph.pool-token-address-strategy.ts
+++ b/src/apps/uniswap-v2/helpers/uniswap-v2.the-graph.pool-token-address-strategy.ts
@@ -45,6 +45,7 @@ export class UniswapV2TheGraphPoolTokenAddressStrategy {
   constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
 
   @Cache({
+    instance: 'business',
     key: (subgraphUrl: string) => {
       const [namespace, name] = subgraphUrl.split('/').slice(-2);
       return `studio:uniswap-v2-fork:pool-token-addresses:${namespace}:${name}`;

--- a/src/apps/yearn/helpers/yearn.vault.token-definitions-resolver.ts
+++ b/src/apps/yearn/helpers/yearn.vault.token-definitions-resolver.ts
@@ -77,6 +77,7 @@ type GetVaultDefinitionsParams = {
 @Injectable()
 export class YearnVaultTokenDefinitionsResolver {
   @Cache({
+    instance: 'business',
     key: network => `studio:yearn:${network}:vault-data`,
     ttl: 5 * 60, // 60 minutes
   })

--- a/src/cache/cache.decorator.ts
+++ b/src/cache/cache.decorator.ts
@@ -14,36 +14,24 @@ type DeserializeInto<T = unknown> = DeserializeIntoArray<T> | ClassConstructor<T
 
 type CacheKeyBuilder = (...args: any) => string;
 type CacheTtlBuilder = (...args: any) => number;
-type CacheForceUpdateBuilder = (...args: any) => boolean;
 
 export type CacheOptions = {
-  instance?: 'user' | 'business';
   key: string | CacheKeyBuilder;
-  /** In seconds */
-  ttl?: number | null | CacheTtlBuilder;
-  /** In seconds */
-  localTtl?: number | null | CacheTtlBuilder;
-  forceUpdate?: boolean | CacheForceUpdateBuilder;
+  instance?: 'user' | 'business';
+  ttl?: number | CacheTtlBuilder; // seconds
+  localTtl?: number | CacheTtlBuilder; // seconds
   deserializeInto?: DeserializeInto;
   cacheNull?: boolean;
 };
 
 export const Cache = (options: CacheOptions) => {
-  const {
-    ttl = null,
-    instance = 'business',
-    localTtl = null,
-    forceUpdate = false,
-    deserializeInto = undefined,
-    cacheNull = false,
-  } = options;
+  const { key, ttl, instance, localTtl, deserializeInto, cacheNull } = options;
 
   return applyDecorators(
-    SetMetadata(CACHE_KEY, options.key),
+    SetMetadata(CACHE_KEY, key),
     SetMetadata(CACHE_INSTANCE, instance),
     SetMetadata(CACHE_TTL, ttl),
     SetMetadata(CACHE_LOCAL_TTL, localTtl),
-    SetMetadata(CACHE_FORCE_UPDATE, forceUpdate),
     SetMetadata(CACHE_DESERIALIZE_INTO, deserializeInto),
     SetMetadata(CACHE_SHOULD_CACHE_NULL, cacheNull),
   );

--- a/src/token/token.service.ts
+++ b/src/token/token.service.ts
@@ -17,7 +17,11 @@ export class TokenService {
     });
   }
 
-  @Cache({ key: (network: Network) => `token-prices:${network}`, ttl: 60 })
+  @Cache({
+    instance: 'business',
+    key: (network: Network) => `token-prices:${network}`,
+    ttl: 60,
+  })
   async getTokenPrices(network: Network) {
     const { data: tokenPrices } = await this.axios.get<BaseToken[]>('/v2/prices', { params: { network } });
     return tokenPrices;


### PR DESCRIPTION
## Description

Clean cache metadata to set no defaults in the decorator. Zapper API will take care of this in the service that consumes these decorated members.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
