### PR TITLE
fix(ci): Dispatch action to zapper-api to trigger studio bump

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -87,3 +87,16 @@ jobs:
           echo "::set-output name=release::${{ steps.fetch-latest-release.outputs.name }}"
           echo "::set-output name=changelog::${{ steps.fetch-latest-release.outputs.body }}"
         if: ${{ steps.release.outputs.release_created }}
+
+  bump-zapper-api:
+    name: Bump on Zapper API
+    needs: [release-please]
+    runs-on: ubuntu-latest
+    if: ${{ needs.release-please.outputs.published == 'true' }}
+    steps:
+      - uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GH_ZAPPER_BOT }}
+          repository: zapper-fi/zapper-api
+          event-type: bump-studio
+          client-payload: '{"release": "${{ needs.release-please.outputs.release }}", "changelog": "${{ needs.release-please.outputs.changelog }}"}'


### PR DESCRIPTION
## Description

Leverages github event dispatch to trigger an action on the API instead of open the PR from here.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
