### PR TITLE
feat(prices-selector): File cache is too slow, use memory cache

### DIFF
--- a/src/apps/balancer-v2/balancer-v2.module.ts
+++ b/src/apps/balancer-v2/balancer-v2.module.ts
@@ -57,6 +57,11 @@ import { PolygonBalancerV2StakedfContractPositionFetcher } from './polygon/balan
     BalancerV2GaugeAddressesGetter,
     BalancerV2GaugeRewardTokenStrategy,
   ],
-  exports: [BalancerV2SpotPriceHelper, BalancerV2PoolTokensHelper, BalancerV2ContractFactory, BalancerV2GaugeRewardTokenStrategy],
+  exports: [
+    BalancerV2SpotPriceHelper,
+    BalancerV2PoolTokensHelper,
+    BalancerV2ContractFactory,
+    BalancerV2GaugeRewardTokenStrategy,
+  ],
 })
 export class BalancerV2AppModule extends AbstractApp() {}

--- a/src/apps/beethoven-x/optimism/beethoven-x.balance-fetcher.ts
+++ b/src/apps/beethoven-x/optimism/beethoven-x.balance-fetcher.ts
@@ -1,5 +1,6 @@
 import { Inject } from '@nestjs/common';
-import { SingleStakingContractPositionBalanceHelper, TokenBalanceHelper } from '~app-toolkit';
+
+import { SingleStakingContractPositionBalanceHelper } from '~app-toolkit';
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { Register } from '~app-toolkit/decorators';
 import { presentBalanceFetcherResponse } from '~app-toolkit/helpers/presentation/balance-fetcher-response.present';
@@ -9,7 +10,6 @@ import { isClaimable } from '~position/position.utils';
 import { Network } from '~types/network.interface';
 
 import { BEETHOVEN_X_DEFINITION } from '../beethoven-x.definition';
-import { BeethovenXContractFactory, BeethovenXMasterchef } from '../contracts';
 
 const appId = BEETHOVEN_X_DEFINITION.id;
 const network = Network.OPTIMISM_MAINNET;

--- a/src/apps/beethoven-x/optimism/beethoven-x.pool.token-fetcher.ts
+++ b/src/apps/beethoven-x/optimism/beethoven-x.pool.token-fetcher.ts
@@ -3,8 +3,6 @@ import { compact } from 'lodash';
 
 import { Register } from '~app-toolkit/decorators';
 import { BalancerV2PoolLabelStrategy, BalancerV2PoolTokensHelper } from '~apps/balancer-v2';
-import { OLYMPUS_DEFINITION } from '~apps/olympus';
-import { YEARN_DEFINITION } from '~apps/yearn';
 import { PositionFetcher } from '~position/position-fetcher.interface';
 import { AppTokenPosition } from '~position/position.interface';
 import { Network } from '~types/network.interface';

--- a/src/token/price-selector.service.ts
+++ b/src/token/price-selector.service.ts
@@ -1,9 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { Interval } from '@nestjs/schedule';
 import DataLoader from 'dataloader';
-import Cache from 'file-system-cache';
 import { isNil, map } from 'lodash';
-import moment from 'moment';
 
 import { Network } from '~types';
 
@@ -24,29 +21,14 @@ type TokenDataLoaderKey = { network: Network; address: string };
 @Injectable()
 export class PriceSelectorService implements PriceSelectorFactory {
   private logger = new Logger(PriceSelectorService.name);
-  private cacheManager = Cache({
-    basePath: './.cache',
-    ns: 'price-selector',
-  });
+  private tokenCache = new Map<Network, Map<string, BaseTokenPrice>>();
 
   constructor(@Inject(TokenApiClient) private readonly tokenApiClient: TokenApiClient) {}
 
-  private getCacheKey(network: Network) {
-    return `$tokens:${network}`;
-  }
-
-  private async getCachedNetworkTokens(network: Network) {
-    const tokenMap = (await this.cacheManager.get(this.getCacheKey(network))) as unknown as Record<
-      string,
-      BaseTokenPrice
-    >;
-    if (!tokenMap) throw new Error(`Could not retrieve "${network}" tokens from cache`);
-    return tokenMap;
-  }
-
   private async getAllFromCache({ network }: Parameters<GetAll>[0], filters: Filters = {}) {
-    const cacheTokenMap = await this.getCachedNetworkTokens(network);
-    const tokens = Object.values(cacheTokenMap);
+    const cacheTokenMap = this.tokenCache.get(network);
+    if (!cacheTokenMap) throw new Error(`Could not retrieve "${network}" tokens from cache`);
+    const tokens = Array.from(cacheTokenMap.values());
 
     return tokens.filter(t => {
       if (!isNil(filters.exchangeable) && filters.exchangeable !== t.canExchange) return false;
@@ -55,9 +37,8 @@ export class PriceSelectorService implements PriceSelectorFactory {
     });
   }
 
-  private async getOneFromCache({ network, address }: Parameters<GetOne>[0], filters: Filters = {}) {
-    const cacheTokenMap = await this.getCachedNetworkTokens(network);
-    const match = cacheTokenMap[address];
+  private getOneFromCache({ network, address }: Parameters<GetOne>[0], filters: Filters = {}) {
+    const match = this.tokenCache.get(network)?.get(address);
 
     if (!match) return null;
     if (!isNil(filters.exchangeable) && filters.exchangeable !== match.canExchange) return null;
@@ -96,20 +77,16 @@ export class PriceSelectorService implements PriceSelectorFactory {
     }
   }
 
-  @Interval(moment.duration(2, 'minutes').asMilliseconds())
   private async updateCache() {
     const networks = Object.values(Network);
 
     await Promise.all(
       map(networks, async network => {
-        const map: Record<string, BaseTokenPrice> = {};
+        const map: Map<string, BaseTokenPrice> = new Map();
         const baseTokens = await this.tokenApiClient.getAllBaseTokenPrices(network);
 
-        baseTokens.forEach(token => {
-          map[token.address] = token;
-        });
-
-        await this.cacheManager.set(this.getCacheKey(network), map as any);
+        baseTokens.forEach(token => map.set(token.address, token));
+        this.tokenCache.set(network, map);
       }),
     );
   }


### PR DESCRIPTION
## Description

Memory leaks would randomly appear when querying large sets of prices using dataloader when relying on the file-cache
## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
