### PR TITLE
fix(rari-fuse): Fix failing RPC calls in Rari Fuse

### DIFF
--- a/src/apps/rari-fuse/ethereum/rari-fuse.borrow.contract-position-balance-fetcher.ts
+++ b/src/apps/rari-fuse/ethereum/rari-fuse.borrow.contract-position-balance-fetcher.ts
@@ -34,7 +34,7 @@ export class EthereumRariFuseBorrowContractPositionBalanceFetcher
     const network = Network.ETHEREUM_MAINNET;
     const fuseLensAddress = '0x8da38681826f4abbe089643d2b3fe4c6e4730493';
     const fuseLens = this.rariFuseContractFactory.rariFusePoolLens({ address: fuseLensAddress, network });
-    const poolsBySupplier = await fuseLens.getPoolsBySupplierWithData(address);
+    const poolsBySupplier = await fuseLens.getPoolsBySupplier(address);
     const participatedComptrollers = poolsBySupplier[1].map(p => p.comptroller.toLowerCase());
 
     return this.appToolkit.helpers.contractPositionBalanceHelper.getContractPositionBalances<CompoundBorrowContractPositionDataProps>(

--- a/src/apps/rari-fuse/ethereum/rari-fuse.supply.token-balance-fetcher.ts
+++ b/src/apps/rari-fuse/ethereum/rari-fuse.supply.token-balance-fetcher.ts
@@ -27,7 +27,7 @@ export class EthereumRariFuseSupplyTokenBalanceFetcher implements PositionBalanc
     const network = Network.ETHEREUM_MAINNET;
     const fuseLensAddress = '0x8da38681826f4abbe089643d2b3fe4c6e4730493';
     const fuseLens = this.rariFuseContractFactory.rariFusePoolLens({ address: fuseLensAddress, network });
-    const poolsBySupplier = await fuseLens.getPoolsBySupplierWithData(address);
+    const poolsBySupplier = await fuseLens.getPoolsBySupplier(address);
     const participatedComptrollers = poolsBySupplier[1].map(p => p.comptroller.toLowerCase());
 
     return this.appToolkit.helpers.tokenBalanceHelper.getTokenBalances<CompoundSupplyTokenDataProps>({


### PR DESCRIPTION
## Description

Reports from Discord indicated `0xCba1A275e2D858EcffaF7a87F606f74B719a8A93` was failing, and upon investigation, it was a call to the Lens contract that was throwing an error. Luckily, we don't need `getPoolsBySupplierWithData`, but just `getPoolsBySupplier` which does not throw.

This address is still missing bveCVX as collateral because we don't support that token yet in Badger.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
