### PR TITLE
feat(rari-fuse): Integrate presentation config for explore page

### DIFF
--- a/src/apps/rari-fuse/rari-fuse.definition.ts
+++ b/src/apps/rari-fuse/rari-fuse.definition.ts
@@ -24,6 +24,27 @@ export const RARI_FUSE_DEFINITION = appDefinition({
     },
   },
 
+  presentationConfig: {
+    tabs: [
+      {
+        label: '{{ dataProps.marketName }}',
+        viewType: 'split',
+        views: [
+          {
+            viewType: 'list',
+            label: 'Supply',
+            groupIds: ['supply'],
+          },
+          {
+            viewType: 'list',
+            label: 'Borrow',
+            groupIds: ['borrow'],
+          },
+        ],
+      },
+    ],
+  },
+
   url: 'https://rari.capital/',
   tags: [AppTag.LIQUIDITY_POOL],
   keywords: [],


### PR DESCRIPTION
## Description

- Uses the market name as the dynamic label, effectively splitting the markets on the explore page for Rari Fuse
- Each market will have its isolated supply and borrow positions visible as lists

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
