### PR TITLE
fix(revert-fi): added IDs to NFTs LPs

### DIFF
--- a/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
@@ -75,7 +75,7 @@ export class ArbitrumRevertFinanceBalanceFetcher implements BalanceFetcher {
         };
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
-          key: this.appToolkit.getPositionKey(position),
+          key: this.appToolkit.getPositionKey(position, ['compoundingPositionId']),
           ...position,
         });
       }),

--- a/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
@@ -63,12 +63,16 @@ export class ArbitrumRevertFinanceBalanceFetcher implements BalanceFetcher {
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
     await Promise.all(
       data.tokens.map(async ({ id }) => {
-        const uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
+        let uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
           positionId: id,
           network,
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
+        uniV3Token = {
+          ...uniV3Token,
+          key: this.appToolkit.getPositionKey(uniV3Token),
+        };
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
           key: this.appToolkit.getPositionKey(position),

--- a/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
@@ -63,16 +63,12 @@ export class ArbitrumRevertFinanceBalanceFetcher implements BalanceFetcher {
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
     await Promise.all(
       data.tokens.map(async ({ id }) => {
-        let uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
+        const uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
           positionId: id,
           network,
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        uniV3Token = {
-          ...uniV3Token,
-          key: this.appToolkit.getPositionKey(uniV3Token),
-        };
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
           key: this.appToolkit.getPositionKey(position, ['compoundingPositionId']),

--- a/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
@@ -75,7 +75,7 @@ export class EthereumRevertFinanceBalanceFetcher implements BalanceFetcher {
         };
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
-          key: this.appToolkit.getPositionKey(position),
+          key: this.appToolkit.getPositionKey(position, ['compoundingPositionId']),
           ...position,
         });
       }),

--- a/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
@@ -63,16 +63,12 @@ export class EthereumRevertFinanceBalanceFetcher implements BalanceFetcher {
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
     await Promise.all(
       data.tokens.map(async ({ id }) => {
-        let uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
+        const uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
           positionId: id,
           network,
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        uniV3Token = {
-          ...uniV3Token,
-          key: this.appToolkit.getPositionKey(uniV3Token),
-        };
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
           key: this.appToolkit.getPositionKey(position, ['compoundingPositionId']),

--- a/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
@@ -63,12 +63,16 @@ export class EthereumRevertFinanceBalanceFetcher implements BalanceFetcher {
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
     await Promise.all(
       data.tokens.map(async ({ id }) => {
-        const uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
+        let uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
           positionId: id,
           network,
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
+        uniV3Token = {
+          ...uniV3Token,
+          key: this.appToolkit.getPositionKey(uniV3Token),
+        };
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
           key: this.appToolkit.getPositionKey(position),

--- a/src/apps/revert-finance/helpers/contractPositionParser.ts
+++ b/src/apps/revert-finance/helpers/contractPositionParser.ts
@@ -20,7 +20,7 @@ export const getCompoundorRewardsContractPosition = (
   network,
   appId: REVERT_FINANCE_DEFINITION.id,
   groupId: REVERT_FINANCE_DEFINITION.groups.compoundorRewards.id,
-  tokens,
+  tokens: tokens.sort((a, b) => b.balanceUSD - a.balanceUSD),
   balanceUSD: tokens.reduce((a, token) => a + token.balanceUSD, 0),
   dataProps: {},
   displayProps: {

--- a/src/apps/revert-finance/helpers/contractPositionParser.ts
+++ b/src/apps/revert-finance/helpers/contractPositionParser.ts
@@ -41,7 +41,9 @@ export const getCompoundingContractPosition = (
   groupId: REVERT_FINANCE_DEFINITION.groups.compoundingPositions.id,
   tokens: [{ ...uniV3Lp, ...drillBalance(uniV3Lp, '1') }],
   balanceUSD: drillBalance(uniV3Lp, '1').balanceUSD,
-  dataProps: {},
+  dataProps: {
+    compoundingPositionId: uniV3Lp.dataProps.id,
+  },
   displayProps: {
     label: `Compounding ${uniV3Lp.displayProps.label}`,
     images: [getTokenImg(uniV3Lp.address, network)],

--- a/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
@@ -75,7 +75,7 @@ export class OptimismRevertFinanceBalanceFetcher implements BalanceFetcher {
         };
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
-          key: this.appToolkit.getPositionKey(position),
+          key: this.appToolkit.getPositionKey(position, ['compoundingPositionId']),
           ...position,
         });
       }),

--- a/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
@@ -63,12 +63,16 @@ export class OptimismRevertFinanceBalanceFetcher implements BalanceFetcher {
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
     await Promise.all(
       data.tokens.map(async ({ id }) => {
-        const uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
+        let uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
           positionId: id,
           network,
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
+        uniV3Token = {
+          ...uniV3Token,
+          key: this.appToolkit.getPositionKey(uniV3Token),
+        };
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
           key: this.appToolkit.getPositionKey(position),

--- a/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
@@ -63,16 +63,12 @@ export class OptimismRevertFinanceBalanceFetcher implements BalanceFetcher {
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
     await Promise.all(
       data.tokens.map(async ({ id }) => {
-        let uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
+        const uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
           positionId: id,
           network,
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        uniV3Token = {
-          ...uniV3Token,
-          key: this.appToolkit.getPositionKey(uniV3Token),
-        };
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
           key: this.appToolkit.getPositionKey(position, ['compoundingPositionId']),

--- a/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
@@ -75,7 +75,7 @@ export class PolygonRevertFinanceBalanceFetcher implements BalanceFetcher {
         };
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
-          key: this.appToolkit.getPositionKey(position),
+          key: this.appToolkit.getPositionKey(position, ['compoundingPositionId']),
           ...position,
         });
       }),

--- a/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
@@ -63,16 +63,12 @@ export class PolygonRevertFinanceBalanceFetcher implements BalanceFetcher {
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
     await Promise.all(
       data.tokens.map(async ({ id }) => {
-        let uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
+        const uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
           positionId: id,
           network,
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
-        uniV3Token = {
-          ...uniV3Token,
-          key: this.appToolkit.getPositionKey(uniV3Token),
-        };
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
           key: this.appToolkit.getPositionKey(position, ['compoundingPositionId']),

--- a/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
@@ -63,12 +63,16 @@ export class PolygonRevertFinanceBalanceFetcher implements BalanceFetcher {
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
     await Promise.all(
       data.tokens.map(async ({ id }) => {
-        const uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
+        let uniV3Token = await this.uniswapV3LiquidityTokenHelper.getLiquidityToken({
           positionId: id,
           network,
           context: { multicall, baseTokens },
         });
         if (!uniV3Token) return;
+        uniV3Token = {
+          ...uniV3Token,
+          key: this.appToolkit.getPositionKey(uniV3Token),
+        };
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
           key: this.appToolkit.getPositionKey(position),

--- a/src/apps/uniswap-v2/helpers/uniswap-v3.liquidity.token-helper.ts
+++ b/src/apps/uniswap-v2/helpers/uniswap-v3.liquidity.token-helper.ts
@@ -92,6 +92,7 @@ export class UniswapV3LiquidityTokenHelper {
     const decimals = 0;
 
     const dataProps = {
+      id: positionId,
       rangeStart: range[0],
       rangeEnd: range[1],
     };
@@ -102,7 +103,7 @@ export class UniswapV3LiquidityTokenHelper {
       statsItems: [{ label: 'Liquidity', value: buildDollarDisplayItem(Number(liquidity)) }],
     };
 
-    const token: AppTokenPosition<UniswapV3LiquidityTokenDataProps> = {
+    let token: AppTokenPosition<UniswapV3LiquidityTokenDataProps> = {
       address: tokenAddress,
       type: ContractType.APP_TOKEN,
       appId: 'uniswap-v3',
@@ -117,7 +118,10 @@ export class UniswapV3LiquidityTokenHelper {
       dataProps,
       displayProps,
     };
-
+    token = {
+      ...token,
+      key: this.appToolkit.getPositionKey(token, ['id']),
+    };
     return token;
   }
 }


### PR DESCRIPTION
## Description

Added IDs to Uni v3 NFTs so the bundle page doesn't consolidate them all under a single LP.
Also sorted compoundor rewards by balanceUSD

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: 0xa03c3fc823457F95ffc3cc7fD5a5133d5AFb850A
- [X] (optional) As a contributor, my Twitter handle is: [Clonescody](https://twitter.com/Clonescody)

## How to test?

Can only test the bundled page in prod, IDs are well returned in the response.
