### PR TITLE
fix(revert-fi): organize compounding positions as ContractPositions

### DIFF
--- a/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
@@ -1,20 +1,19 @@
 import { Inject } from '@nestjs/common';
 import { getAddress } from 'ethers/lib/utils';
 
-import { drillBalance } from '~app-toolkit';
 import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
 import { Register } from '~app-toolkit/decorators';
 import { presentBalanceFetcherResponse } from '~app-toolkit/helpers/presentation/balance-fetcher-response.present';
 import { UniswapV2ContractFactory } from '~apps/uniswap-v2';
 import { UniswapV3LiquidityTokenHelper } from '~apps/uniswap-v2/helpers/uniswap-v3.liquidity.token-helper';
 import { BalanceFetcher } from '~balance/balance-fetcher.interface';
-import { AppTokenPositionBalance, ContractPositionBalance } from '~position/position-balance.interface';
+import { ContractPositionBalance } from '~position/position-balance.interface';
 import { Network } from '~types/network.interface';
 
 import { accountBalancesQuery, CompoundorAccountBalances } from '../graphql/accountBalancesQuery';
 import { accountCompoundingTokensQuery, CompoundingAccountTokens } from '../graphql/accountCompoundingTokensQuery';
 import { generateGraphUrlForNetwork } from '../graphql/graphUrlGenerator';
-import { getCompoundorContractPosition } from '../helpers/contractPositionParser';
+import { getCompoundingContractPosition, getCompoundorContractPosition } from '../helpers/contractPositionParser';
 import { REVERT_FINANCE_DEFINITION } from '../revert-finance.definition';
 
 const network = Network.ARBITRUM_MAINNET;
@@ -55,7 +54,7 @@ export class ArbitrumRevertFinanceBalanceFetcher implements BalanceFetcher {
     });
     if (!data) return [];
     const multicall = this.appToolkit.getMulticall(network);
-    const compoundingBalances: Array<AppTokenPositionBalance> = [];
+    const compoundingBalances: Array<ContractPositionBalance> = [];
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
     await Promise.all(
       data.tokens.map(async ({ id }) => {
@@ -65,10 +64,7 @@ export class ArbitrumRevertFinanceBalanceFetcher implements BalanceFetcher {
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        compoundingBalances.push({
-          ...drillBalance(uniV3Token, '1'),
-          key: this.appToolkit.getPositionKey(uniV3Token, ['supply']),
-        });
+        compoundingBalances.push(getCompoundingContractPosition(network, uniV3Token));
       }),
     );
     return compoundingBalances;

--- a/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
@@ -65,7 +65,10 @@ export class ArbitrumRevertFinanceBalanceFetcher implements BalanceFetcher {
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        compoundingBalances.push(drillBalance(uniV3Token, '1'));
+        compoundingBalances.push({
+          ...drillBalance(uniV3Token, '1'),
+          key: this.appToolkit.getPositionKey(uniV3Token, ['supply']),
+        });
       }),
     );
     return compoundingBalances;

--- a/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
@@ -65,7 +65,10 @@ export class EthereumRevertFinanceBalanceFetcher implements BalanceFetcher {
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        compoundingBalances.push(drillBalance(uniV3Token, '1'));
+        compoundingBalances.push({
+          ...drillBalance(uniV3Token, '1'),
+          key: this.appToolkit.getPositionKey(uniV3Token, ['supply']),
+        });
       }),
     );
     return compoundingBalances;

--- a/src/apps/revert-finance/helpers/contractPositionParser.ts
+++ b/src/apps/revert-finance/helpers/contractPositionParser.ts
@@ -5,6 +5,7 @@ import { buildDollarDisplayItem } from '~app-toolkit/helpers/presentation/displa
 import { getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
 import { ContractType } from '~position/contract.interface';
 import { ContractPositionBalance } from '~position/position-balance.interface';
+import { AppTokenPosition } from '~position/position.interface';
 import { claimable } from '~position/position.utils';
 import { BaseToken } from '~position/token.interface';
 import { Network } from '~types';
@@ -40,14 +41,21 @@ export const getCompoundorContractPosition = (
   };
 };
 
