### PR TITLE
fix(ci): Fix when assets are deleted

### DIFF
--- a/.github/workflows/upload-app-assets.yml
+++ b/.github/workflows/upload-app-assets.yml
@@ -21,6 +21,7 @@ jobs:
           node-version: 'lts/gallium'
       - name: Compile new apps images
         run: |
+          mkdir -p tmp/assets/apps
           node ./scripts/compile-app-assets.js tmp/assets/apps
       - name: Upload new app images to GCS
         uses: google-github-actions/upload-cloud-storage@main


### PR DESCRIPTION
## Description

When assets are deleted, this task is executed but the directory is missing. I'm creating the temp directory, even if it won't upload anything.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
