### PR TITLE
fix(spool): vault locally calculated base APY to [0, 1.0]

### DIFF
--- a/src/apps/spool/ethereum/spool.vault.contract-position-fetcher.ts
+++ b/src/apps/spool/ethereum/spool.vault.contract-position-fetcher.ts
@@ -240,7 +240,7 @@ export class EthereumSpoolVaultContractPositionFetcher implements PositionFetche
       .map(strategy => parseFloat(strategy.allocation) * strategyAnalytics[strategy.strategy.id][0].apy)
       .reduce((a, b) => a + b, 0);
 
-    const apy = stats.apy || baseApy;
+    const apy = stats.apy || (baseApy / 100.0);
     const tvr = parseFloat(stats.tvr);
 
     const incentivizedApy = Object.values(rewardAnalytics[vault.id] || {})


### PR DESCRIPTION
## Description

Locally calculated base APY (used as a fallback) normalised to [0, 1.0].

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