-// export const getCompoundingContractPosition = (network: Network, uniV3Lp: AppTokenPosition): TokenBalance => ({
-//   ...uniV3Lp,
-//   network,
-//   type: ContractType.APP_TOKEN,
-//   appId: REVERT_FINANCE_DEFINITION.id,
-//   groupId: REVERT_FINANCE_DEFINITION.groups.compoundorRewards.id,
-//   tokens: [...uniV3Lp.tokens],
-//   balanceUSD: uniV3Lp.balanceUSD,
-//   dataProps: uniV3Lp.dataProps,
-//   displayProps: uniV3Lp.displayProps,
-// });
+export const getCompoundingContractPosition = (
+  network: Network,
+  uniV3Lp: AppTokenPosition,
+): ContractPositionBalance => ({
+  address: CompoundorContractAddress,
+  type: ContractType.POSITION,
+  network,
+  appId: REVERT_FINANCE_DEFINITION.id,
+  groupId: REVERT_FINANCE_DEFINITION.groups.compoundingPositions.id,
+  tokens: [{ ...uniV3Lp, ...drillBalance(uniV3Lp, '1') }],
+  balanceUSD: drillBalance(uniV3Lp, '1').balanceUSD,
+  dataProps: {},
+  displayProps: {
+    label: `Compounding ${uniV3Lp.displayProps.label}`,
+    images: [getTokenImg(uniV3Lp.address, network)],
+    statsItems: [],
+  },
+});

--- a/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
@@ -1,20 +1,19 @@
 import { Inject } from '@nestjs/common';
 import { getAddress } from 'ethers/lib/utils';
 
-import { drillBalance } from '~app-toolkit';
 import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
 import { Register } from '~app-toolkit/decorators';
 import { presentBalanceFetcherResponse } from '~app-toolkit/helpers/presentation/balance-fetcher-response.present';
 import { UniswapV2ContractFactory } from '~apps/uniswap-v2';
 import { UniswapV3LiquidityTokenHelper } from '~apps/uniswap-v2/helpers/uniswap-v3.liquidity.token-helper';
 import { BalanceFetcher } from '~balance/balance-fetcher.interface';
-import { AppTokenPositionBalance, ContractPositionBalance } from '~position/position-balance.interface';
+import { ContractPositionBalance } from '~position/position-balance.interface';
 import { Network } from '~types/network.interface';
 
 import { accountBalancesQuery, CompoundorAccountBalances } from '../graphql/accountBalancesQuery';
 import { accountCompoundingTokensQuery, CompoundingAccountTokens } from '../graphql/accountCompoundingTokensQuery';
 import { generateGraphUrlForNetwork } from '../graphql/graphUrlGenerator';
-import { getCompoundorContractPosition } from '../helpers/contractPositionParser';
+import { getCompoundingContractPosition, getCompoundorContractPosition } from '../helpers/contractPositionParser';
 import { REVERT_FINANCE_DEFINITION } from '../revert-finance.definition';
 
 const network = Network.OPTIMISM_MAINNET;
@@ -55,7 +54,7 @@ export class OptimismRevertFinanceBalanceFetcher implements BalanceFetcher {
     });
     if (!data) return [];
     const multicall = this.appToolkit.getMulticall(network);
-    const compoundingBalances: Array<AppTokenPositionBalance> = [];
+    const compoundingBalances: Array<ContractPositionBalance> = [];
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
     await Promise.all(
       data.tokens.map(async ({ id }) => {
@@ -65,10 +64,7 @@ export class OptimismRevertFinanceBalanceFetcher implements BalanceFetcher {
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        compoundingBalances.push({
-          ...drillBalance(uniV3Token, '1'),
-          key: this.appToolkit.getPositionKey(uniV3Token, ['supply']),
-        });
+        compoundingBalances.push(getCompoundingContractPosition(network, uniV3Token));
       }),
     );
     return compoundingBalances;

--- a/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
@@ -65,7 +65,10 @@ export class OptimismRevertFinanceBalanceFetcher implements BalanceFetcher {
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        compoundingBalances.push(drillBalance(uniV3Token, '1'));
+        compoundingBalances.push({
+          ...drillBalance(uniV3Token, '1'),
+          key: this.appToolkit.getPositionKey(uniV3Token, ['supply']),
+        });
       }),
     );
     return compoundingBalances;

--- a/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
@@ -65,7 +65,10 @@ export class PolygonRevertFinanceBalanceFetcher implements BalanceFetcher {
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        compoundingBalances.push(drillBalance(uniV3Token, '1'));
+        compoundingBalances.push({
+          ...drillBalance(uniV3Token, '1'),
+          key: this.appToolkit.getPositionKey(uniV3Token, ['supply']),
+        });
       }),
     );
     return compoundingBalances;

