### PR TITLE
fix: Fixed existingToken test on Revert

### DIFF
--- a/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
@@ -44,7 +44,7 @@ export class ArbitrumRevertFinanceBalanceFetcher implements BalanceFetcher {
     const accountRewardsBalances: Array<TokenBalance> = [];
     data.accountBalances.forEach(({ token, balance }) => {
       const existingToken = baseTokens.find(item => item.address === token)!;
-      if (!token) return [];
+      if (!existingToken) return;
       accountRewardsBalances.push({ ...existingToken, ...drillBalance(claimable(existingToken), balance) });
     });
     return [getCompoundorRewardsContractPosition(network, accountRewardsBalances)];

--- a/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
@@ -44,7 +44,7 @@ export class EthereumRevertFinanceBalanceFetcher implements BalanceFetcher {
     const accountRewardsBalances: Array<TokenBalance> = [];
     data.accountBalances.forEach(({ token, balance }) => {
       const existingToken = baseTokens.find(item => item.address === token)!;
-      if (!token) return [];
+      if (!existingToken) return;
       accountRewardsBalances.push({ ...existingToken, ...drillBalance(claimable(existingToken), balance) });
     });
     return [getCompoundorRewardsContractPosition(network, accountRewardsBalances)];

--- a/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
@@ -44,7 +44,7 @@ export class OptimismRevertFinanceBalanceFetcher implements BalanceFetcher {
     const accountRewardsBalances: Array<TokenBalance> = [];
     data.accountBalances.forEach(({ token, balance }) => {
       const existingToken = baseTokens.find(item => item.address === token)!;
-      if (!token) return [];
+      if (!existingToken) return;
       accountRewardsBalances.push({ ...existingToken, ...drillBalance(claimable(existingToken), balance) });
     });
     return [getCompoundorRewardsContractPosition(network, accountRewardsBalances)];

--- a/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
@@ -44,7 +44,7 @@ export class PolygonRevertFinanceBalanceFetcher implements BalanceFetcher {
     const accountRewardsBalances: Array<TokenBalance> = [];
     data.accountBalances.forEach(({ token, balance }) => {
       const existingToken = baseTokens.find(item => item.address === token)!;
-      if (!token) return [];
+      if (!existingToken) return;
       accountRewardsBalances.push({ ...existingToken, ...drillBalance(claimable(existingToken), balance) });
     });
     return [getCompoundorRewardsContractPosition(network, accountRewardsBalances)];


### PR DESCRIPTION
## Description

Fix a test on the existing token, was failing and causing an empty response on Optimism

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: 0xa03c3fc823457F95ffc3cc7fD5a5133d5AFb850A
- [X] (optional) As a contributor, my Twitter handle is:  [Clonescody](https://twitter.com/Clonescody)

## How to test?

App id `revert-finance`

This address currently displays no claimable balance on Optimism.
https://zapper.fi/account/0x89b579d25f8ebc6476dd9eb2d8c4e02b406a8904

After fix : [http://localhost:5001/apps/revert-finance/balances?addresses[]=0x89B579D25F8ebc6476Dd9EB2D8C4e02b406A8904&network=optimism](http://localhost:5001/apps/revert-finance/balances?addresses[]=0x89B579D25F8ebc6476Dd9EB2D8C4e02b406A8904&network=optimism)

Not be too tired 