### PR TITLE
feat(curve): Resolve coin addresses from on-chain again

### DIFF
--- a/src/apps/bastion-protocol/bastion-protocol.module.ts
+++ b/src/apps/bastion-protocol/bastion-protocol.module.ts
@@ -1,6 +1,11 @@
 import { Register } from '~app-toolkit/decorators';
 import { AbstractApp } from '~app/app.dynamic-module';
-import { CurvePoolTokenHelper } from '~apps/curve';
+import {
+  CurvePoolOnChainCoinStrategy,
+  CurvePoolOnChainReserveStrategy,
+  CurvePoolTokenHelper,
+  CurvePoolVirtualPriceStrategy,
+} from '~apps/curve';
 
 import { AuroraBastionProtocolBalanceFetcher } from './aurora/bastion-protocol.balance-fetcher';
 import { AuroraBastionProtocolBorrowAuroraEcosystemContractPositionFetcher } from './aurora/bastion-protocol.borrow-aurora-ecosystem.contract-position-fetcher';
@@ -38,6 +43,9 @@ import { BastionSupplyTokenHelper } from './helper/bastion-protocol.supply.token
     BastionSupplyTokenHelper,
     BastionBorrowContractPositionHelper,
     CurvePoolTokenHelper,
+    CurvePoolOnChainCoinStrategy,
+    CurvePoolOnChainReserveStrategy,
+    CurvePoolVirtualPriceStrategy,
   ],
 })
 export class BastionProtocolAppModule extends AbstractApp() {}

--- a/src/apps/curve/curve.module.ts
+++ b/src/apps/curve/curve.module.ts
@@ -27,6 +27,8 @@ import { CurveGaugeIsActiveStrategy } from './helpers/curve.gauge.is-active-stra
 import { CurveGaugeRegistry } from './helpers/curve.gauge.registry';
 import { CurveGaugeRoiStrategy } from './helpers/curve.gauge.roi-strategy';
 import { CurvePoolDefaultTokenHelper } from './helpers/curve.pool.default.token-helper';
+import { CurvePoolOnChainCoinStrategy } from './helpers/curve.pool.on-chain.coin-strategy';
+import { CurvePoolOnChainReserveStrategy } from './helpers/curve.pool.on-chain.reserve-strategy';
 import { CurvePoolRegistry } from './helpers/curve.pool.registry';
 import { CurvePoolTokenHelper } from './helpers/curve.pool.token-helper';
 import { CurvePoolVirtualPriceStrategy } from './helpers/curve.pool.virtual.price-strategy';
@@ -76,18 +78,23 @@ import { PolygonCurvePoolTokenFetcher } from './polygon/curve.pool.token-fetcher
     PolygonCurveBalanceFetcher,
     PolygonCurvePoolTokenFetcher,
     PolygonCurveGaugeContractPositionFetcher,
-    // Token Helpers
+    // API Helpers
     CurveApiClient,
+    // Pool Token Helpers
     CurvePoolRegistry,
     CurvePoolTokenHelper,
     CurvePoolDefaultTokenHelper,
     CurvePoolVirtualPriceStrategy,
+    CurvePoolOnChainCoinStrategy,
+    CurvePoolOnChainReserveStrategy,
+    // Gauge Helpers
     CurveGaugeRegistry,
     CurveGaugeDefaultContractPositionHelper,
     CurveGaugeDefaultContractPositionBalanceHelper,
     CurveGaugeIsActiveStrategy,
     CurveGaugeRoiStrategy,
     CurveChildLiquidityGaugeRoiStrategy,
+    // Escrow Helpers
     CurveVotingEscrowContractPositionHelper,
     CurveVotingEscrowContractPositionBalanceHelper,
     CurveVestingEscrowContractPositionHelper,

