### PR TITLE
fix(coslend): update comptroller address

### DIFF
--- a/src/apps/coslend/evmos/coslend.supply.token-fetcher.ts
+++ b/src/apps/coslend/evmos/coslend.supply.token-fetcher.ts
@@ -25,7 +25,7 @@ export class EvmosCoslendSupplyTokenFetcher implements PositionFetcher<AppTokenP
       network,
       appId,
       groupId,
-      comptrollerAddress: '0x2c8b48dc777c26dc857e1040d8ef3bdd3b1ef499',
+      comptrollerAddress: '0x5b32B588Af5F99F4e5c4038dDE6BDD991024F650',
       getComptrollerContract: ({ address, network }) =>
         this.coslendContractFactory.coslendComptroller({ address, network }),
       getTokenContract: ({ address, network }) => this.coslendContractFactory.coslendCToken({ address, network }),


### PR DESCRIPTION
## Description

fix [coslend](https://coslend.com/) comptroller address

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [x] (optional) As a contributor, my Twitter handle is: https://twitter.com/coslend

## How to test?

1. edit/create .env adding ENABLED_APPS="coslend"
2. run pnpm dev to spin up nest server
3. visit dev endpoints below to see result of fetchers to integrate coslend:

- http://localhost:5001/apps/coslend/tokens?network=evmos&groupIds[]=supply
- http://localhost:5001/apps/coslend/positions?network=evmos&groupIds[]=borrow
- http://localhost:5001/apps/coslend/tvl?network=evmos
- http://localhost:5001/apps/coslend/balances?network=evmos&addresses[]=<wallet_address>
