### PR TITLE
fix(mean-finance): find apptokens first and then basetokens

### DIFF
--- a/src/apps/mean-finance/optimism/mean-finance.balance-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.balance-fetcher.ts
@@ -38,7 +38,7 @@ export class OptimismMeanFinanceBalanceFetcher implements BalanceFetcher {
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
     @Inject(MeanFinanceContractFactory)
     private readonly meanFinanceContractFactory: MeanFinanceContractFactory,
-  ) {}
+  ) { }
 
   async getUserPositions(address: string, version: PositionVersions) {
     const graphHelper = this.appToolkit.helpers.theGraphHelper;
@@ -61,7 +61,7 @@ export class OptimismMeanFinanceBalanceFetcher implements BalanceFetcher {
       network,
     });
 
-    const allTokens = [...baseTokens, ...appTokens];
+    const allTokens = [...appTokens, ...baseTokens];
 
     const amountsToFetch: { tokenFrom: string; tokenTo: string; amount: string; positionId: string }[] = [];
 
@@ -133,9 +133,8 @@ export class OptimismMeanFinanceBalanceFetcher implements BalanceFetcher {
       let label = '';
 
       if (remainingSwaps > 0) {
-        label = `Swapping ~${formattedRate} ${fromToUse.symbol}${
-          hasYieldFrom ? ' + yield' : ''
-        } ${swapIntervalAdverb} to ${toToUse.symbol}`;
+        label = `Swapping ~${formattedRate} ${fromToUse.symbol}${hasYieldFrom ? ' + yield' : ''
+          } ${swapIntervalAdverb} to ${toToUse.symbol}`;
       } else {
         label = `Swapping ${fromToUse.symbol} to ${toToUse.symbol}`;
       }

--- a/src/apps/mean-finance/polygon/mean-finance.balance-fetcher.ts
+++ b/src/apps/mean-finance/polygon/mean-finance.balance-fetcher.ts
@@ -38,7 +38,7 @@ export class PolygonMeanFinanceBalanceFetcher implements BalanceFetcher {
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
     @Inject(MeanFinanceContractFactory)
     private readonly meanFinanceContractFactory: MeanFinanceContractFactory,
-  ) {}
+  ) { }
 
   async getUserPositions(address: string, version: PositionVersions) {
     const graphHelper = this.appToolkit.helpers.theGraphHelper;
@@ -61,7 +61,7 @@ export class PolygonMeanFinanceBalanceFetcher implements BalanceFetcher {
       network,
     });
 
-    const allTokens = [...baseTokens, ...appTokens];
+    const allTokens = [...appTokens, ...baseTokens];
 
     const amountsToFetch: { tokenFrom: string; tokenTo: string; amount: string; positionId: string }[] = [];
 
@@ -133,9 +133,8 @@ export class PolygonMeanFinanceBalanceFetcher implements BalanceFetcher {
       let label = '';
 
       if (remainingSwaps > 0) {
-        label = `Swapping ~${formattedRate} ${fromToUse.symbol}${
-          hasYieldFrom ? ' + yield' : ''
-        } ${swapIntervalAdverb} to ${toToUse.symbol}`;
+        label = `Swapping ~${formattedRate} ${fromToUse.symbol}${hasYieldFrom ? ' + yield' : ''
+          } ${swapIntervalAdverb} to ${toToUse.symbol}`;
       } else {
         label = `Swapping ${fromToUse.symbol} to ${toToUse.symbol}`;
       }


### PR DESCRIPTION
## Description

Fixes mean finance yield integration to search for appTokens first and then base tokens so yield bearing tokens are displayed correctly

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: fiboape.eth
- [X] (optional) As a contributor, my Twitter handle is: @fiboape

## How to test?

http://localhost:5001/apps/mean-finance/balances?addresses[]=0xf488aaf75D987cC30a84A2c3b6dA72bd17A0a555&network=polygon