### PR TITLE
fix(spool): Transform percentage values when displaying APY (X*100)

### DIFF
--- a/src/apps/spool/ethereum/spool.vault.contract-position-fetcher.ts
+++ b/src/apps/spool/ethereum/spool.vault.contract-position-fetcher.ts
@@ -189,7 +189,7 @@ export class EthereumSpoolVaultContractPositionFetcher implements PositionFetche
             secondaryLabel: vault.underlying.symbol,
             images: [],
             statsItems: [
-              { label: 'APY', value: buildPercentageDisplayItem(stats.adjustedApy) },
+              { label: 'APY', value: buildPercentageDisplayItem(stats.adjustedApy * 100) },
               { label: 'TVR', value: buildDollarDisplayItem(stats.tvr) },
               { label: 'Risk Model', value: buildStringDisplayItem(riskModels[vault.riskProvider.id] || '') },
               { label: 'Asset', value: buildStringDisplayItem(vault.underlying.symbol) },


### PR DESCRIPTION
## Description

Spool app: fix vault APY percentage display - multiply by 100 to show full percentage instead of 0.xx.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
