### PR TITLE
fix(symphony): Add missing supported network in definition file

### DIFF
--- a/src/apps/symphony/symphony.definition.ts
+++ b/src/apps/symphony/symphony.definition.ts
@@ -28,6 +28,7 @@ export const SYMPHONY_DEFINITION = appDefinition({
   },
   supportedNetworks: {
     [Network.POLYGON_MAINNET]: [AppAction.VIEW],
+    [Network.OPTIMISM_MAINNET]: [AppAction.VIEW],
     [Network.AVALANCHE_MAINNET]: [AppAction.VIEW],
   },
   primaryColor: '#1f222c',


### PR DESCRIPTION
## Description

App page on Optimism wasn't loading because we're still using `supportedNetworks` to render application pages pages :rip:

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
