### PR TITLE
feat(velodrome): Fix missing pools

### DIFF
--- a/src/apps/curve/helpers/curve.pool.token-helper.ts
+++ b/src/apps/curve/helpers/curve.pool.token-helper.ts
@@ -194,7 +194,8 @@ export class CurvePoolTokenHelper {
       poolDefinitions.map(async definition => {
         if (definition.coinAddresses) return definition;
         const poolContract = resolvePoolContract({ network, address: definition.swapAddress });
-        const coinAddresses = await resolvePoolCoinAddresses({ multicall, poolContract });
+        const rawCoinAddresses = await resolvePoolCoinAddresses({ multicall, poolContract });
+        const coinAddresses = rawCoinAddresses.map(v => v.toLowerCase());
         return { ...definition, coinAddresses };
       }),
     );


### PR DESCRIPTION
## Description
Velodrome is missing multiple pools. Only ETH and OP pools are showing. We where missing lowercasing addresses in one of the curve helper. ETH and OP where the only one working because there was no alphabetical character in their address.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)


## How to test?

[http://localhost:5001/apps/velodrome/tokens?groupIds%5B%5D=pool&network=optimism](http://localhost:5001/apps/velodrome/tokens?groupIds%5B%5D=pool&network=optimism)
