### PR TITLE
feat(revert-fi): track compoundors claimable fees

### DIFF
--- a/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
@@ -43,7 +43,7 @@ export class ArbitrumRevertFinanceBalanceFetcher implements BalanceFetcher {
 
     return presentBalanceFetcherResponse([
       {
-        label: 'Compoundor bot rewards',
+        label: 'Compoundor rewards',
         assets: accumulatedCompoundorBalances,
       },
     ]);

--- a/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
@@ -1,0 +1,51 @@
+import { Inject } from '@nestjs/common';
+import { getAddress } from 'ethers/lib/utils';
+
+import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
+import { Register } from '~app-toolkit/decorators';
+import { presentBalanceFetcherResponse } from '~app-toolkit/helpers/presentation/balance-fetcher-response.present';
+import { BalanceFetcher } from '~balance/balance-fetcher.interface';
+import { ContractPositionBalance } from '~position/position-balance.interface';
+import { Network } from '~types/network.interface';
+
+import { accountBalancesQuery, CompoundorUserPosition } from '../graphql/accountBalancesQuery';
+import { generateGraphUrlForNetwork } from '../graphql/graphUrlGenerator';
+import { getCompoundorContractPosition } from '../helpers/contractPositionParser';
+import { REVERT_FINANCE_DEFINITION } from '../revert-finance.definition';
+
+const network = Network.ARBITRUM_MAINNET;
+
+@Register.BalanceFetcher(REVERT_FINANCE_DEFINITION.id, network)
+export class ArbitrumRevertFinanceBalanceFetcher implements BalanceFetcher {
+  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
+
+  async getAccumulatedCompoundorBalances(address: string) {
+    const graphHelper = this.appToolkit.helpers.theGraphHelper;
+    const data = await graphHelper.requestGraph<CompoundorUserPosition>({
+      endpoint: generateGraphUrlForNetwork(network),
+      query: accountBalancesQuery,
+      variables: { address: getAddress(address) },
+    });
+    if (!data) return [];
+    const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
+    const rewards: Array<ContractPositionBalance> = [];
+    data.accountBalances.map(({ token, balance }) => {
+      const existingToken = baseTokens.find(item => item.address === token)!;
+      if (!token) return [];
+
+      rewards.push(getCompoundorContractPosition(network, existingToken, balance));
+    });
+    return rewards;
+  }
+
+  async getBalances(address: string) {
+    const [accumulatedCompoundorBalances] = await Promise.all([this.getAccumulatedCompoundorBalances(address)]);
+
+    return presentBalanceFetcherResponse([
+      {
+        label: 'Compoundor bot rewards',
+        assets: accumulatedCompoundorBalances,
+      },
+    ]);
+  }
+}

--- a/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
@@ -19,7 +19,7 @@ const network = Network.ARBITRUM_MAINNET;
 export class ArbitrumRevertFinanceBalanceFetcher implements BalanceFetcher {
   constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
 
-  async getAccumulatedCompoundorBalances(address: string) {
+  async getAccumulatedCompoundorRewards(address: string) {
     const graphHelper = this.appToolkit.helpers.theGraphHelper;
     const data = await graphHelper.requestGraph<CompoundorUserPosition>({
       endpoint: generateGraphUrlForNetwork(network),
@@ -39,12 +39,12 @@ export class ArbitrumRevertFinanceBalanceFetcher implements BalanceFetcher {
   }
 
   async getBalances(address: string) {
-    const [accumulatedCompoundorBalances] = await Promise.all([this.getAccumulatedCompoundorBalances(address)]);
+    const [accumulatedCompoundorRewards] = await Promise.all([this.getAccumulatedCompoundorRewards(address)]);
 
     return presentBalanceFetcherResponse([
       {
         label: 'Compoundor rewards',
-        assets: accumulatedCompoundorBalances,
+        assets: accumulatedCompoundorRewards,
       },
     ]);
   }

--- a/src/apps/revert-finance/contracts/index.ts
+++ b/src/apps/revert-finance/contracts/index.ts
@@ -1,0 +1,14 @@
+import { Injectable, Inject } from '@nestjs/common';
+
+import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
+import { ContractFactory } from '~contract/contracts';
+import { Network } from '~types/network.interface';
+// eslint-disable-next-line
+type ContractOpts = { address: string; network: Network };
+
+@Injectable()
+export class RevertFinanceContractFactory extends ContractFactory {
+  constructor(@Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit) {
+    super((network: Network) => appToolkit.getNetworkProvider(network));
+  }
+}

--- a/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
@@ -1,0 +1,51 @@
+import { Inject } from '@nestjs/common';
+import { getAddress } from 'ethers/lib/utils';
+
+import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
+import { Register } from '~app-toolkit/decorators';
+import { presentBalanceFetcherResponse } from '~app-toolkit/helpers/presentation/balance-fetcher-response.present';
+import { BalanceFetcher } from '~balance/balance-fetcher.interface';
+import { ContractPositionBalance } from '~position/position-balance.interface';
+import { Network } from '~types/network.interface';
+
+import { accountBalancesQuery, CompoundorUserPosition } from '../graphql/accountBalancesQuery';
+import { generateGraphUrlForNetwork } from '../graphql/graphUrlGenerator';
+import { getCompoundorContractPosition } from '../helpers/contractPositionParser';
+import { REVERT_FINANCE_DEFINITION } from '../revert-finance.definition';
+
+const network = Network.ETHEREUM_MAINNET;
+
+@Register.BalanceFetcher(REVERT_FINANCE_DEFINITION.id, network)
+export class EthereumRevertFinanceBalanceFetcher implements BalanceFetcher {
+  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
+
+  async getAccumulatedCompoundorBalances(address: string) {
+    const graphHelper = this.appToolkit.helpers.theGraphHelper;
+    const data = await graphHelper.requestGraph<CompoundorUserPosition>({
+      endpoint: generateGraphUrlForNetwork(network),
+      query: accountBalancesQuery,
+      variables: { address: getAddress(address) },
+    });
+    if (!data) return [];
+    const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
+    const rewards: Array<ContractPositionBalance> = [];
+    data.accountBalances.map(({ token, balance }) => {
+      const existingToken = baseTokens.find(item => item.address === token)!;
+      if (!token) return [];
+
+      rewards.push(getCompoundorContractPosition(network, existingToken, balance));
+    });
+    return rewards;
+  }
+
+  async getBalances(address: string) {
+    const [accumulatedCompoundorBalances] = await Promise.all([this.getAccumulatedCompoundorBalances(address)]);
+
+    return presentBalanceFetcherResponse([
+      {
+        label: 'Compoundor bot rewards',
+        assets: accumulatedCompoundorBalances,
+      },
+    ]);
+  }
+}

--- a/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
@@ -19,7 +19,7 @@ const network = Network.ETHEREUM_MAINNET;
 export class EthereumRevertFinanceBalanceFetcher implements BalanceFetcher {
   constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
 
-  async getAccumulatedCompoundorBalances(address: string) {
+  async getAccumulatedCompoundorRewards(address: string) {
     const graphHelper = this.appToolkit.helpers.theGraphHelper;
     const data = await graphHelper.requestGraph<CompoundorUserPosition>({
       endpoint: generateGraphUrlForNetwork(network),
@@ -39,12 +39,12 @@ export class EthereumRevertFinanceBalanceFetcher implements BalanceFetcher {
   }
 
   async getBalances(address: string) {
-    const [accumulatedCompoundorBalances] = await Promise.all([this.getAccumulatedCompoundorBalances(address)]);
+    const [accumulatedCompoundorRewards] = await Promise.all([this.getAccumulatedCompoundorRewards(address)]);
 
     return presentBalanceFetcherResponse([
       {
         label: 'Compoundor rewards',
-        assets: accumulatedCompoundorBalances,
+        assets: accumulatedCompoundorRewards,
       },
     ]);
   }

--- a/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
@@ -43,7 +43,7 @@ export class EthereumRevertFinanceBalanceFetcher implements BalanceFetcher {
 
     return presentBalanceFetcherResponse([
       {
-        label: 'Compoundor bot rewards',
+        label: 'Compoundor rewards',
         assets: accumulatedCompoundorBalances,
       },
     ]);

--- a/src/apps/revert-finance/graphql/accountBalancesQuery.ts
+++ b/src/apps/revert-finance/graphql/accountBalancesQuery.ts
@@ -1,0 +1,23 @@
+import { gql } from 'graphql-request';
+
+type AccountBalance = {
+  id: string;
+  token: string;
+  account: string;
+  balance: string;
+};
+
+export type CompoundorUserPosition = {
+  accountBalances: Array<AccountBalance>;
+};
+
+export const accountBalancesQuery = gql`
+  query getUserPositions($address: String!) {
+    accountBalances(where: { account: $address }) {
+      id
+      account
+      token
+      balance
+    }
+  }
+`;

--- a/src/apps/revert-finance/graphql/graphUrlGenerator.ts
+++ b/src/apps/revert-finance/graphql/graphUrlGenerator.ts
@@ -1,0 +1,12 @@
+export const generateGraphUrlForNetwork = (network: string): string => {
+  let parsedNetwork = '';
+  switch (network) {
+    case 'ethereum':
+      parsedNetwork = 'mainnet';
+      break;
+    default:
+      parsedNetwork = network;
+      break;
+  }
+  return `https://api.thegraph.com/subgraphs/name/revert-finance/compoundor-${parsedNetwork}`;
+};

--- a/src/apps/revert-finance/helpers/contractPositionParser.ts
+++ b/src/apps/revert-finance/helpers/contractPositionParser.ts
@@ -1,0 +1,41 @@
+import { getAddress } from 'ethers/lib/utils';
+
+import { drillBalance } from '~app-toolkit';
+import { buildDollarDisplayItem } from '~app-toolkit/helpers/presentation/display-item.present';
+import { getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
+import { ContractType } from '~position/contract.interface';
+import { ContractPositionBalance } from '~position/position-balance.interface';
+import { claimable } from '~position/position.utils';
+import { BaseToken } from '~position/token.interface';
+import { Network } from '~types';
+
+import REVERT_FINANCE_DEFINITION from '../revert-finance.definition';
+
+const CompoundorContractAddress = getAddress('0x5411894842e610c4d0f6ed4c232da689400f94a1');
+
+export const getCompoundorContractPosition = (
+  network: Network,
+  existingToken: BaseToken,
+  balanceRaw: string,
+): ContractPositionBalance => {
+  const balance = [drillBalance(claimable(existingToken), balanceRaw)];
+  const dataProps = {};
+  const displayProps = {
+    label: `Claimable ${existingToken.symbol}`,
+    secondaryLabel: buildDollarDisplayItem(existingToken.price),
+    images: [getTokenImg(existingToken.address, network)],
+    statsItems: [],
+  };
+
+  return {
+    type: ContractType.POSITION,
+    address: CompoundorContractAddress,
+    network,
+    appId: REVERT_FINANCE_DEFINITION.id,
+    groupId: REVERT_FINANCE_DEFINITION.groups.compoundorBotRewards.id,
+    tokens: balance,
+    balanceUSD: balance[0].balanceUSD,
+    dataProps,
+    displayProps,
+  };
+};

--- a/src/apps/revert-finance/helpers/contractPositionParser.ts
+++ b/src/apps/revert-finance/helpers/contractPositionParser.ts
@@ -32,7 +32,7 @@ export const getCompoundorContractPosition = (
     address: CompoundorContractAddress,
     network,
     appId: REVERT_FINANCE_DEFINITION.id,
-    groupId: REVERT_FINANCE_DEFINITION.groups.compoundorBotRewards.id,
+    groupId: REVERT_FINANCE_DEFINITION.groups.compoundorRewards.id,
     tokens: balance,
     balanceUSD: balance[0].balanceUSD,
     dataProps,

--- a/src/apps/revert-finance/index.ts
+++ b/src/apps/revert-finance/index.ts
@@ -1,0 +1,3 @@
+export { REVERT_FINANCE_DEFINITION, RevertFinanceAppDefinition } from './revert-finance.definition';
+export { RevertFinanceAppModule } from './revert-finance.module';
+export { RevertFinanceContractFactory } from './contracts';

--- a/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
@@ -19,7 +19,7 @@ const network = Network.OPTIMISM_MAINNET;
 export class OptimismRevertFinanceBalanceFetcher implements BalanceFetcher {
   constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
 
-  async getAccumulatedCompoundorBalances(address: string) {
+  async getAccumulatedCompoundorRewards(address: string) {
     const graphHelper = this.appToolkit.helpers.theGraphHelper;
     const data = await graphHelper.requestGraph<CompoundorUserPosition>({
       endpoint: generateGraphUrlForNetwork(network),
@@ -39,12 +39,12 @@ export class OptimismRevertFinanceBalanceFetcher implements BalanceFetcher {
   }
 
   async getBalances(address: string) {
-    const [accumulatedCompoundorBalances] = await Promise.all([this.getAccumulatedCompoundorBalances(address)]);
+    const [accumulatedCompoundorRewards] = await Promise.all([this.getAccumulatedCompoundorRewards(address)]);
 
     return presentBalanceFetcherResponse([
       {
         label: 'Compoundor rewards',
-        assets: accumulatedCompoundorBalances,
+        assets: accumulatedCompoundorRewards,
       },
     ]);
   }

--- a/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
@@ -43,7 +43,7 @@ export class OptimismRevertFinanceBalanceFetcher implements BalanceFetcher {
 
     return presentBalanceFetcherResponse([
       {
-        label: 'Compoundor bot rewards',
+        label: 'Compoundor rewards',
         assets: accumulatedCompoundorBalances,
       },
     ]);

--- a/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
@@ -1,0 +1,51 @@
+import { Inject } from '@nestjs/common';
+import { getAddress } from 'ethers/lib/utils';
+
+import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
+import { Register } from '~app-toolkit/decorators';
+import { presentBalanceFetcherResponse } from '~app-toolkit/helpers/presentation/balance-fetcher-response.present';
+import { BalanceFetcher } from '~balance/balance-fetcher.interface';
+import { ContractPositionBalance } from '~position/position-balance.interface';
+import { Network } from '~types/network.interface';
+
+import { accountBalancesQuery, CompoundorUserPosition } from '../graphql/accountBalancesQuery';
+import { generateGraphUrlForNetwork } from '../graphql/graphUrlGenerator';
+import { getCompoundorContractPosition } from '../helpers/contractPositionParser';
+import { REVERT_FINANCE_DEFINITION } from '../revert-finance.definition';
+
+const network = Network.OPTIMISM_MAINNET;
+
+@Register.BalanceFetcher(REVERT_FINANCE_DEFINITION.id, network)
+export class OptimismRevertFinanceBalanceFetcher implements BalanceFetcher {
+  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
+
+  async getAccumulatedCompoundorBalances(address: string) {
+    const graphHelper = this.appToolkit.helpers.theGraphHelper;
+    const data = await graphHelper.requestGraph<CompoundorUserPosition>({
+      endpoint: generateGraphUrlForNetwork(network),
+      query: accountBalancesQuery,
+      variables: { address: getAddress(address) },
+    });
+    if (!data) return [];
+    const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
+    const rewards: Array<ContractPositionBalance> = [];
+    data.accountBalances.map(({ token, balance }) => {
+      const existingToken = baseTokens.find(item => item.address === token)!;
+      if (!token) return [];
+
+      rewards.push(getCompoundorContractPosition(network, existingToken, balance));
+    });
+    return rewards;
+  }
+
+  async getBalances(address: string) {
+    const [accumulatedCompoundorBalances] = await Promise.all([this.getAccumulatedCompoundorBalances(address)]);
+
+    return presentBalanceFetcherResponse([
+      {
+        label: 'Compoundor bot rewards',
+        assets: accumulatedCompoundorBalances,
+      },
+    ]);
+  }
+}

--- a/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
@@ -43,7 +43,7 @@ export class PolygonRevertFinanceBalanceFetcher implements BalanceFetcher {
 
     return presentBalanceFetcherResponse([
       {
-        label: 'Compoundor bot rewards',
+        label: 'Compoundor rewards',
         assets: accumulatedCompoundorBalances,
       },
     ]);

--- a/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
@@ -19,7 +19,7 @@ const network = Network.POLYGON_MAINNET;
 export class PolygonRevertFinanceBalanceFetcher implements BalanceFetcher {
   constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
 
-  async getAccumulatedCompoundorBalances(address: string) {
+  async getAccumulatedCompoundorRewards(address: string) {
     const graphHelper = this.appToolkit.helpers.theGraphHelper;
     const data = await graphHelper.requestGraph<CompoundorUserPosition>({
       endpoint: generateGraphUrlForNetwork(network),
@@ -39,12 +39,12 @@ export class PolygonRevertFinanceBalanceFetcher implements BalanceFetcher {
   }
 
   async getBalances(address: string) {
-    const [accumulatedCompoundorBalances] = await Promise.all([this.getAccumulatedCompoundorBalances(address)]);
+    const [accumulatedCompoundorRewards] = await Promise.all([this.getAccumulatedCompoundorRewards(address)]);
 
     return presentBalanceFetcherResponse([
       {
         label: 'Compoundor rewards',
-        assets: accumulatedCompoundorBalances,
+        assets: accumulatedCompoundorRewards,
       },
     ]);
   }

--- a/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
@@ -1,0 +1,51 @@
+import { Inject } from '@nestjs/common';
+import { getAddress } from 'ethers/lib/utils';
+
+import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
+import { Register } from '~app-toolkit/decorators';
+import { presentBalanceFetcherResponse } from '~app-toolkit/helpers/presentation/balance-fetcher-response.present';
+import { BalanceFetcher } from '~balance/balance-fetcher.interface';
+import { ContractPositionBalance } from '~position/position-balance.interface';
+import { Network } from '~types/network.interface';
+
+import { accountBalancesQuery, CompoundorUserPosition } from '../graphql/accountBalancesQuery';
+import { generateGraphUrlForNetwork } from '../graphql/graphUrlGenerator';
+import { getCompoundorContractPosition } from '../helpers/contractPositionParser';
+import { REVERT_FINANCE_DEFINITION } from '../revert-finance.definition';
+
+const network = Network.POLYGON_MAINNET;
+
+@Register.BalanceFetcher(REVERT_FINANCE_DEFINITION.id, network)
+export class PolygonRevertFinanceBalanceFetcher implements BalanceFetcher {
+  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
+
+  async getAccumulatedCompoundorBalances(address: string) {
+    const graphHelper = this.appToolkit.helpers.theGraphHelper;
+    const data = await graphHelper.requestGraph<CompoundorUserPosition>({
+      endpoint: generateGraphUrlForNetwork(network),
+      query: accountBalancesQuery,
+      variables: { address: getAddress(address) },
+    });
+    if (!data) return [];
+    const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
+    const rewards: Array<ContractPositionBalance> = [];
+    data.accountBalances.map(({ token, balance }) => {
+      const existingToken = baseTokens.find(item => item.address === token)!;
+      if (!token) return [];
+
+      rewards.push(getCompoundorContractPosition(network, existingToken, balance));
+    });
+    return rewards;
+  }
+
+  async getBalances(address: string) {
+    const [accumulatedCompoundorBalances] = await Promise.all([this.getAccumulatedCompoundorBalances(address)]);
+
+    return presentBalanceFetcherResponse([
+      {
+        label: 'Compoundor bot rewards',
+        assets: accumulatedCompoundorBalances,
+      },
+    ]);
+  }
+}

--- a/src/apps/revert-finance/revert-finance.definition.ts
+++ b/src/apps/revert-finance/revert-finance.definition.ts
@@ -10,10 +10,10 @@ export const REVERT_FINANCE_DEFINITION = appDefinition({
   url: 'https://revert.finance/',
 
   groups: {
-    compoundorBotRewards: {
-      id: 'compoundor-bot-rewards',
+    compoundorRewards: {
+      id: 'compoundor-rewards',
       type: GroupType.POSITION,
-      label: 'Compoundor bot rewards',
+      label: 'Compoundor rewards',
     },
   },
 

--- a/src/apps/revert-finance/revert-finance.definition.ts
+++ b/src/apps/revert-finance/revert-finance.definition.ts
@@ -1,0 +1,41 @@
+import { Register } from '~app-toolkit/decorators';
+import { appDefinition, AppDefinition } from '~app/app.definition';
+import { AppAction, AppTag, GroupType } from '~app/app.interface';
+import { Network } from '~types/network.interface';
+
+export const REVERT_FINANCE_DEFINITION = appDefinition({
+  id: 'revert-finance',
+  name: 'Revert finance',
+  description: 'Revert develops analytics and management tools for liquidity providers in AMM protocols. ',
+  url: 'https://revert.finance/',
+
+  groups: {
+    compoundorBotRewards: {
+      id: 'compoundor-bot-rewards',
+      type: GroupType.POSITION,
+      label: 'Compoundor bot rewards',
+    },
+  },
+
+  tags: [AppTag.ASSET_MANAGEMENT],
+  keywords: [],
+  links: {},
+
+  supportedNetworks: {
+    [Network.ETHEREUM_MAINNET]: [AppAction.VIEW],
+    [Network.POLYGON_MAINNET]: [AppAction.VIEW],
+    [Network.OPTIMISM_MAINNET]: [AppAction.VIEW],
+    [Network.ARBITRUM_MAINNET]: [AppAction.VIEW],
+  },
+
+  primaryColor: '#fff',
+});
+
+@Register.AppDefinition(REVERT_FINANCE_DEFINITION.id)
+export class RevertFinanceAppDefinition extends AppDefinition {
+  constructor() {
+    super(REVERT_FINANCE_DEFINITION);
+  }
+}
+
+export default REVERT_FINANCE_DEFINITION;

--- a/src/apps/revert-finance/revert-finance.module.ts
+++ b/src/apps/revert-finance/revert-finance.module.ts
@@ -1,0 +1,22 @@
+import { Register } from '~app-toolkit/decorators';
+import { AbstractApp } from '~app/app.dynamic-module';
+
+import { ArbitrumRevertFinanceBalanceFetcher } from './arbitrum/revert-finance.balance-fetcher';
+import { RevertFinanceContractFactory } from './contracts';
+import { EthereumRevertFinanceBalanceFetcher } from './ethereum/revert-finance.balance-fetcher';
+import { OptimismRevertFinanceBalanceFetcher } from './optimism/revert-finance.balance-fetcher';
+import { PolygonRevertFinanceBalanceFetcher } from './polygon/revert-finance.balance-fetcher';
+import { RevertFinanceAppDefinition, REVERT_FINANCE_DEFINITION } from './revert-finance.definition';
+
+@Register.AppModule({
+  appId: REVERT_FINANCE_DEFINITION.id,
+  providers: [
+    ArbitrumRevertFinanceBalanceFetcher,
+    EthereumRevertFinanceBalanceFetcher,
+    OptimismRevertFinanceBalanceFetcher,
+    PolygonRevertFinanceBalanceFetcher,
+    RevertFinanceAppDefinition,
+    RevertFinanceContractFactory,
+  ],
+})
+export class RevertFinanceAppModule extends AbstractApp() {}


### PR DESCRIPTION
## Description

[Revert finance](https://revert.finance/) develops analytics and management tools for liquidity providers in AMM protocols. 

Anybody can compound their LP vaults and accumulate a fees in their contract as compensation, this PR aims to track those accumulated fees.

Deployed on Ethereum, Arbitrum, Polygon, Optimism.

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: 0xa03c3fc823457F95ffc3cc7fD5a5133d5AFb850A
- [X] (optional) As a contributor, my Twitter handle is: [@Clonescody](https://twitter.com/Clonescody)
 
## How to test?

App ID : `revert-finance`
- Ethereum : http://localhost:5001/apps/revert-finance/balances?addresses[]=0x0401343c50ff963a7b02b20b31fa9b0b159354d4&network=ethereum
- Arbitrum : http://localhost:5001/apps/revert-finance/balances?addresses[]=0x89B579D25F8ebc6476Dd9EB2D8C4e02b406A8904&network=arbitrum
- Optimism : http://localhost:5001/apps/revert-finance/balances?addresses[]=0x89B579D25F8ebc6476Dd9EB2D8C4e02b406A8904&network=optimism
- Polygon : http://localhost:5001/apps/revert-finance/balances?addresses[]=0x89B579D25F8ebc6476Dd9EB2D8C4e02b406A8904&network=polygon




