### PR TITLE
fix(kwenta): display when no position open

### DIFF
--- a/src/apps/kwenta/optimism/kwenta.perp.contract-position-fetcher.ts
+++ b/src/apps/kwenta/optimism/kwenta.perp.contract-position-fetcher.ts
@@ -137,12 +137,16 @@ export class OptimismKwentaPerpContractPositionFetcher extends ContractPositionT
 
   private async getEnrichedDisplayItems({ address, contract }) {
     const position = await contract.positions(address);
+    const positionSizeRaw = Number(position.size);
+    if (positionSizeRaw === 0) {
+      return [];
+    }
     const liquidationPriceRaw = await contract.liquidationPrice(address);
     const pnlRaw = await contract.profitLoss(address);
     const notionalValueRaw = await contract.notionalValue(address);
     return [
-      { label: 'Side', ...buildStringDisplayItem(Number(position.size) > 0 ? 'LONG' : 'SHORT') },
-      { label: 'Size', ...buildNumberDisplayItem(Number(position.size) / 10 ** 18) },
+      { label: 'Side', ...buildStringDisplayItem(positionSizeRaw > 0 ? 'LONG' : 'SHORT') },
+      { label: 'Size', ...buildNumberDisplayItem(positionSizeRaw / 10 ** 18) },
       { label: 'Notional Value', ...buildDollarDisplayItem(Number(notionalValueRaw.value) / 10 ** 18) },
       { label: 'PnL', ...buildDollarDisplayItem(Number(pnlRaw.pnl) / 10 ** 18) },
       { label: 'Last Price', ...buildDollarDisplayItem(Number(position.lastPrice) / 10 ** 18) },


### PR DESCRIPTION
## Description

Do not add enriched display if there is no open position (only margin deposited)

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: gaulois.eth
- [X] (optional) As a contributor, my Twitter handle is: @pseudo__alakon

## How to test?

Test address: 
Position open, enriched display:
0xcd1d321485f74d740988f691276971f01073103b
No position open, no enriched display: 
0x324Fbd9536bf3d77d36137310fd4abe5130DfEA9