### PR TITLE
feat(positions): Separate balance fetching from hydration in position fetchers

### DIFF
--- a/src/app-toolkit/helpers/balance/token-balance.helper.ts
+++ b/src/app-toolkit/helpers/balance/token-balance.helper.ts
@@ -32,8 +32,8 @@ type Options = {
 
 type InferHasMetaType<T, B> = T extends WithMetaType<T> ? WithMetaType<B> : B;
 
-type InferTokenBalanceType<T> = T extends AppTokenPosition
-  ? InferHasMetaType<T, AppTokenPositionBalance>
+type InferTokenBalanceType<T, V = DefaultDataProps> = T extends AppTokenPosition
+  ? InferHasMetaType<T, AppTokenPositionBalance<V>>
   : T extends BaseToken
   ? InferHasMetaType<T, BaseTokenBalance>
   : never;
@@ -51,17 +51,17 @@ export const getContractPositionFromToken = <T>(
   return contractPosition;
 };
 
-export const drillBalance = <T extends Token>(
+export const drillBalance = <T extends Token, V = DefaultDataProps>(
   token: T,
   balanceRaw: string,
   options: Options = {},
-): InferTokenBalanceType<T> => {
+): InferTokenBalanceType<T, V> => {
   const balance = Number(balanceRaw) / 10 ** token.decimals;
   const balanceUSD = balance * token.price * (options.isDebt ? -1 : 1);
 
   if (token.type === ContractType.BASE_TOKEN || token.type === ContractType.NON_FUNGIBLE_TOKEN) {
     const tokenWithBalance = { ...(token as BaseToken), balance, balanceRaw, balanceUSD };
-    return tokenWithBalance as unknown as InferTokenBalanceType<T>;
+    return tokenWithBalance as unknown as InferTokenBalanceType<T, V>;
   }
 
   // Token share stats item
@@ -97,7 +97,7 @@ export const drillBalance = <T extends Token>(
     },
   };
 
-  return tokenWithBalance as unknown as InferTokenBalanceType<T>;
+  return tokenWithBalance as unknown as InferTokenBalanceType<T, V>;
 };
 
 @Injectable()

--- a/src/position/position-balance.interface.ts
+++ b/src/position/position-balance.interface.ts
@@ -22,5 +22,17 @@ export interface ContractPositionBalance<T = DefaultDataProps> extends ContractP
   balanceUSD: number;
 }
 
+export type RawTokenBalance = {
+  key: string;
+  balance: string;
+};
+
+export type RawAppTokenBalance = RawTokenBalance;
+
+export type RawContractPositionBalance = {
+  key: string;
+  tokens: RawTokenBalance[];
+};
+
 export type TokenBalance = BaseTokenBalance | AppTokenPositionBalance | NonFungibleTokenBalance;
 export type PositionBalance<T = DefaultDataProps> = ContractPositionBalance<T> | AppTokenPositionBalance<T>;

--- a/src/position/position-fetcher.template-registry.ts
+++ b/src/position/position-fetcher.template-registry.ts
@@ -46,8 +46,16 @@ export class PositionFetcherTemplateRegistry implements OnModuleInit {
     return this.appTokenTemplateRegistry.get(appId)?.get(network)?.get(groupId) ?? null;
   }
 
+  getAppTokenTemplates({ network, appId }: { network: Network; appId: string }) {
+    return Array.from(this.appTokenTemplateRegistry.get(appId)?.get(network)?.values() ?? []);
+  }
+
   getContractPositionTemplate({ network, appId, groupId }: { network: Network; appId: string; groupId: string }) {
     return this.contractPositionTemplateRegistry.get(appId)?.get(network)?.get(groupId) ?? null;
+  }
+
+  getContractPositionTemplates({ network, appId }: { network: Network; appId: string }) {
+    return Array.from(this.contractPositionTemplateRegistry.get(appId)?.get(network)?.values() ?? []);
   }
 
   getTemplatesForApp(appId: string) {

--- a/src/position/template/app-token.template.position-fetcher.ts
+++ b/src/position/template/app-token.template.position-fetcher.ts
@@ -13,7 +13,7 @@ import { IMulticallWrapper } from '~multicall';
 import { isMulticallUnderlyingError } from '~multicall/multicall.ethers';
 import { ContractType } from '~position/contract.interface';
 import { DefaultDataProps, DisplayProps, StatsItem } from '~position/display.interface';
-import { AppTokenPositionBalance } from '~position/position-balance.interface';
+import { AppTokenPositionBalance, RawAppTokenBalance } from '~position/position-balance.interface';
 import { PositionFetcher } from '~position/position-fetcher.interface';
 import { AppTokenPosition } from '~position/position.interface';
 import { Network } from '~types/network.interface';
@@ -279,7 +279,7 @@ export abstract class AppTokenTemplatePositionFetcher<
     multicall,
   }: {
     address: string;
-    appToken: AppTokenPosition<V>;
+    appToken: AppTokenPosition;
     multicall: IMulticallWrapper;
   }): Promise<BigNumberish> {
     return multicall.wrap(this.getContract(appToken.address)).balanceOf(address);
@@ -302,5 +302,38 @@ export abstract class AppTokenTemplatePositionFetcher<
     );
 
     return balances as AppTokenPositionBalance<V>[];
+  }
+
+  async getRawBalances(address: string): Promise<RawAppTokenBalance[]> {
+    const multicall = this.appToolkit.getMulticall(this.network);
+    const appTokens = await this.appToolkit.getAppTokenPositions({
+      appId: this.appId,
+      network: this.network,
+      groupIds: [this.groupId],
+    });
+
+    return Promise.all(
+      appTokens.map(async appToken => ({
+        key: this.appToolkit.getPositionKey(appToken),
+        balance: (await this.getBalancePerToken({ multicall, address, appToken })).toString(),
+      })),
+    );
+  }
+
+  async drillRawBalances(balances: RawAppTokenBalance[]): Promise<AppTokenPositionBalance<V>[]> {
+    const appTokens = await this.appToolkit.getAppTokenPositions<V>({
+      appId: this.appId,
+      network: this.network,
+      groupIds: [this.groupId],
+    });
+
+    return compact(
+      appTokens.map(token => {
+        const tokenBalance = balances.find(b => b.key === this.appToolkit.getPositionKey(token));
+        if (!tokenBalance) return null;
+
+        return drillBalance<typeof token, V>(token, tokenBalance.balance);
+      }),
+    );
   }
 }


### PR DESCRIPTION
## Description

Provides a way to fetch the app token and contract position balances without returning the entire asset so that the drilling/presentation can happen at a different time than the web3 calls.

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