--- a/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
@@ -1,20 +1,19 @@
 import { Inject } from '@nestjs/common';
 import { getAddress } from 'ethers/lib/utils';
 
-import { drillBalance } from '~app-toolkit';
 import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
 import { Register } from '~app-toolkit/decorators';
 import { presentBalanceFetcherResponse } from '~app-toolkit/helpers/presentation/balance-fetcher-response.present';
 import { UniswapV2ContractFactory } from '~apps/uniswap-v2';
 import { UniswapV3LiquidityTokenHelper } from '~apps/uniswap-v2/helpers/uniswap-v3.liquidity.token-helper';
 import { BalanceFetcher } from '~balance/balance-fetcher.interface';
-import { AppTokenPositionBalance, ContractPositionBalance } from '~position/position-balance.interface';
+import { ContractPositionBalance } from '~position/position-balance.interface';
 import { Network } from '~types/network.interface';
 
 import { accountBalancesQuery, CompoundorAccountBalances } from '../graphql/accountBalancesQuery';
 import { accountCompoundingTokensQuery, CompoundingAccountTokens } from '../graphql/accountCompoundingTokensQuery';
 import { generateGraphUrlForNetwork } from '../graphql/graphUrlGenerator';
-import { getCompoundorContractPosition } from '../helpers/contractPositionParser';
+import { getCompoundingContractPosition, getCompoundorContractPosition } from '../helpers/contractPositionParser';
 import { REVERT_FINANCE_DEFINITION } from '../revert-finance.definition';
 
 const network = Network.POLYGON_MAINNET;
@@ -55,7 +54,7 @@ export class PolygonRevertFinanceBalanceFetcher implements BalanceFetcher {
     });
     if (!data) return [];
     const multicall = this.appToolkit.getMulticall(network);
-    const compoundingBalances: Array<AppTokenPositionBalance> = [];
+    const compoundingBalances: Array<ContractPositionBalance> = [];
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
     await Promise.all(
       data.tokens.map(async ({ id }) => {
@@ -65,10 +64,7 @@ export class PolygonRevertFinanceBalanceFetcher implements BalanceFetcher {
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        compoundingBalances.push({
-          ...drillBalance(uniV3Token, '1'),
-          key: this.appToolkit.getPositionKey(uniV3Token, ['supply']),
-        });
+        compoundingBalances.push(getCompoundingContractPosition(network, uniV3Token));
       }),
     );
     return compoundingBalances;


### PR DESCRIPTION
Added IDs to the compounding positions in order to prevent double accounting on bundle page

Checklist
 I have followed the [Contributing Guidelines](https://github.com/Zapper-fi/studio/CONTRIBUTING.md)
 (X) As a contributor, my Ethereum address/ENS is: 0xa03c3fc823457F95ffc3cc7fD5a5133d5AFb850A
 (X) As a contributor, my Twitter handle is: [Clonescody](https://twitter.com/Clonescody)

How to test?

Ethereum : [http://localhost:5001/apps/revert-finance/balances?addresses[]=0x5853ed4f26a3fcea565b3fbc698bb19cdf6deb85&network=ethereum](http://localhost:5001/apps/revert-finance/balances?addresses%5B%5D=0x5853ed4f26a3fcea565b3fbc698bb19cdf6deb85&network=ethereum)
Arbitrum : [http://localhost:5001/apps/revert-finance/balances?addresses[]=0x76d2ddce6b781e66c4b184c82fbf4f94346cfb0d&network=arbitrum](http://localhost:5001/apps/revert-finance/balances?addresses%5B%5D=0x76d2ddce6b781e66c4b184c82fbf4f94346cfb0d&network=arbitrum)
Polygon : [http://localhost:5001/apps/revert-finance/balances?addresses[]=0x3c7c41a500b496ee1961b1966e43248a43e20a9e&network=polygon](http://localhost:5001/apps/revert-finance/balances?addresses%5B%5D=0x3c7c41a500b496ee1961b1966e43248a43e20a9e&network=polygon)
Optimism : [http://localhost:5001/apps/revert-finance/balances?addresses[]=0x7dfdd48508addcc5748454714cf3d808ea1cbd34&network=optimism](http://localhost:5001/apps/revert-finance/balances?addresses%5B%5D=0x7dfdd48508addcc5748454714cf3d808ea1cbd34&network=optimism)