### PR TITLE
feat(symphony): Symphony Finance Optimism Integration

### DIFF
--- a/src/apps/symphony/optimism/symphony.balance-fetcher.ts
+++ b/src/apps/symphony/optimism/symphony.balance-fetcher.ts
@@ -1,0 +1,64 @@
+import { Inject } from '@nestjs/common';
+import BigNumber from 'bignumber.js';
+import _, { sumBy } from 'lodash';
+
+import { drillBalance } from '~app-toolkit';
+import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
+import { Register } from '~app-toolkit/decorators';
+import { presentBalanceFetcherResponse } from '~app-toolkit/helpers/presentation/balance-fetcher-response.present';
+import { BalanceFetcher } from '~balance/balance-fetcher.interface';
+import { isSupplied } from '~position/position.utils';
+import { Network } from '~types/network.interface';
+
+import { getOpenOrdersByUser } from '../helpers/graph';
+import { SYMPHONY_DEFINITION } from '../symphony.definition';
+
+const network = Network.OPTIMISM_MAINNET;
+
+@Register.BalanceFetcher(SYMPHONY_DEFINITION.id, network)
+export class OptimismSymphonyBalanceFetcher implements BalanceFetcher {
+  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
+
+  async getUserPositions(address: string) {
+    const graphHelper = this.appToolkit.helpers.theGraphHelper;
+    const data = await getOpenOrdersByUser(address.toLocaleLowerCase(), Network.OPTIMISM_MAINNET, graphHelper);
+    return data.orders;
+  }
+
+  async getBalances(address: string) {
+    const contractPositions = await this.appToolkit.getAppContractPositions({
+      appId: SYMPHONY_DEFINITION.id,
+      network,
+      groupIds: [SYMPHONY_DEFINITION.groups.yolo.id],
+    });
+
+    const positions = await this.getUserPositions(address);
+
+    const contractPositionBalances = await Promise.all(
+      contractPositions.map(async contractPosition => {
+        const position = positions.filter(
+          p => p.inputToken.toLocaleLowerCase() === contractPosition.address.toLocaleLowerCase(),
+        )!;
+
+        if (position) {
+          const claimableToken = contractPosition.tokens.find(isSupplied)!;
+          const totalSupplied = position.reduce(
+            (partialSum, a) => partialSum.plus(new BigNumber(a.inputAmount)),
+            new BigNumber(0),
+          );
+          const suppliedTokenBalance = drillBalance(claimableToken, totalSupplied.toString());
+          const tokens = [suppliedTokenBalance].filter(v => v.balanceUSD > 0);
+          const balanceUSD = sumBy(tokens, t => t.balanceUSD);
+          return { ...contractPosition, tokens, balanceUSD };
+        }
+      }),
+    );
+
+    return presentBalanceFetcherResponse([
+      {
+        label: 'Orders',
+        assets: _.reject(contractPositionBalances, _.isUndefined),
+      },
+    ]);
+  }
+}

