### PR TITLE
feat(debt): Add ability to define debt for app token positions

### DIFF
--- a/src/apps/aave-amm/helpers/aave-amm.lending.template.token-fetcher.ts
+++ b/src/apps/aave-amm/helpers/aave-amm.lending.template.token-fetcher.ts
@@ -33,7 +33,6 @@ export abstract class AaveAmmLendingTemplateTokenFetcher extends AppTokenTemplat
     super(appToolkit);
   }
 
-  abstract isDebt: boolean;
   abstract providerAddress: string;
   abstract getTokenAddress(reserveTokenAddressesData: AaveV2ReserveTokenAddressesData): string;
   abstract getApyFromReserveData(reserveApyData: AaveV2ReserveApyData): number;
@@ -127,24 +126,5 @@ export abstract class AaveAmmLendingTemplateTokenFetcher extends AppTokenTemplat
     appToken,
   }: GetDisplayPropsParams<AaveAmmAToken, AaveV2LendingTokenDataProps>): Promise<string> {
     return appToken.symbol;
-  }
-
-  async getBalances(address: string): Promise<AppTokenPositionBalance<AaveV2LendingTokenDataProps>[]> {
-    const multicall = this.appToolkit.getMulticall(this.network);
-    const appTokens = await this.appToolkit.getAppTokenPositions<AaveV2LendingTokenDataProps>({
-      appId: this.appId,
-      network: this.network,
-      groupIds: [this.groupId],
-    });
-
-    const balances = await Promise.all(
-      appTokens.map(async appToken => {
-        const balanceRaw = await this.getBalancePerToken({ multicall, address, appToken });
-        const tokenBalance = drillBalance(appToken, balanceRaw.toString(), { isDebt: this.isDebt });
-        return tokenBalance;
-      }),
-    );
-
-    return balances as AppTokenPositionBalance<AaveV2LendingTokenDataProps>[];
   }
 }

--- a/src/apps/aave-v2/helpers/aave-v2.lending.template.token-fetcher.ts
+++ b/src/apps/aave-v2/helpers/aave-v2.lending.template.token-fetcher.ts
@@ -56,7 +56,6 @@ export abstract class AaveV2LendingTemplateTokenFetcher extends AppTokenTemplate
     super(appToolkit);
   }
 
-  abstract isDebt: boolean;
   abstract providerAddress: string;
   abstract getTokenAddress(reserveTokenAddressesData: AaveV2ReserveTokenAddressesData): string;
   abstract getApyFromReserveData(reserveApyData: AaveV2ReserveApyData): number;
@@ -149,24 +148,5 @@ export abstract class AaveV2LendingTemplateTokenFetcher extends AppTokenTemplate
     appToken,
   }: GetDisplayPropsParams<AaveV2AToken, AaveV2LendingTokenDataProps>): Promise<string> {
     return appToken.symbol;
-  }
-
-  async getBalances(address: string): Promise<AppTokenPositionBalance<AaveV2LendingTokenDataProps>[]> {
-    const multicall = this.appToolkit.getMulticall(this.network);
-    const appTokens = await this.appToolkit.getAppTokenPositions<AaveV2LendingTokenDataProps>({
-      appId: this.appId,
-      network: this.network,
-      groupIds: [this.groupId],
-    });
-
-    const balances = await Promise.all(
-      appTokens.map(async appToken => {
-        const balanceRaw = await this.getBalancePerToken({ multicall, address, appToken });
-        const tokenBalance = drillBalance(appToken, balanceRaw.toString(), { isDebt: this.isDebt });
-        return tokenBalance;
-      }),
-    );
-
-    return balances as AppTokenPositionBalance<AaveV2LendingTokenDataProps>[];
   }
 }

--- a/src/position/template/app-token.template.position-fetcher.ts
+++ b/src/position/template/app-token.template.position-fetcher.ts
@@ -41,6 +41,7 @@ export abstract class AppTokenTemplatePositionFetcher<
   appId: string;
   groupId: string;
   network: Network;
+  isDebt: boolean = false;
   abstract groupLabel: string;
 
   isExcludedFromBalances = false;
@@ -308,7 +309,7 @@ export abstract class AppTokenTemplatePositionFetcher<
     const balances = await Promise.all(
       appTokens.map(async appToken => {
         const balanceRaw = await this.getBalancePerToken({ multicall, address, appToken });
-        const tokenBalance = drillBalance(appToken, balanceRaw.toString());
+        const tokenBalance = drillBalance(appToken, balanceRaw.toString(), { isDebt: this.isDebt });
         return tokenBalance;
       }),
     );
@@ -343,7 +344,7 @@ export abstract class AppTokenTemplatePositionFetcher<
       const tokenBalance = balances.find(b => b.key === this.appToolkit.getPositionKey(token));
       if (!tokenBalance) return null;
 
-      const result = drillBalance<typeof token, V>(token, tokenBalance.balance);
+      const result = drillBalance<typeof token, V>(token, tokenBalance.balance, { isDebt: this.isDebt });
       return result;
     });
 


### PR DESCRIPTION
## Description

The only way apps can define an AppToken as a debt right now is to re-define the entire `getBalance` method on the AppTokenTemplatePositionFetcher to pass `{ isDebt: true }` to the `drill` call.

This PR adds an `isDebt` flag on the base AppTokenTemplatePositionFetcher that is default to false. This allows us to remove the `getBalance` overrides that we have in place and only have the app token templates define `isDebt = true` (https://github.com/Zapper-fi/studio/blob/main/src/apps/aave-v2/ethereum/aave-v2.stable-debt.token-fetcher.ts#L16).

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
