### PR TITLE
fix(stargate): Fix balance fetcher when farm reward period is over

### DIFF
--- a/src/apps/stargate/arbitrum/stargate.balance-fetcher.ts
+++ b/src/apps/stargate/arbitrum/stargate.balance-fetcher.ts
@@ -62,7 +62,10 @@ export class ArbitrumStargateBalanceFetcher implements BalanceFetcher {
       }),
       resolveClaimableTokenBalances: this.appToolkit.helpers.masterChefDefaultClaimableBalanceStrategy.build({
         resolveClaimableBalance: ({ multicall, contract, contractPosition, address }) =>
-          multicall.wrap(contract).pendingStargate(contractPosition.dataProps.poolIndex, address),
+          multicall
+            .wrap(contract)
+            .pendingStargate(contractPosition.dataProps.poolIndex, address)
+            .catch(() => 0),
       }),
     });
   }

--- a/src/apps/stargate/avalanche/stargate.balance-fetcher.ts
+++ b/src/apps/stargate/avalanche/stargate.balance-fetcher.ts
@@ -53,7 +53,10 @@ export class AvalancheStargateBalanceFetcher implements BalanceFetcher {
       }),
       resolveClaimableTokenBalances: this.appToolkit.helpers.masterChefDefaultClaimableBalanceStrategy.build({
         resolveClaimableBalance: ({ multicall, contract, contractPosition, address }) =>
-          multicall.wrap(contract).pendingStargate(contractPosition.dataProps.poolIndex, address),
+          multicall
+            .wrap(contract)
+            .pendingStargate(contractPosition.dataProps.poolIndex, address)
+            .catch(() => 0),
       }),
     });
   }

--- a/src/apps/stargate/binance-smart-chain/stargate.balance-fetcher.ts
+++ b/src/apps/stargate/binance-smart-chain/stargate.balance-fetcher.ts
@@ -53,7 +53,10 @@ export class BinanceSmartChainStargateBalanceFetcher implements BalanceFetcher {
       }),
       resolveClaimableTokenBalances: this.appToolkit.helpers.masterChefDefaultClaimableBalanceStrategy.build({
         resolveClaimableBalance: ({ multicall, contract, contractPosition, address }) =>
-          multicall.wrap(contract).pendingStargate(contractPosition.dataProps.poolIndex, address),
+          multicall
+            .wrap(contract)
+            .pendingStargate(contractPosition.dataProps.poolIndex, address)
+            .catch(() => 0),
       }),
     });
   }

--- a/src/apps/stargate/ethereum/stargate.balance-fetcher.ts
+++ b/src/apps/stargate/ethereum/stargate.balance-fetcher.ts
@@ -62,7 +62,10 @@ export class EthereumStargateBalanceFetcher implements BalanceFetcher {
       }),
       resolveClaimableTokenBalances: this.appToolkit.helpers.masterChefDefaultClaimableBalanceStrategy.build({
         resolveClaimableBalance: ({ multicall, contract, contractPosition, address }) =>
-          multicall.wrap(contract).pendingStargate(contractPosition.dataProps.poolIndex, address),
+          multicall
+            .wrap(contract)
+            .pendingStargate(contractPosition.dataProps.poolIndex, address)
+            .catch(() => 0),
       }),
     });
   }

--- a/src/apps/stargate/fantom/stargate.balance-fetcher.ts
+++ b/src/apps/stargate/fantom/stargate.balance-fetcher.ts
@@ -53,7 +53,10 @@ export class FantomStargateBalanceFetcher implements BalanceFetcher {
       }),
       resolveClaimableTokenBalances: this.appToolkit.helpers.masterChefDefaultClaimableBalanceStrategy.build({
         resolveClaimableBalance: ({ multicall, contract, contractPosition, address }) =>
-          multicall.wrap(contract).pendingStargate(contractPosition.dataProps.poolIndex, address),
+          multicall
+            .wrap(contract)
+            .pendingStargate(contractPosition.dataProps.poolIndex, address)
+            .catch(() => 0),
       }),
     });
   }

--- a/src/apps/stargate/optimism/stargate.balance-fetcher.ts
+++ b/src/apps/stargate/optimism/stargate.balance-fetcher.ts
@@ -62,7 +62,10 @@ export class OptimismStargateBalanceFetcher implements BalanceFetcher {
       }),
       resolveClaimableTokenBalances: this.appToolkit.helpers.masterChefDefaultClaimableBalanceStrategy.build({
         resolveClaimableBalance: ({ multicall, contract, contractPosition, address }) =>
-          multicall.wrap(contract).pendingStargate(contractPosition.dataProps.poolIndex, address),
+          multicall
+            .wrap(contract)
+            .pendingStargate(contractPosition.dataProps.poolIndex, address)
+            .catch(() => 0),
       }),
     });
   }

--- a/src/apps/stargate/polygon/stargate.balance-fetcher.ts
+++ b/src/apps/stargate/polygon/stargate.balance-fetcher.ts
@@ -53,7 +53,10 @@ export class PolygonStargateBalanceFetcher implements BalanceFetcher {
       }),
       resolveClaimableTokenBalances: this.appToolkit.helpers.masterChefDefaultClaimableBalanceStrategy.build({
         resolveClaimableBalance: ({ multicall, contract, contractPosition, address }) =>
-          multicall.wrap(contract).pendingStargate(contractPosition.dataProps.poolIndex, address),
+          multicall
+            .wrap(contract)
+            .pendingStargate(contractPosition.dataProps.poolIndex, address)
+            .catch(() => 0),
       }),
     });
   }


### PR DESCRIPTION
## Description
Stargate balance fetching is currently failing on Optimism. This due to a Multicall failure when trying to call `pendingStargate` on the [LP staking contract](https://optimistic.etherscan.io/address/0x4a364f8c717caad9a442737eb7b8a55cc6cf18d8#readContract).There is `SafeMath: division by zero` error returned by the contract. I found out that the call is throwing that because the reward period is over on that MasterChef contract and there is a [piece of code](https://optimistic.etherscan.deth.net/address/0x4a364f8c717caad9a442737eb7b8a55cc6cf18d8#readContract#123) attempting to divide by the `totalAllocPoint` which is equal to 0.
In this fix, I am catching the exception and falling back to 0.

![image](https://user-images.githubusercontent.com/1527361/182472680-77f07682-60ad-4e61-81cb-51c467c232cb.png)
![image](https://user-images.githubusercontent.com/1527361/182472279-848e220c-da2c-47c8-a496-43e8d28b7758.png)
![image](https://user-images.githubusercontent.com/1527361/182472372-a1278d1d-5d1b-4e9f-b0a4-bd12a148d49a.png)
![image](https://user-images.githubusercontent.com/1527361/182472415-5a732817-3914-4e58-a01f-adff116cf014.png)


## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

