### PR TITLE
fix(revert-fi): add IDs to distinguish compounding positions 

### DIFF
--- a/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
@@ -69,7 +69,11 @@ export class ArbitrumRevertFinanceBalanceFetcher implements BalanceFetcher {
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        compoundingBalances.push(getCompoundingContractPosition(network, uniV3Token));
+        const position = getCompoundingContractPosition(network, uniV3Token);
+        compoundingBalances.push({
+          key: this.appToolkit.getPositionKey(position),
+          ...position,
+        });
       }),
     );
     return compoundingBalances;

--- a/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
@@ -69,7 +69,11 @@ export class EthereumRevertFinanceBalanceFetcher implements BalanceFetcher {
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        compoundingBalances.push(getCompoundingContractPosition(network, uniV3Token));
+        const position = getCompoundingContractPosition(network, uniV3Token);
+        compoundingBalances.push({
+          key: this.appToolkit.getPositionKey(position),
+          ...position,
+        });
       }),
     );
     return compoundingBalances;

--- a/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
@@ -69,7 +69,11 @@ export class OptimismRevertFinanceBalanceFetcher implements BalanceFetcher {
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        compoundingBalances.push(getCompoundingContractPosition(network, uniV3Token));
+        const position = getCompoundingContractPosition(network, uniV3Token);
+        compoundingBalances.push({
+          key: this.appToolkit.getPositionKey(position),
+          ...position,
+        });
       }),
     );
     return compoundingBalances;

--- a/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
@@ -69,7 +69,11 @@ export class PolygonRevertFinanceBalanceFetcher implements BalanceFetcher {
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        compoundingBalances.push(getCompoundingContractPosition(network, uniV3Token));
+        const position = getCompoundingContractPosition(network, uniV3Token);
+        compoundingBalances.push({
+          key: this.appToolkit.getPositionKey(position),
+          ...position,
+        });
       }),
     );
     return compoundingBalances;


### PR DESCRIPTION
Added IDs to the compounding positions in order to prevent double accounting on the bundle page

Checklist
 (X) I have followed the [Contributing Guidelines](https://github.com/Zapper-fi/studio/CONTRIBUTING.md)
 (X) As a contributor, my Ethereum address/ENS is: 0xa03c3fc823457F95ffc3cc7fD5a5133d5AFb850A
 (X) As a contributor, my Twitter handle is: [Clonescody](https://twitter.com/Clonescody)

How to test?

Need to test the bundle page, all individual pages are fine 

Previous test addresses 

- Ethereum : [http://localhost:5001/apps/revert-finance/balances?addresses[]=0x5853ed4f26a3fcea565b3fbc698bb19cdf6deb85&network=ethereum](http://localhost:5001/apps/revert-finance/balances?addresses%5B%5D=0x5853ed4f26a3fcea565b3fbc698bb19cdf6deb85&network=ethereum)
- Arbitrum : [http://localhost:5001/apps/revert-finance/balances?addresses[]=0x76d2ddce6b781e66c4b184c82fbf4f94346cfb0d&network=arbitrum](http://localhost:5001/apps/revert-finance/balances?addresses%5B%5D=0x76d2ddce6b781e66c4b184c82fbf4f94346cfb0d&network=arbitrum)
- Polygon : [http://localhost:5001/apps/revert-finance/balances?addresses[]=0x3c7c41a500b496ee1961b1966e43248a43e20a9e&network=polygon](http://localhost:5001/apps/revert-finance/balances?addresses%5B%5D=0x3c7c41a500b496ee1961b1966e43248a43e20a9e&network=polygon)
- Optimism : [http://localhost:5001/apps/revert-finance/balances?addresses[]=0x7dfdd48508addcc5748454714cf3d808ea1cbd34&network=optimism](http://localhost:5001/apps/revert-finance/balances?addresses%5B%5D=0x7dfdd48508addcc5748454714cf3d808ea1cbd34&network=optimism)