--- a/src/apps/curve/curve.types.ts
+++ b/src/apps/curve/curve.types.ts
@@ -8,6 +8,7 @@ export enum CurvePoolType {
 export type CurvePoolDefinition = {
   swapAddress: string;
   tokenAddress: string;
+  coinAddresses?: string[];
   gaugeAddresses?: string[];
   poolType?: CurvePoolType;
   volume?: number;

--- a/src/apps/curve/curve.types.ts
+++ b/src/apps/curve/curve.types.ts
@@ -8,7 +8,6 @@ export enum CurvePoolType {
 export type CurvePoolDefinition = {
   swapAddress: string;
   tokenAddress: string;
-  coinAddresses: string[];
   gaugeAddresses?: string[];
   poolType?: CurvePoolType;
   volume?: number;

--- a/src/apps/curve/helpers/curve.pool.default.token-helper.ts
+++ b/src/apps/curve/helpers/curve.pool.default.token-helper.ts
@@ -4,9 +4,11 @@ import { CurvePool } from '~apps/curve/contracts/ethers/CurvePool';
 import { AppGroupsDefinition } from '~position/position.service';
 import { Network } from '~types/network.interface';
 
-import { CurveContractFactory } from '../contracts';
+import { CurveContractFactory, CurvePoolLegacy } from '../contracts';
 import { CURVE_DEFINITION } from '../curve.definition';
 
+import { CurvePoolOnChainCoinStrategy } from './curve.pool.on-chain.coin-strategy';
+import { CurvePoolOnChainReserveStrategy } from './curve.pool.on-chain.reserve-strategy';
 import { CurvePoolRegistry } from './curve.pool.registry';
 import { CurvePoolTokenHelper } from './curve.pool.token-helper';
 import { CurvePoolVirtualPriceStrategy } from './curve.pool.virtual.price-strategy';
@@ -21,6 +23,10 @@ export class CurvePoolDefaultTokenHelper {
   constructor(
     @Inject(CurvePoolTokenHelper)
     private readonly curvePoolTokenHelper: CurvePoolTokenHelper,
+    @Inject(CurvePoolOnChainCoinStrategy)
+    private readonly curvePoolOnChainCoinStrategy: CurvePoolOnChainCoinStrategy,
+    @Inject(CurvePoolOnChainReserveStrategy)
+    private readonly curvePoolOnChainReserveStrategy: CurvePoolOnChainReserveStrategy,
     @Inject(CurvePoolVirtualPriceStrategy)
     private readonly curvePoolVirtualPriceStrategy: CurvePoolVirtualPriceStrategy,
     @Inject(CurveContractFactory)
@@ -30,25 +36,30 @@ export class CurvePoolDefaultTokenHelper {
   ) {}
 
   async getTokens({ network, dependencies = [] }: CurvePoolDefaultTokenHelperParams) {
-    return this.curvePoolTokenHelper.getTokens<CurvePool>({
+    const poolDefinitions = await this.curvePoolRegistry.getPoolDefinitions(network);
+    const legacy = poolDefinitions.filter(v => v.isLegacy).map(v => v.swapAddress);
+
+    return this.curvePoolTokenHelper.getTokens<CurvePool | CurvePoolLegacy>({
       network,
       dependencies,
       appId: CURVE_DEFINITION.id,
       groupId: CURVE_DEFINITION.groups.pool.id,
-      poolDefinitions: await this.curvePoolRegistry.getPoolDefinitions(network),
+      poolDefinitions: poolDefinitions,
       minLiquidity: 1000,
-      resolvePoolContract: ({ network, definition }) =>
-        this.curveContractFactory.curvePool({ network, address: definition.swapAddress }),
-      resolvePoolReserves: ({ definition, multicall }) => {
-        const contract = definition.isLegacy
-          ? this.curveContractFactory.curvePoolLegacy({ address: definition.swapAddress, network })
-          : this.curveContractFactory.curvePool({ address: definition.swapAddress, network });
-        return Promise.all(definition.coinAddresses.map((_, i) => multicall.wrap(contract).balances(i)));
-      },
-      resolvePoolFee: ({ multicall, poolContract }) => multicall.wrap(poolContract).fee(),
+      resolvePoolContract: ({ network, address }) =>
+        legacy.includes(address)
+          ? this.curveContractFactory.curvePoolLegacy({ address, network })
+          : this.curveContractFactory.curvePool({ address, network }),
+      resolvePoolCoinAddresses: this.curvePoolOnChainCoinStrategy.build({
+        resolveCoinAddress: ({ poolContract, multicall, index }) => multicall.wrap(poolContract).coins(index),
+      }),
+      resolvePoolReserves: this.curvePoolOnChainReserveStrategy.build({
+        resolveReserve: ({ poolContract, multicall, index }) => multicall.wrap(poolContract).balances(index),
+      }),
       resolvePoolTokenPrice: this.curvePoolVirtualPriceStrategy.build({
         resolveVirtualPrice: ({ multicall, poolContract }) => multicall.wrap(poolContract).get_virtual_price(),
       }),
+      resolvePoolFee: ({ multicall, poolContract }) => multicall.wrap(poolContract).fee(),
     });
   }
 }

--- a/src/apps/curve/helpers/curve.pool.on-chain.coin-strategy.ts
+++ b/src/apps/curve/helpers/curve.pool.on-chain.coin-strategy.ts
@@ -1,0 +1,29 @@
+import { compact, range } from 'lodash';
+
+import { isMulticallUnderlyingError } from '~multicall/multicall.ethers';
+import { IMulticallWrapper } from '~multicall/multicall.interface';
+
+import { CurvePoolTokenHelperParams } from './curve.pool.token-helper';
+
+export type CurvePoolOnChainCoinStrategyParams<T> = {
+  resolveCoinAddress: (opts: { multicall: IMulticallWrapper; poolContract: T; index: number }) => Promise<string>;
+};
+
+export class CurvePoolOnChainCoinStrategy {
+  build<T>({
+    resolveCoinAddress,
+  }: CurvePoolOnChainCoinStrategyParams<T>): CurvePoolTokenHelperParams<T>['resolvePoolCoinAddresses'] {
+    return async ({ multicall, poolContract }) => {
+      const coinAddresses = await Promise.all(
+        range(0, 4).map(index =>
+          resolveCoinAddress({ multicall, poolContract, index }).catch(err => {
+            if (isMulticallUnderlyingError(err)) return null;
+            throw err;
+          }),
+        ),
+      );
+
+      return compact(coinAddresses).map(v => v.toLowerCase());
+    };
+  }
+}

--- a/src/apps/curve/helpers/curve.pool.on-chain.reserve-strategy.ts
+++ b/src/apps/curve/helpers/curve.pool.on-chain.reserve-strategy.ts
@@ -1,0 +1,24 @@
+import { BigNumberish } from 'ethers';
+import { range } from 'lodash';
+
+import { IMulticallWrapper } from '~multicall/multicall.interface';
+
+import { CurvePoolTokenHelperParams } from './curve.pool.token-helper';
+
+export type CurvePoolOnChainReserveStrategyParams<T> = {
+  resolveReserve: (opts: { multicall: IMulticallWrapper; poolContract: T; index: number }) => Promise<BigNumberish>;
+};
+
+export class CurvePoolOnChainReserveStrategy {
+  build<T>({
+    resolveReserve,
+  }: CurvePoolOnChainReserveStrategyParams<T>): CurvePoolTokenHelperParams<T>['resolvePoolReserves'] {
+    return async ({ multicall, poolContract, coinAddresses }) => {
+      const reserves = await Promise.all(
+        range(0, coinAddresses.length).map(index => resolveReserve({ multicall, poolContract, index })),
+      );
+
+      return reserves;
+    };
+  }
+}

--- a/src/apps/curve/helpers/curve.pool.registry.ts
+++ b/src/apps/curve/helpers/curve.pool.registry.ts
@@ -174,7 +174,6 @@ export class CurvePoolRegistry {
           swapAddress,
           tokenAddress,
           gaugeAddresses,
-          coinAddresses,
           apy,
           volume,
         };

--- a/src/apps/curve/index.ts
+++ b/src/apps/curve/index.ts
@@ -7,6 +7,8 @@ export { CurveGaugeIsActiveStrategy } from './helpers/curve.gauge.is-active-stra
 export { CurveGaugeRoiStrategy } from './helpers/curve.gauge.roi-strategy';
 export { CurvePoolTokenHelper } from './helpers/curve.pool.token-helper';
 export { CurvePoolVirtualPriceStrategy } from './helpers/curve.pool.virtual.price-strategy';
+export { CurvePoolOnChainCoinStrategy } from './helpers/curve.pool.on-chain.coin-strategy';
+export { CurvePoolOnChainReserveStrategy } from './helpers/curve.pool.on-chain.reserve-strategy';
 export { CurveVestingEscrowContractPositionBalanceHelper } from './helpers/curve.vesting-escrow.contract-position-balance-helper';
 export { CurveVestingEscrowContractPositionHelper } from './helpers/curve.vesting-escrow.contract-position-helper';
 export { CurveVotingEscrowContractPositionBalanceHelper } from './helpers/curve.voting-escrow.contract-position-balance-helper';

--- a/src/apps/kinesis-labs/evmos/kinesis-labs.pool.definitions.ts
+++ b/src/apps/kinesis-labs/evmos/kinesis-labs.pool.definitions.ts
@@ -5,20 +5,10 @@ export const KINESIS_LABS_BASEPOOL_DEFINITIONS: CurvePoolDefinition[] = [
   {
     swapAddress: '0x49b97224655aad13832296b8f6185231afb8aacc',
     tokenAddress: '0xfb25679ff0651cde4cf58887be266b68326ddab6',
-    coinAddresses: [
-      '0xe03494d0033687543a80c9b1ca7d6237f2ea8bd8',
-      '0x51e44ffad5c2b122c8b635671fcc8139dc636e82',
-      '0x7ff4a56b32ee13d7d4d405887e0ea37d61ed919e',
-    ],
   },
   // Celer Base Pool celerUSDC/celerUSDT/FRAX
   {
     swapAddress: '0xbbd5a7ae45a484bd8dabdfeeeb33e4b859d2c95c',
     tokenAddress: '0xf6b65b88a9e7846ed0de503e682cc230f892c2fa',
-    coinAddresses: [
-      '0xe03494d0033687543a80c9b1ca7d6237f2ea8bd8',
-      '0xe46910336479f254723710d57e7b683f3315b22b',
-      '0xb72a7567847aba28a2819b855d7fe679d4f59846',
-    ],
   },
 ];

--- a/src/apps/kinesis-labs/evmos/kinesis-labs.pool.token-fetcher.ts
+++ b/src/apps/kinesis-labs/evmos/kinesis-labs.pool.token-fetcher.ts
@@ -3,7 +3,12 @@ import { BigNumber } from 'ethers';
 import { uniqBy } from 'lodash';
 
 import { Register } from '~app-toolkit/decorators';
-import { CurvePoolTokenHelper, CurvePoolVirtualPriceStrategy } from '~apps/curve';
+import {
+  CurvePoolOnChainCoinStrategy,
+  CurvePoolOnChainReserveStrategy,
+  CurvePoolTokenHelper,
+  CurvePoolVirtualPriceStrategy,
+} from '~apps/curve';
 import { PositionFetcher } from '~position/position-fetcher.interface';
 import { AppTokenPosition } from '~position/position.interface';
 import { Network } from '~types/network.interface';
@@ -22,9 +27,14 @@ export class EvmosKinesisLabsPoolTokenFetcher implements PositionFetcher<AppToke
   constructor(
     @Inject(CurvePoolTokenHelper)
     private readonly curvePoolTokenHelper: CurvePoolTokenHelper,
+    @Inject(CurvePoolOnChainCoinStrategy)
+    private readonly curvePoolOnChainCoinStrategy: CurvePoolOnChainCoinStrategy,
+    @Inject(CurvePoolOnChainReserveStrategy)
+    private readonly curvePoolOnChainReserveStrategy: CurvePoolOnChainReserveStrategy,
     @Inject(CurvePoolVirtualPriceStrategy)
     private readonly curvePoolVirtualPriceStrategy: CurvePoolVirtualPriceStrategy,
-    @Inject(KinesisLabsContractFactory) private readonly kinesisLabsContractFactory: KinesisLabsContractFactory,
+    @Inject(KinesisLabsContractFactory)
+    private readonly kinesisLabsContractFactory: KinesisLabsContractFactory,
   ) {}
 
   async getPositions() {
@@ -33,14 +43,18 @@ export class EvmosKinesisLabsPoolTokenFetcher implements PositionFetcher<AppToke
       appId,
       groupId,
       poolDefinitions: KINESIS_LABS_BASEPOOL_DEFINITIONS,
-      resolvePoolContract: ({ network, definition }) =>
-        this.kinesisLabsContractFactory.kinesisLabsPool({ network, address: definition.swapAddress }),
-      resolvePoolReserves: ({ definition, multicall, poolContract }) =>
-        Promise.all(definition.coinAddresses.map((_, i) => multicall.wrap(poolContract).getTokenBalance(i))),
-      resolvePoolFee: async () => BigNumber.from('4000000'),
+      resolvePoolContract: ({ network, address }) =>
+        this.kinesisLabsContractFactory.kinesisLabsPool({ network, address }),
+      resolvePoolCoinAddresses: this.curvePoolOnChainCoinStrategy.build({
+        resolveCoinAddress: ({ multicall, poolContract, index }) => multicall.wrap(poolContract).getToken(index),
+      }),
+      resolvePoolReserves: this.curvePoolOnChainReserveStrategy.build({
+        resolveReserve: ({ multicall, poolContract, index }) => multicall.wrap(poolContract).getTokenBalance(index),
+      }),
       resolvePoolTokenPrice: this.curvePoolVirtualPriceStrategy.build({
         resolveVirtualPrice: ({ multicall, poolContract }) => multicall.wrap(poolContract).getVirtualPrice(),
       }),
+      resolvePoolFee: async () => BigNumber.from('4000000'),
     });
 
     return uniqBy([basePools].flat(), v => v.address);

--- a/src/apps/kinesis-labs/kinesis-labs.module.ts
+++ b/src/apps/kinesis-labs/kinesis-labs.module.ts
@@ -1,6 +1,11 @@
 import { Register } from '~app-toolkit/decorators';
 import { AbstractApp } from '~app/app.dynamic-module';
-import { CurvePoolTokenHelper, CurvePoolVirtualPriceStrategy } from '~apps/curve';
+import {
+  CurvePoolOnChainCoinStrategy,
+  CurvePoolOnChainReserveStrategy,
+  CurvePoolTokenHelper,
+  CurvePoolVirtualPriceStrategy,
+} from '~apps/curve';
 
 import { KinesisLabsContractFactory } from './contracts';
 import { EvmosKinesisLabsPoolTokenFetcher } from './evmos/kinesis-labs.pool.token-fetcher';
@@ -13,6 +18,8 @@ import { KinesisLabsAppDefinition, KINESIS_LABS_DEFINITION } from './kinesis-lab
     KinesisLabsAppDefinition,
     KinesisLabsContractFactory,
     CurvePoolTokenHelper,
+    CurvePoolOnChainCoinStrategy,
+    CurvePoolOnChainReserveStrategy,
     CurvePoolVirtualPriceStrategy,
   ],
 })

--- a/src/apps/saddle/ethereum/saddle.pool.definitions.ts
+++ b/src/apps/saddle/ethereum/saddle.pool.definitions.ts
@@ -5,91 +5,50 @@ export const SADDLE_POOL_DEFINITIONS: CurvePoolDefinition[] = [
   {
     swapAddress: '0x4f6a43ad7cba042606decaca730d4ce0a57ac62e',
     tokenAddress: '0xc28df698475dec994be00c9c9d8658a548e6304f',
-    coinAddresses: [
-      '0x8daebade922df735c38c80c7ebd708af50815faa',
-      '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
-      '0xeb4c2781e4eba804ce9a9803c67d0893436bb27d',
-      '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6',
-    ],
   },
   // Saddle wBTC/renBTC/sBTC (BTC Pool V2)
   {
     swapAddress: '0xdf3309771d2bf82cb2b6c56f9f5365c8bd97c4f2',
     tokenAddress: '0xf32e91464ca18fc156ab97a697d6f8ae66cd21a3',
-    coinAddresses: [
-      '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
-      '0xeb4c2781e4eba804ce9a9803c67d0893436bb27d',
-      '0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6',
-    ],
   },
   // Saddle DAI/USDC/USDT (v1)
   {
     swapAddress: '0x3911f80530595fbd01ab1516ab61255d75aeb066',
     tokenAddress: '0x76204f8cfe8b95191a3d1cfa59e267ea65e06fac',
-    coinAddresses: [
-      '0x6b175474e89094c44da98b954eedeac495271d0f',
-      '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-      '0xdac17f958d2ee523a2206206994597c13d831ec7',
-    ],
   },
   // Saddle WETH/vETH2 (v1)
   {
     swapAddress: '0xdec2157831d6abc3ec328291119cc91b337272b5',
     tokenAddress: '0xe37e2a01fea778bc1717d72bd9f018b6a6b241d5',
-    coinAddresses: ['0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', '0x898bad2774eb97cf6b94605677f43b41871410b1'],
   },
   // Saddle alETH (v2)
   {
     swapAddress: '0xa6018520eaacc06c30ff2e1b3ee2c7c22e64196a',
     tokenAddress: '0xc9da65931abf0ed1b74ce5ad8c041c4220940368',
-    coinAddresses: [
-      '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-      '0x0100546f2cd4c9d97f798ffc9755e47865ff7ee6',
-      '0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb',
-    ],
   },
   // Saddle D4 (v2)
   {
     swapAddress: '0xc69ddcd4dfef25d8a793241834d4cc4b3668ead6',
     tokenAddress: '0xd48cf4d7fb0824cc8bae055df3092584d0a1726a',
-    coinAddresses: [
-      '0xbc6da0fe9ad5f3b0d58160288917aa56653660e9',
-      '0x956f47f50a910163d8bf957cf5846d573e7f87ca',
-      '0x853d955acef822db058eb8505911ed77f175b99e',
-      '0x5f98805a4e8be255a32880fdec7f6728c6568ba0',
-    ],
   },
   // Saddle 4Pool
   {
     swapAddress: '0x101cd330d088634b6f64c2eb4276e63bf1bbfde3',
     tokenAddress: '0x1b4ab394327fdf9524632ddf2f0f04f9fa1fe2ec',
-    coinAddresses: [
-      '0x6b175474e89094c44da98b954eedeac495271d0f',
-      '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-      '0xdac17f958d2ee523a2206206994597c13d831ec7',
-      '0x853d955acef822db058eb8505911ed77f175b99e',
-    ],
   },
   // Saddle Frax 3Pool
   {
     swapAddress: '0x8caea59f3bf1f341f89c51607e4919841131e47a',
     tokenAddress: '0x0785addf5f7334adb7ec40cd785ebf39bfd91520',
-    coinAddresses: [
-      '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-      '0xdac17f958d2ee523a2206206994597c13d831ec7',
-      '0x853d955acef822db058eb8505911ed77f175b99e',
-    ],
   },
   // Saddle tBTCV2/wBTC/renBTC/sBTC (tBTCv2 Metapool V1)
   {
     swapAddress: '0xf74ebe6e5586275dc4ced78f5dbef31b1efbe7a5',
     tokenAddress: '0x122eca07139eb368245a29fb702c9ff11e9693b7',
-    coinAddresses: ['0x18084fba666a33d37592fa2633fd49a74dd93a88', '0xf32e91464ca18fc156ab97a697d6f8ae66cd21a3'],
   },
   // Saddle tBTCV2/wBTC/renBTC/sBTC (tBTCv2 Metapool V2)
   {
     swapAddress: '0xa0b4a2667dd60d5cdd7ecff1084f0ceb8dd84326',
     tokenAddress: '0x3f2f811605bc6d701c3ad6e501be13461c560320',
-    coinAddresses: ['0x18084fba666a33d37592fa2633fd49a74dd93a88', '0xf32e91464ca18fc156ab97a697d6f8ae66cd21a3'],
   },
 ];

--- a/src/apps/saddle/ethereum/saddle.pool.token-fetcher.ts
+++ b/src/apps/saddle/ethereum/saddle.pool.token-fetcher.ts
@@ -2,7 +2,12 @@ import { Inject } from '@nestjs/common';
 import { BigNumber } from 'ethers';
 
 import { Register } from '~app-toolkit/decorators';
-import { CurvePoolTokenHelper, CurvePoolVirtualPriceStrategy } from '~apps/curve';
+import {
+  CurvePoolOnChainCoinStrategy,
+  CurvePoolOnChainReserveStrategy,
+  CurvePoolTokenHelper,
+  CurvePoolVirtualPriceStrategy,
+} from '~apps/curve';
 import { PositionFetcher } from '~position/position-fetcher.interface';
 import { AppTokenPosition } from '~position/position.interface';
 import { Network } from '~types/network.interface';
@@ -21,6 +26,10 @@ export class EthereumSaddlePoolTokenFetcher implements PositionFetcher<AppTokenP
   constructor(
     @Inject(CurvePoolTokenHelper)
     private readonly curvePoolTokenHelper: CurvePoolTokenHelper,
+    @Inject(CurvePoolOnChainCoinStrategy)
+    private readonly curvePoolOnChainCoinStrategy: CurvePoolOnChainCoinStrategy,
+    @Inject(CurvePoolOnChainReserveStrategy)
+    private readonly curvePoolOnChainReserveStrategy: CurvePoolOnChainReserveStrategy,
     @Inject(CurvePoolVirtualPriceStrategy)
     private readonly curvePoolVirtualPriceStrategy: CurvePoolVirtualPriceStrategy,
     @Inject(SaddleContractFactory)
@@ -33,14 +42,17 @@ export class EthereumSaddlePoolTokenFetcher implements PositionFetcher<AppTokenP
       appId: SADDLE_DEFINITION.id,
       groupId: SADDLE_DEFINITION.groups.pool.id,
       poolDefinitions: SADDLE_POOL_DEFINITIONS,
-      resolvePoolContract: ({ network, definition }) =>
-        this.saddleContractFactory.saddleSwap({ network, address: definition.swapAddress }),
-      resolvePoolReserves: async ({ definition, multicall, poolContract }) =>
-        Promise.all(definition.coinAddresses.map((_, i) => multicall.wrap(poolContract).getTokenBalance(i))),
-      resolvePoolFee: async () => BigNumber.from('4000000'),
+      resolvePoolContract: ({ network, address }) => this.saddleContractFactory.saddleSwap({ network, address }),
+      resolvePoolCoinAddresses: this.curvePoolOnChainCoinStrategy.build({
+        resolveCoinAddress: ({ multicall, poolContract, index }) => multicall.wrap(poolContract).getToken(index),
+      }),
+      resolvePoolReserves: this.curvePoolOnChainReserveStrategy.build({
+        resolveReserve: ({ multicall, poolContract, index }) => multicall.wrap(poolContract).getTokenBalance(index),
+      }),
       resolvePoolTokenPrice: this.curvePoolVirtualPriceStrategy.build({
         resolveVirtualPrice: ({ multicall, poolContract }) => multicall.wrap(poolContract).getVirtualPrice(),
       }),
+      resolvePoolFee: async () => BigNumber.from('4000000'),
     });
   }
 }

