### PR TITLE
feat(votium): Add TTL on Votium keys to allow prior claimable amounts to expire

### DIFF
--- a/src/app-toolkit/app-toolkit.interface.ts
+++ b/src/app-toolkit/app-toolkit.interface.ts
@@ -58,7 +58,7 @@ export interface IAppToolkit {
   // Cache
 
   getFromCache<T = any>(key: string): Promise<T | undefined>;
-  msetToCache<T = any>(entries: [string, T][]): Promise<void>;
+  setManyToCache<T = any>(entries: [string, T][], ttl?: number): Promise<void>;
 
   // Global Helpers
 

--- a/src/app-toolkit/app-toolkit.service.ts
+++ b/src/app-toolkit/app-toolkit.service.ts
@@ -102,9 +102,9 @@ export class AppToolkit implements IAppToolkit {
     return this.cacheManager.get<T>(key);
   }
 
-  async msetToCache<T = any>(entries: [string, T][]) {
-    // In production, this is a Redis `mset`
-    await Promise.all(entries.map(([key, value]) => this.cacheManager.set(key, value)));
+  async setManyToCache<T = any>(entries: [string, T][], ttl = 60) {
+    // In production, this is a Redis pipeline of `set` commands
+    await Promise.all(entries.map(([key, value]) => this.cacheManager.set(key, value, { ttl })));
   }
 
   // Global Helpers

--- a/src/app-toolkit/helpers/merkle/merkle.cache.ts
+++ b/src/app-toolkit/helpers/merkle/merkle.cache.ts
@@ -41,7 +41,7 @@ export abstract class MerkleCache<T = any> {
       });
     });
 
-    await this.appToolkit.msetToCache(cacheable, moment.duration('30', 'minutes').asSeconds());
+    await this.appToolkit.setManyToCache(cacheable, moment.duration('30', 'minutes').asSeconds());
   }
 
   async getClaim(rewardTokenAddress: string, walletAddress: string) {

--- a/src/app-toolkit/helpers/merkle/merkle.cache.ts
+++ b/src/app-toolkit/helpers/merkle/merkle.cache.ts
@@ -30,7 +30,7 @@ export abstract class MerkleCache<T = any> {
   }
 
   @Schedule({
-    every: moment.duration('15', 'minutes').asMilliseconds(),
+    every: moment.duration('5', 'minutes').asMilliseconds(),
   })
   async cacheMerkleData() {
     const data = await this.resolveMerkleData();

--- a/src/app-toolkit/helpers/merkle/merkle.cache.ts
+++ b/src/app-toolkit/helpers/merkle/merkle.cache.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { entries } from 'lodash';
+import moment from 'moment';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { Schedule } from '~scheduler/scheduler.decorator';
@@ -29,7 +30,7 @@ export abstract class MerkleCache<T = any> {
   }
 
   @Schedule({
-    every: 15 * 60 * 1000,
+    every: moment.duration('15', 'minutes').asMilliseconds(),
   })
   async cacheMerkleData() {
     const data = await this.resolveMerkleData();
@@ -40,7 +41,7 @@ export abstract class MerkleCache<T = any> {
       });
     });
 
-    await this.appToolkit.msetToCache(cacheable);
+    await this.appToolkit.msetToCache(cacheable, moment.duration('30', 'minutes').asSeconds());
   }
 
   async getClaim(rewardTokenAddress: string, walletAddress: string) {


### PR DESCRIPTION
## Description

Expire the keys after 30m so that old Merkle amounts expire. I'll manually expire the keys without a TTL currently.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
