### PR TITLE
feat(debt): Add support for debt in drillRawBalance

### DIFF
--- a/src/position/template/contract-position.template.position-fetcher.ts
+++ b/src/position/template/contract-position.template.position-fetcher.ts
@@ -254,7 +254,9 @@ export abstract class ContractPositionTemplatePositionFetcher<
           const tokenBalance = positionBalances.tokens.find(b => b.key === this.appToolkit.getPositionKey(token));
           if (!tokenBalance) return null;
 
-          return drillBalance<typeof token, V>(token, tokenBalance.balance);
+          return drillBalance<typeof token, V>(token, tokenBalance.balance, {
+            isDebt: token.metaType === MetaType.BORROWED,
+          });
         });
 
         const tokens = compact(allTokens).filter(t => Math.abs(t.balanceUSD) > 0.01);


### PR DESCRIPTION
## Description

Follow up to https://github.com/Zapper-fi/studio/pull/1515, it seems like the contract position template already supported debt, but i forgot to add the `isDebt` flag in the drillBalance call of the new `drillRawBalance` method. This has for effect of having position balanceUSD values when a token has a `borrowed` meta type. 

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