--- a/src/apps/saddle/evmos/saddle.pool.definitions.ts
+++ b/src/apps/saddle/evmos/saddle.pool.definitions.ts
@@ -5,10 +5,5 @@ export const SADDLE_POOL_DEFINITIONS: CurvePoolDefinition[] = [
   {
     swapAddress: '0x21d4365834b7c61447e142ef6bcf01136cbd01c6',
     tokenAddress: '0x2801fe8f9de3a4ad6098a5b95d5165676bb01f82',
-    coinAddresses: [
-      '0x51e44ffad5c2b122c8b635671fcc8139dc636e82',
-      '0x7ff4a56b32ee13d7d4d405887e0ea37d61ed919e',
-      '0xe03494d0033687543a80c9b1ca7d6237f2ea8bd8',
-    ],
   },
 ];

--- a/src/apps/saddle/saddle.module.ts
+++ b/src/apps/saddle/saddle.module.ts
@@ -1,6 +1,11 @@
 import { Register } from '~app-toolkit/decorators';
 import { AbstractApp } from '~app/app.dynamic-module';
-import { CurvePoolTokenHelper, CurvePoolVirtualPriceStrategy } from '~apps/curve';
+import {
+  CurvePoolOnChainCoinStrategy,
+  CurvePoolOnChainReserveStrategy,
+  CurvePoolTokenHelper,
+  CurvePoolVirtualPriceStrategy,
+} from '~apps/curve';
 import { SynthetixAppModule } from '~apps/synthetix';
 
 import { SaddleContractFactory } from './contracts';
