### PR TITLE
fix(synthetix): enable SNX to be exchangeable on optimism

### DIFF
--- a/src/apps/synthetix/optimism/synthetix.synth.token-fetcher.ts
+++ b/src/apps/synthetix/optimism/synthetix.synth.token-fetcher.ts
@@ -20,6 +20,7 @@ export class OptimismSynthetixSynthTokenFetcher implements PositionFetcher<AppTo
     return this.tokenHelper.getTokens({
       network,
       resolverAddress: '0x95a6a3f44a70172e7d50a9e28c85dfd712756b8c',
+      exchangeable: true,
     });
   }
 }


### PR DESCRIPTION
## Description

- Enabled SNX to be exchangeable on Optimism

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
