### PR TITLE
fix(dhedge-v2): polygon vaults underlying tokens

### DIFF
--- a/src/apps/dhedge-v2/polygon/dhedge-v2.pool.token-fetcher.ts
+++ b/src/apps/dhedge-v2/polygon/dhedge-v2.pool.token-fetcher.ts
@@ -46,7 +46,7 @@ export class PolygonDhedgeV2PoolTokenFetcher implements PositionFetcher<AppToken
   constructor(
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
     @Inject(DhedgeV2ContractFactory) private readonly contractFactory: DhedgeV2ContractFactory,
-  ) {}
+  ) { }
 
   async getPositions() {
     const endpoint = 'https://api.thegraph.com/subgraphs/name/dhedge/dhedge-v2-polygon';
@@ -69,7 +69,7 @@ export class PolygonDhedgeV2PoolTokenFetcher implements PositionFetcher<AppToken
         ]);
         const supply = Number(supplyRaw) / 10 ** decimals;
         const tokens = filter(
-          pool.assets.map(asset => baseTokens.find(t => t.address === asset.id.toLowerCase())),
+          pool.assets.map(asset => baseTokens.find(t => t.address === asset.id.toLowerCase().split("-").pop())),
         ) as BaseToken[];
         const pricePerShare = Number(pool.tokenPrice) / 10 ** decimals;
         const price = pricePerShare * dUSD.price;


### PR DESCRIPTION
## Description

Graph query gives underlying assets with following format:
{vaultAddress}-{underlyingAssetAdress}
Only second part must be kept.

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: gaulois.eth
- [X] (optional) As a contributor, my Twitter handle is: @pseudo__alakon

## How to test?

address holding USDt bear tokens
0xc6a21511ebd02525cf94bd1dd379fde007550dea
