### PR TITLE
feat(apps): Add labelDetailed display props for nested display name

### DIFF
--- a/src/app-toolkit/helpers/presentation/image.present.ts
+++ b/src/app-toolkit/helpers/presentation/image.present.ts
@@ -29,7 +29,7 @@ export const getImagesFromToken = (token: Token): string[] => {
 
 export const getLabelFromToken = (token: Token): string => {
   if (token.type === ContractType.APP_TOKEN) {
-    return token.displayProps.label;
+    return token.displayProps.labelDetailed ?? token.displayProps.label;
   }
   return token.symbol;
 };

--- a/src/apps/aave-v2/helpers/aave-v2.lending.token-helper.ts
+++ b/src/apps/aave-v2/helpers/aave-v2.lending.token-helper.ts
@@ -67,7 +67,8 @@ export type AaveV2LendingTokenHelperParams<T = AaveProtocolDataProvider> = {
   exchangeable?: boolean;
   resolveTokenAddress: (opts: { reserveTokenAddressesData: ReserveTokenAddressesData }) => string;
   resolveLendingRate: (opts: { reserveData: ReserveData }) => BigNumber;
-  resolveLabel: (opts: { reserveToken: Token }) => string;
+  resolveLabel: (opts: { symbol: string; reserveToken: Token }) => string;
+  resolveLabelDetailed?: (opts: { symbol: string; reserveToken: Token }) => string;
   resolveApyLabel: (opts: { apy: number }) => string;
 };
 
@@ -83,13 +84,14 @@ export class AaveV2LendingTokenHelper {
     groupId,
     network,
     dependencies = [],
-    protocolDataProviderAddress,
     isDebt = false,
+    exchangeable = false,
+    protocolDataProviderAddress,
     resolveTokenAddress,
     resolveLendingRate,
-    resolveLabel,
     resolveApyLabel,
-    exchangeable,
+    resolveLabel,
+    resolveLabelDetailed = ({ symbol }) => symbol,
     resolveContract = ({ contractFactory, address }) =>
       contractFactory.aaveProtocolDataProvider({ network, address }) as unknown as T,
     resolveReserveTokens = ({ contract }) =>
@@ -145,7 +147,7 @@ export class AaveV2LendingTokenHelper {
         const tokens = [reserveToken];
         const dataProps = {
           apy,
-          exchangeable: exchangeable ?? false,
+          exchangeable,
           enabledAsCollateral,
           liquidity: contextualizedLiquidity,
           liquidationThreshold,
@@ -153,7 +155,8 @@ export class AaveV2LendingTokenHelper {
         };
 
         // Display Props
-        const label = resolveLabel({ reserveToken });
+        const label = resolveLabel({ symbol, reserveToken });
+        const labelDetailed = resolveLabelDetailed({ symbol, reserveToken });
         const secondaryLabel = buildDollarDisplayItem(reserveToken.price);
         const tertiaryLabel = resolveApyLabel({ apy });
         const images = getImagesFromToken(reserveToken);
@@ -177,6 +180,7 @@ export class AaveV2LendingTokenHelper {
           dataProps,
           displayProps: {
             label,
+            labelDetailed,
             secondaryLabel,
             tertiaryLabel,
             images,

--- a/src/apps/balancer-v2/ethereum/balancer-v2.wrapped-aave.token-fetcher.ts
+++ b/src/apps/balancer-v2/ethereum/balancer-v2.wrapped-aave.token-fetcher.ts
@@ -4,7 +4,7 @@ import { compact } from 'lodash';
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { Register } from '~app-toolkit/decorators';
 import { buildDollarDisplayItem } from '~app-toolkit/helpers/presentation/display-item.present';
-import { getImagesFromToken } from '~app-toolkit/helpers/presentation/image.present';
+import { getImagesFromToken, getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
 import { AAVE_V2_DEFINITION } from '~apps/aave-v2/aave-v2.definition';
 import { ContractType } from '~position/contract.interface';
 import { PositionFetcher } from '~position/position-fetcher.interface';
@@ -56,7 +56,7 @@ export class EthereumBalancerV2WrappedAaveTokenFetcher implements PositionFetche
         if (!underlyingToken) return null;
 
         // Display Props
-        const label = underlyingToken.symbol;
+        const label = getLabelFromToken(underlyingToken);
         const secondaryLabel = buildDollarDisplayItem(underlyingToken.price);
         const images = getImagesFromToken(underlyingToken);
 

--- a/src/position/display.interface.ts
+++ b/src/position/display.interface.ts
@@ -52,6 +52,7 @@ export enum BalanceDisplayMode {
 
 export interface DisplayProps {
   label: string;
+  labelDetailed?: string;
   secondaryLabel?: string | number | DollarDisplayItem | PercentageDisplayItem;
   tertiaryLabel?: string | number | DollarDisplayItem | PercentageDisplayItem;
   images: string[];


### PR DESCRIPTION
## Description

- The `label` display property is great when there is surrounding context. i.e: We can display `aUSDC` as `USDC` within a group labelled `Supply` under the Aave V2 app in the frontend.
- However, when this label is used within another label, we lose context. For example, if we use this label in Rari Fuse for deposited `aRAI`, it ends up displaying as `RAI`.
- As such, we need to support two separate labels:
  - `label`: Use this label within a framed context, like in the Aave V2 explore page under the `Supply` token group
  - `labelDetailed`: Use this label within detailed contexts like a token breakdown, or within a higher level label

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
