### PR TITLE
fix(uniswap-v2): Providing a subgraph url from Fura would throw since it doesn't have the _meta attribute

### DIFF
--- a/src/apps/uniswap-v2/common/uniswap-v2.pool.subgraph.template.token-fetcher.ts
+++ b/src/apps/uniswap-v2/common/uniswap-v2.pool.subgraph.template.token-fetcher.ts
@@ -109,7 +109,7 @@ export abstract class UniswapV2PoolSubgraphTemplateTokenFetcher<
       query: this.lastBlockSyncedOnGraphQuery,
     });
 
-    const blockNumberLastSynced = graphMetaData._meta.block.number;
+    const blockNumberLastSynced = graphMetaData._meta?.block.number;
     if (block1DayAgo > blockNumberLastSynced) return [];
 
     // Retrieve volume data from TheGraph (@TODO Cache this)


### PR DESCRIPTION
## Description

Providing a subgraph Url from Fura would throw since it doens't have a _meta attribute. The Quickswap app integration needs this change because it's the only valid subgraph synced with all the pools (plus, it's the one their website uses)

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