@@ -22,6 +27,8 @@ import { SaddleAppDefinition, SADDLE_DEFINITION } from './saddle.definition';
     // Helpers
     CurvePoolTokenHelper,
     CurvePoolVirtualPriceStrategy,
+    CurvePoolOnChainCoinStrategy,
+    CurvePoolOnChainReserveStrategy,
     // Ethereum
     EthereumSaddleBalanceFetcher,
     EthereumSaddleCommunalFarmContractPositionFetcher,

--- a/src/apps/tempus/helpers/tempus.amm.token-helper.ts
+++ b/src/apps/tempus/helpers/tempus.amm.token-helper.ts
@@ -32,10 +32,14 @@ export class TempusAmmTokenFetcher {
       poolDefinitions: data.tempusPools.map(pool => ({
         swapAddress: pool.ammAddress.toLowerCase(),
         tokenAddress: pool.ammAddress.toLowerCase(),
-        coinAddresses: [pool.principalsAddress.toLowerCase(), pool.yieldsAddress.toLowerCase()],
       })),
-      resolvePoolContract: ({ network, definition }) =>
-        this.contractFactory.tempusAmm({ network, address: definition.swapAddress }),
+      resolvePoolContract: ({ network, address }) => this.contractFactory.tempusAmm({ network, address }),
+      resolvePoolCoinAddresses: async ({ poolContract }) => {
+        const pool = data.tempusPools.find(
+          pool => pool.ammAddress.toLowerCase() === poolContract.address.toLowerCase(),
+        )!;
+        return [pool.principalsAddress.toLowerCase(), pool.yieldsAddress.toLowerCase()];
+      },
       resolvePoolReserves: async ({ multicall, poolContract }) => {
         const totalSupply = await multicall.wrap(poolContract).totalSupply();
         const [principals, yields] = await multicall.wrap(poolContract).getExpectedTokensOutGivenBPTIn(totalSupply);

--- a/src/apps/velodrome/optimism/velodrome.pool.token-fetcher.ts
+++ b/src/apps/velodrome/optimism/velodrome.pool.token-fetcher.ts
@@ -50,10 +50,10 @@ export class OptimismVelodromePoolsTokenFetcher implements PositionFetcher<AppTo
         swapAddress: pool.address.toLowerCase(),
         tokenAddress: pool.address.toLowerCase(),
         gaugeAddress: pool.gauge_address.toLowerCase(),
-        coinAddresses: [pool.token0_address.toLowerCase(), pool.token1_address.toLowerCase()],
       })),
-      resolvePoolContract: ({ network, definition }) =>
-        this.contractFactory.velodromePool({ network, address: definition.swapAddress }),
+      resolvePoolContract: ({ network, address }) => this.contractFactory.velodromePool({ network, address }),
+      resolvePoolCoinAddresses: async ({ multicall, poolContract }) =>
+        Promise.all([multicall.wrap(poolContract).token0(), multicall.wrap(poolContract).token1()]),
       resolvePoolReserves: async ({ multicall, poolContract }) =>
         Promise.all([multicall.wrap(poolContract).reserve0(), multicall.wrap(poolContract).reserve1()]),
       resolvePoolFee: async () => BigNumber.from(0), // TODO: get actual value


### PR DESCRIPTION
## Description

Easier to resolve addresses from on-chain requests, and catch underlying call failures using Multicall to filter out non-token indices.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
