### PR TITLE
fix: farms has been renamed to governance

### DIFF
--- a/src/apps/euler/ethereum/euler.p-token.token-fetcher.ts
+++ b/src/apps/euler/ethereum/euler.p-token.token-fetcher.ts
@@ -57,7 +57,7 @@ interface EulerMarketsResponse {
   };
 }
 
-@Register.TokenPositionFetcher({ appId, groupId, network, options: { includeInTvl: true } })
+@Register.TokenPositionFetcher({ appId, groupId, network })
 export class EthereumEulerPTokenTokenFetcher implements PositionFetcher<AppTokenPosition> {
   constructor(
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,

--- a/src/apps/euler/euler.definition.ts
+++ b/src/apps/euler/euler.definition.ts
@@ -15,20 +15,21 @@ export const EULER_DEFINITION = appDefinition({
       id: 'e-token',
       type: GroupType.TOKEN,
       label: 'Lending',
-      groupLabel: 'E Token',
+      groupLabel: 'Supply',
     },
 
     dToken: {
       id: 'd-token',
       type: GroupType.TOKEN,
       label: 'Lending',
-      groupLabel: 'D Token',
+      groupLabel: 'Borrow',
     },
 
     pToken: {
       id: 'p-token',
       type: GroupType.TOKEN,
       label: 'P Token',
+      isHiddenFromExplore: true,
     },
   },
   presentationConfig: {
@@ -39,17 +40,16 @@ export const EULER_DEFINITION = appDefinition({
         views: [
           {
             viewType: 'list',
-            label: 'E Token',
+            label: 'Supply',
             groupIds: ['e-token'],
           },
           {
             viewType: 'list',
-            label: 'D Token',
+            label: 'Borrow',
             groupIds: ['d-token'],
           },
         ],
       },
-      { label: 'P Token', viewType: 'list', groupIds: ['p-token'] },
     ],
   },
   tags: [AppTag.LENDING],

--- a/src/apps/yearn/yearn.definition.ts
+++ b/src/apps/yearn/yearn.definition.ts
@@ -8,7 +8,6 @@ export const YEARN_DEFINITION = appDefinition({
   name: 'Yearn',
   description: `Automate your yield. DeFi made simple.`,
   groups: {
-    farm: { id: 'farm', type: GroupType.POSITION, label: 'Governance' },
     v1Vault: { id: 'v1-vault', type: GroupType.TOKEN, label: 'V1 Vaults' },
     v2Vault: { id: 'v2-vault', type: GroupType.TOKEN, label: 'Vaults' },
     governance: { id: 'governance', type: GroupType.POSITION, label: 'Governance' },


### PR DESCRIPTION
## Description

- Yearn groupId "farm" has been renamed to governance in a prior PR
- Renamed Euler E Token and D Token to Supply and Borrow (only the labels, not the ids) 

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
