### PR TITLE
fix(synthetix): use new synths logos

### DIFF
--- a/src/apps/synthetix/helpers/synthetix.loan.contract-position-helper.ts
+++ b/src/apps/synthetix/helpers/synthetix.loan.contract-position-helper.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 
 import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
 import { ZERO_ADDRESS } from '~app-toolkit/constants/address';
-import { getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
+import { getTokenImg, getAppAssetImage } from '~app-toolkit/helpers/presentation/image.present';
 import { ContractType } from '~position/contract.interface';
 import { ContractPosition } from '~position/position.interface';
 import { borrowed, supplied } from '~position/position.utils';
@@ -15,9 +15,11 @@ export type SynthetixLoanContractPositionHelperParams = {
   network: Network;
 };
 
+const appId = SYNTHETIX_DEFINITION.id;
+
 @Injectable()
 export class SynthetixLoanContractPositionHelper {
-  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
+  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) { }
 
   async getPositions({ loanContractAddress, network }: SynthetixLoanContractPositionHelperParams) {
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
@@ -31,8 +33,8 @@ export class SynthetixLoanContractPositionHelper {
     const label = SYNTHETIX_DEFINITION.groups.loan.label;
     const images = [
       getTokenImg(ethToken.address, network),
-      getTokenImg(susdToken.address, network),
-      getTokenImg(sethToken.address, network),
+      getAppAssetImage(appId, susdToken.symbol),
+      getAppAssetImage(appId, sethToken.symbol)
     ];
 
     const position: ContractPosition = {

--- a/src/apps/synthetix/helpers/synthetix.mintr.contract-position-helper.ts
+++ b/src/apps/synthetix/helpers/synthetix.mintr.contract-position-helper.ts
@@ -3,7 +3,7 @@ import { sumBy } from 'lodash';
 
 import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
 import { buildDollarDisplayItem } from '~app-toolkit/helpers/presentation/display-item.present';
-import { getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
+import { getTokenImg, getAppAssetImage } from '~app-toolkit/helpers/presentation/image.present';
 import { ContractType } from '~position/contract.interface';
 import { ContractPosition } from '~position/position.interface';
 import { borrowed, supplied } from '~position/position.utils';
@@ -23,9 +23,11 @@ export type SynthetixMintrContractPositionHelperParams = {
   network: Network;
 };
 
+const appId = SYNTHETIX_DEFINITION.id;
+
 @Injectable()
 export class SynthetixMintrContractPositionHelper {
-  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) {}
+  constructor(@Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit) { }
 
   async getPositions({ holders, network }: SynthetixMintrContractPositionHelperParams) {
     const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
@@ -37,7 +39,7 @@ export class SynthetixMintrContractPositionHelper {
     // Display Props
     const label = 'SNX Staking';
     const secondaryLabel = buildDollarDisplayItem(snxToken.price);
-    const images = [getTokenImg(snxToken.address, network), getTokenImg(susdToken.address, network)];
+    const images = [getTokenImg(snxToken.address, network), getAppAssetImage(appId, susdToken.symbol)];
     const liquidity = sumBy(holders, v => (Number(v.collateral) - Number(v.transferable)) * snxToken.price);
 
     const position: ContractPosition = {


### PR DESCRIPTION
## Description

use new synths logo in loan and mintr groups

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: gaulois.eth
- [X] (optional) As a contributor, my Twitter handle is: @pseudo__alakon

## How to test?

address with staked SNX and loans on OP:
0x99d9cc5240b11c986037f5d010a405ac65e140c9