--- a/src/apps/symphony/optimism/symphony.yolo.contract-position-fetcher.ts
+++ b/src/apps/symphony/optimism/symphony.yolo.contract-position-fetcher.ts
@@ -1,0 +1,93 @@
+import { Inject } from '@nestjs/common';
+import axios from 'axios';
+
+import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
+import { ZERO_ADDRESS } from '~app-toolkit/constants/address';
+import { Register } from '~app-toolkit/decorators';
+import { buildDollarDisplayItem } from '~app-toolkit/helpers/presentation/display-item.present';
+import { getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
+import { ContractType } from '~position/contract.interface';
+import { PositionFetcher } from '~position/position-fetcher.interface';
+import { ContractPosition } from '~position/position.interface';
+import { supplied } from '~position/position.utils';
+import { Network } from '~types/network.interface';
+
+import { SymphonyContractFactory } from '../contracts';
+import { SymphonyYoloTokenDataProps, Token } from '../helpers/types';
+import { SYMPHONY_DEFINITION } from '../symphony.definition';
+
+const appId = SYMPHONY_DEFINITION.id;
+const groupId = SYMPHONY_DEFINITION.groups.yolo.id;
+const network = Network.OPTIMISM_MAINNET;
+const YOLO_ADDRESS = '0x3Ff61F4d7e1d912CA3Cb342581B2e764aE24d017';
+const TOKENLIST_URL = 'https://raw.githubusercontent.com/symphony-finance/token-list/master/symphony.tokenlist.json';
+
+@Register.ContractPositionFetcher({ appId, groupId, network })
+export class OptimismSymphonyYoloContractPositionFetcher implements PositionFetcher<ContractPosition> {
+  constructor(
+    @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
+    @Inject(SymphonyContractFactory) private readonly symphonyContractFactory: SymphonyContractFactory,
+  ) {}
+
+  async getPositions() {
+    const multicall = this.appToolkit.getMulticall(network);
+    const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
+
+    const tokenList: Token[] = (await axios.get(TOKENLIST_URL)).data.tokens
+      .filter((data: Token) => data.chainId == 10 && !data.extensions.isNative)
+      .map((token: Token) => token);
+
+    const yoloContract = this.symphonyContractFactory.symphonyYolo({
+      address: YOLO_ADDRESS,
+      network,
+    });
+
+    const balances = await Promise.all(
+      tokenList.map(async (token, i: number) => {
+        const tokenContract = this.appToolkit.globalContracts.erc20({ address: token.address, network });
+
+        const [contractBalances] = await Promise.all([multicall.wrap(tokenContract).balanceOf(YOLO_ADDRESS)]);
+
+        const [totalBalances] = await Promise.all([
+          multicall
+            .wrap(yoloContract)
+            .callStatic.getTotalTokens(
+              token.address,
+              contractBalances && contractBalances[i] ? contractBalances[i] : 0,
+              token.extensions.strategy ? token.extensions.strategy : ZERO_ADDRESS,
+            ),
+        ]);
+
+        const tokenData = baseTokens.find(p => p.address.toLocaleLowerCase() === token.address.toLocaleLowerCase())!;
+
+        const tokenBalance = Number(totalBalances) / 10 ** token.decimals;
+        const tokenBalanceUSD = tokenBalance * (tokenData && tokenData.price ? tokenData.price : 0);
+
+        // Display Props
+        const label = `${token.symbol} Order`;
+        const images = [getTokenImg(token.address.toLocaleLowerCase(), network)];
+
+        const position: ContractPosition<SymphonyYoloTokenDataProps> = {
+          type: ContractType.POSITION,
+          address: token.address,
+          appId: SYMPHONY_DEFINITION.id,
+          groupId: SYMPHONY_DEFINITION.groups.yolo.id,
+          network,
+          tokens: [supplied(tokenData)],
+          dataProps: {
+            liquidity: tokenBalanceUSD,
+          },
+          displayProps: {
+            label,
+            images,
+            statsItems: [{ label: 'Liquidity', value: buildDollarDisplayItem(tokenBalanceUSD) }],
+          },
+        };
+
+        return position;
+      }),
+    );
+
+    return balances;
+  }
+}

--- a/src/apps/symphony/symphony.module.ts
+++ b/src/apps/symphony/symphony.module.ts
@@ -4,6 +4,8 @@ import { AbstractApp } from '~app/app.dynamic-module';
 import { AvalancheSymphonyBalanceFetcher } from './avalanche/symphony.balance-fetcher';
 import { AvalancheSymphonyYoloContractPositionFetcher } from './avalanche/symphony.yolo.contract-position-fetcher';
 import { SymphonyContractFactory } from './contracts';
+import { OptimismSymphonyBalanceFetcher } from './optimism/symphony.balance-fetcher';
+import { OptimismSymphonyYoloContractPositionFetcher } from './optimism/symphony.yolo.contract-position-fetcher';
 import { PolygonSymphonyBalanceFetcher } from './polygon/symphony.balance-fetcher';
 import { PolygonSymphonyYoloContractPositionFetcher } from './polygon/symphony.yolo.contract-position-fetcher';
 import { SymphonyAppDefinition, SYMPHONY_DEFINITION } from './symphony.definition';
@@ -19,6 +21,9 @@ import { SymphonyAppDefinition, SYMPHONY_DEFINITION } from './symphony.definitio
     // Polygon
     PolygonSymphonyBalanceFetcher,
     PolygonSymphonyYoloContractPositionFetcher,
+    // Optimism
+    OptimismSymphonyBalanceFetcher,
+    OptimismSymphonyYoloContractPositionFetcher,
   ],
 })
-export class SymphonyAppModule extends AbstractApp() {}
+export class SymphonyAppModule extends AbstractApp() { }


### PR DESCRIPTION
## Description

Adds Optimism network support for Symphony Finance.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: kakas.eth
- [x] (optional) As a contributor, my Twitter handle is: 0x_kakashi

## How to test?
TVL:
http://localhost:5001/apps/symphony/tvl?network=optimism

Contract Positions:
http://localhost:5001/apps/symphony/positions?groupIds%5B%5D=yolo&network=optimism

Balances:
http://localhost:5001/apps/symphony/balances?addresses%5B%5D=0x94db037207f6fb697dbd33524aadffd108819dc8&network=optimism