### PR TITLE
fix(balancer-v2): Use filtered underlying tokens

### DIFF
--- a/src/apps/balancer-v2/ethereum/balancer-v2.wrapped-aave.token-fetcher.ts
+++ b/src/apps/balancer-v2/ethereum/balancer-v2.wrapped-aave.token-fetcher.ts
@@ -4,7 +4,7 @@ import { compact } from 'lodash';
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { Register } from '~app-toolkit/decorators';
 import { buildDollarDisplayItem } from '~app-toolkit/helpers/presentation/display-item.present';
-import { getImagesFromToken, getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
+import { getImagesFromToken } from '~app-toolkit/helpers/presentation/image.present';
 import { AAVE_V2_DEFINITION } from '~apps/aave-v2/aave-v2.definition';
 import { ContractType } from '~position/contract.interface';
 import { PositionFetcher } from '~position/position-fetcher.interface';
@@ -56,7 +56,7 @@ export class EthereumBalancerV2WrappedAaveTokenFetcher implements PositionFetche
         if (!underlyingToken) return null;
 
         // Display Props
-        const label = getLabelFromToken(underlyingToken);
+        const label = underlyingToken.symbol;
         const secondaryLabel = buildDollarDisplayItem(underlyingToken.price);
         const images = getImagesFromToken(underlyingToken);
 

--- a/src/apps/balancer-v2/helpers/balancer-v2.pool.token-helper.ts
+++ b/src/apps/balancer-v2/helpers/balancer-v2.pool.token-helper.ts
@@ -5,7 +5,7 @@ import { isEmpty } from 'lodash';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { buildDollarDisplayItem } from '~app-toolkit/helpers/presentation/display-item.present';
-import { getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
+import { getLabelFromToken, getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
 import { ContractType } from '~position/contract.interface';
 import { AppTokenPosition } from '~position/position.interface';
 import { AppGroupsDefinition } from '~position/position.service';
@@ -124,7 +124,7 @@ export class BalancerV2PoolTokensHelper {
         const label =
           labelStrategy === BalancerV2PoolLabelStrategy.POOL_NAME
             ? await multicall.wrap(poolContract).name()
-            : tokens.map(v => v.symbol).join(' / ');
+            : tokens.map(v => getLabelFromToken(v)).join(' / ');
         const ratio = reservePercentages.map(p => `${Math.round(p * 100)}%`).join(' / ');
         const secondaryLabel = ratio;
         const images = tokens.map(v => getTokenImg(v.address, network));

--- a/src/apps/balancer-v2/helpers/balancer-v2.pool.token-helper.ts
+++ b/src/apps/balancer-v2/helpers/balancer-v2.pool.token-helper.ts
@@ -5,7 +5,7 @@ import { isEmpty } from 'lodash';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { buildDollarDisplayItem } from '~app-toolkit/helpers/presentation/display-item.present';
-import { getLabelFromToken, getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
+import { getImagesFromToken, getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
 import { ContractType } from '~position/contract.interface';
 import { AppTokenPosition } from '~position/position.interface';
 import { AppGroupsDefinition } from '~position/position.service';
@@ -127,7 +127,7 @@ export class BalancerV2PoolTokensHelper {
             : tokens.map(v => getLabelFromToken(v)).join(' / ');
         const ratio = reservePercentages.map(p => `${Math.round(p * 100)}%`).join(' / ');
         const secondaryLabel = ratio;
-        const images = tokens.map(v => getTokenImg(v.address, network));
+        const images = tokens.flatMap(v => getImagesFromToken(v));
 
         const token: AppTokenPosition<BalancerV2PoolTokenDataProps> = {
           type,


### PR DESCRIPTION
## Description

Use filtered underlying tokens from building token data, which already have redundant underlying tokens for Aave Linear and Phantom Stable pools removed.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
