### PR TITLE
fix(synthetix): synths price

### DIFF
--- a/src/apps/synthetix/helpers/synthetix.synth.token-helper.ts
+++ b/src/apps/synthetix/helpers/synthetix.synth.token-helper.ts
@@ -46,6 +46,9 @@ export class SynthetixSynthTokenHelper {
     const synthRates = await snxUtilsContract.synthsRates();
     const synthSymbolBytes = synthRates[0];
     const synthPrices = synthRates[1];
+    const baseTokens = await this.appToolkit.getBaseTokenPrices(network);
+    const susdToken = baseTokens.find(p => p.symbol === 'sUSD')!;
+    const susdMarketPice = susdToken.price;
 
     const tokens = await Promise.all(
       synthSymbolBytes.map(async (byte, i) => {
@@ -58,7 +61,7 @@ export class SynthetixSynthTokenHelper {
         const supplyRaw = await multicall.wrap(synthContract).totalSupply();
         const address = addressRaw.toLowerCase();
         const supply = Number(supplyRaw) / 10 ** decimals;
-        const price = Number(synthPrices[i]) / 10 ** decimals;
+        const price = Number(synthPrices[i]) * susdMarketPice / 10 ** decimals;
         const pricePerShare = 1;
         const tokens = [];
         const liquidity = supply * price;


### PR DESCRIPTION
## Description

Current code assume 1 sUSD = $1
We need to multiply synthRates by sUSD market price to take synth price premium (or discount) into account

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: gaulois.eth
- [X] (optional) As a contributor, my Twitter handle is: @pseudo__alakon

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->

This address holds sUSD on OP: 0x324Fbd9536bf3d77d36137310fd4abe5130DfEA9
