### PR TITLE
fix(arth): Fix missing override to token definitions

### DIFF
--- a/src/apps/arth/ethereum/arth.stability-pool.contract-position-fetcher.ts
+++ b/src/apps/arth/ethereum/arth.stability-pool.contract-position-fetcher.ts
@@ -30,7 +30,7 @@ export class EthereumArthStabilityPoolContractPositionFetcher extends ContractPo
     return [{ address: '0x2c360b513ae52947eeb37cfad57ac9b7c9373e1b' }];
   }
 
-  async getTokenDescriptors() {
+  async getTokenDefinitions() {
     return [
       { metaType: MetaType.SUPPLIED, address: '0x8cc0f052fff7ead7f2edcccac895502e884a8a71' }, // ARTH
       { metaType: MetaType.CLAIMABLE, address: ZERO_ADDRESS }, // ETH

--- a/src/apps/arth/ethereum/arth.trove.contract-position-fetcher.ts
+++ b/src/apps/arth/ethereum/arth.trove.contract-position-fetcher.ts
@@ -29,7 +29,7 @@ export class EthereumArthTroveContractPositionFetcher extends ContractPositionTe
     return [{ address: '0xf4ed5d0c3c977b57382fabbea441a63faaf843d3' }];
   }
 
-  async getTokenDescriptors() {
+  async getTokenDefinitions() {
     return [
       { metaType: MetaType.SUPPLIED, address: ZERO_ADDRESS }, // ETH
       { metaType: MetaType.BORROWED, address: '0x8cc0f052fff7ead7f2edcccac895502e884a8a71' }, // ARTH

--- a/src/position/template/contract-position.template.position-fetcher.ts
+++ b/src/position/template/contract-position.template.position-fetcher.ts
@@ -52,9 +52,7 @@ export abstract class ContractPositionTemplatePositionFetcher<
   abstract getContract(address: string): T;
 
   // 3. Get token definitions (supplied tokens, borrowed tokens, claimable tokens, etc.)
-  async getTokenDefinitions(_params: GetTokenDefinitionsParams<T, R>): Promise<UnderlyingTokenDefinition[] | null> {
-    return [];
-  }
+  abstract getTokenDefinitions(_params: GetTokenDefinitionsParams<T, R>): Promise<UnderlyingTokenDefinition[] | null>;
 
   // 4. Get additional data properties
   async getDataProps(_params: GetDataPropsParams<T, V, R>): Promise<V> {


### PR DESCRIPTION
## Description

- `getTokenDescriptors` was renamed to `getTokenDefinitions`
- Make it abstract in the base class so TS catches it

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
