### PR TITLE
fix: removed prefix from coslend positions label

### DIFF
--- a/src/apps/abracadabra/arbitrum/abracadabra.m-spell.contract-position-fetcher.ts
+++ b/src/apps/abracadabra/arbitrum/abracadabra.m-spell.contract-position-fetcher.ts
@@ -12,6 +12,7 @@ import { AbracadabraContractFactory, AbracadabraMspell } from '../contracts';
 const appId = ABRACADABRA_DEFINITION.id;
 const groupId = ABRACADABRA_DEFINITION.groups.mSpell.id;
 const network = Network.ARBITRUM_MAINNET;
+
 @Register.ContractPositionFetcher({ appId, groupId, network })
 export class ArbitrumAbracadabraMspellContractPositionFetcher implements PositionFetcher<ContractPosition> {
   constructor(

--- a/src/apps/abracadabra/avalanche/abracadabra.m-spell.contract-position-fetcher.ts
+++ b/src/apps/abracadabra/avalanche/abracadabra.m-spell.contract-position-fetcher.ts
@@ -12,6 +12,7 @@ import { AbracadabraContractFactory, AbracadabraMspell } from '../contracts';
 const appId = ABRACADABRA_DEFINITION.id;
 const groupId = ABRACADABRA_DEFINITION.groups.mSpell.id;
 const network = Network.AVALANCHE_MAINNET;
+
 @Register.ContractPositionFetcher({ appId, groupId, network })
 export class AvalancheAbracadabraMspellContractPositionFetcher implements PositionFetcher<ContractPosition> {
   constructor(

--- a/src/apps/abracadabra/fantom/abracadabra.m-spell.contract-position-fetcher.ts
+++ b/src/apps/abracadabra/fantom/abracadabra.m-spell.contract-position-fetcher.ts
@@ -12,6 +12,7 @@ import { AbracadabraContractFactory, AbracadabraMspell } from '../contracts';
 const appId = ABRACADABRA_DEFINITION.id;
 const groupId = ABRACADABRA_DEFINITION.groups.mSpell.id;
 const network = Network.FANTOM_OPERA_MAINNET;
+
 @Register.ContractPositionFetcher({ appId, groupId, network })
 export class FantomAbracadabraMspellContractPositionFetcher implements PositionFetcher<ContractPosition> {
   constructor(

--- a/src/apps/coslend/helper/coslend.borrow.contract-position-helper.ts
+++ b/src/apps/coslend/helper/coslend.borrow.contract-position-helper.ts
@@ -83,7 +83,7 @@ export class CoslendBorrowContractPositionHelper {
       const images = appToken.displayProps.images;
       const statsItems = isNumber(borrowApy)
         ? [
-            { label: 'Borrow APR', value: buildPercentageDisplayItem(borrowApy) },
+            { label: 'APR', value: buildPercentageDisplayItem(borrowApy) },
             { label: 'Liquidity', value: buildDollarDisplayItem(borrowLiquidity) },
           ]
         : [];

--- a/src/apps/coslend/helper/coslend.supply.token-helper.ts
+++ b/src/apps/coslend/helper/coslend.supply.token-helper.ts
@@ -168,7 +168,7 @@ export class CoslendSupplyTokenHelper {
         const images = [getTokenImg(underlyingToken.address, network)];
         const balanceDisplayMode = BalanceDisplayMode.UNDERLYING;
         const statsItems = [
-          { label: 'Supply APY', value: buildPercentageDisplayItem(supplyApy) },
+          { label: 'APY', value: buildPercentageDisplayItem(supplyApy) },
           { label: 'Liquidity', value: buildDollarDisplayItem(liquidity) },
         ];
 


### PR DESCRIPTION
## Description

- Removed prefix from Coslend (supply and borrow) position label

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
