### PR TITLE
fix(b-protocol): fix b-protocol (liquity adapter)

### DIFF
--- a/src/apps/b-protocol/adapters/liquity.b-protocol-adapter.ts
+++ b/src/apps/b-protocol/adapters/liquity.b-protocol-adapter.ts
@@ -19,6 +19,7 @@ const network = Network.ETHEREUM_MAINNET;
 
 export class LiquityBProtocolAdapter {
   private readonly bammPools = [
+    '0x00ff66ab8699aafa050ee5ef5041d1503aa0849a',
     '0x0d3abaa7e088c2c82f54b2f47613da438ea8c598',
     '0x54bc9113f1f55cdbdf221daf798dc73614f6d972',
   ];

--- a/src/apps/liquity/ethereum/liquity.balance-fetcher.ts
+++ b/src/apps/liquity/ethereum/liquity.balance-fetcher.ts
@@ -56,7 +56,7 @@ export class EthereumLiquityBalanceFetcher implements BalanceFetcher {
       this.appToolkit.helpers.singleStakingContractPositionBalanceHelper.getBalances<LiquityStaking>({
         address,
         appId,
-        groupId: LIQUITY_DEFINITION.groups.farm.id,
+        groupId: LIQUITY_DEFINITION.groups.staking.id,
         network,
         resolveContract: () =>
           this.liquityContractFactory.liquityStaking({

--- a/src/apps/liquity/ethereum/liquity.staking.contract-position-fetcher.ts
+++ b/src/apps/liquity/ethereum/liquity.staking.contract-position-fetcher.ts
@@ -19,15 +19,14 @@ const FARMS = [
 ];
 
 const appId = LIQUITY_DEFINITION.id;
-const groupId = LIQUITY_DEFINITION.groups.farm.id;
+const groupId = LIQUITY_DEFINITION.groups.staking.id;
 const network = Network.ETHEREUM_MAINNET;
 
 @Register.ContractPositionFetcher({ appId, groupId, network })
-export class EthereumLiquityFarmContractPositionFetcher implements PositionFetcher<ContractPosition> {
+export class EthereumLiquityStakingContractPositionFetcher implements PositionFetcher<ContractPosition> {
   constructor(
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
-    @Inject(LiquityContractFactory)
-    private readonly liquityContractFactory: LiquityContractFactory,
+    @Inject(LiquityContractFactory) private readonly liquityContractFactory: LiquityContractFactory,
   ) {}
 
   async getPositions() {

--- a/src/apps/liquity/liquity.definition.ts
+++ b/src/apps/liquity/liquity.definition.ts
@@ -17,7 +17,7 @@ export const LIQUITY_DEFINITION = appDefinition({
     medium: 'https://medium.com/liquity',
   },
   groups: {
-    farm: { id: 'farm', type: GroupType.POSITION, label: 'Staked', groupLabel: 'Farms' },
+    staking: { id: 'staking', type: GroupType.POSITION, label: 'Staked', groupLabel: 'Staked' },
     trove: { id: 'trove', type: GroupType.POSITION, label: 'Trove' },
     stabilityPool: { id: 'stability-pool', type: GroupType.POSITION, label: 'Stability Pool', groupLabel: 'Pools' },
   },

--- a/src/apps/liquity/liquity.module.ts
+++ b/src/apps/liquity/liquity.module.ts
@@ -3,7 +3,7 @@ import { AbstractApp } from '~app/app.dynamic-module';
 
 import { LiquityContractFactory } from './contracts';
 import { EthereumLiquityBalanceFetcher } from './ethereum/liquity.balance-fetcher';
-import { EthereumLiquityFarmContractPositionFetcher } from './ethereum/liquity.farm.contract-position-fetcher';
+import { EthereumLiquityStakingContractPositionFetcher } from './ethereum/liquity.staking.contract-position-fetcher';
 import { LiquityStabilityPoolBalanceHelper } from './helpers/liquity.stability-pool.balance-helper';
 import { LiquityTroveBalanceHelper } from './helpers/liquity.trove.balance-helper';
 import LIQUITY_DEFINITION, { LiquityAppDefinition } from './liquity.definition';
@@ -14,7 +14,7 @@ import LIQUITY_DEFINITION, { LiquityAppDefinition } from './liquity.definition';
     LiquityAppDefinition,
     LiquityContractFactory,
     EthereumLiquityBalanceFetcher,
-    EthereumLiquityFarmContractPositionFetcher,
+    EthereumLiquityStakingContractPositionFetcher,
     LiquityTroveBalanceHelper,
     LiquityStabilityPoolBalanceHelper,
   ],


### PR DESCRIPTION
## Description

- Renamed liquidity farms group to `staking`
- Added new BAMM pool to b-protocol (liquity adapter)

https://github.com/Zapper-fi/studio/issues/1015

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
