### PR TITLE
fix(umami-finance): api v2 switch

### DIFF
--- a/src/apps/umami-finance/arbitrum/umami-finance.compound.token-fetcher.ts
+++ b/src/apps/umami-finance/arbitrum/umami-finance.compound.token-fetcher.ts
@@ -73,7 +73,7 @@ export class ArbitrumUmamiFinanceCompoundTokenFetcher extends AppTokenTemplatePo
   }
 
   async getApy(_params: GetDataPropsParams<UmamiFinanceCompound>) {
-    const { marinate } = await this.yieldResolver.getYield();
-    return Number(marinate.apy);
+    const { apy } = await this.yieldResolver.getYield();
+    return Number(apy);
   }
 }

--- a/src/apps/umami-finance/arbitrum/umami-finance.marinate-umami.token-fetcher.ts
+++ b/src/apps/umami-finance/arbitrum/umami-finance.marinate-umami.token-fetcher.ts
@@ -50,7 +50,7 @@ export class ArbitrumUmamiFinanceMarinateUmamiTokenFetcher extends AppTokenTempl
   }
 
   async getApy(_params: GetDataPropsParams<UmamiFinanceMarinate>) {
-    const { marinate } = await this.yieldResolver.getYield();
-    return Number(marinate.apr);
+    const { apr } = await this.yieldResolver.getYield();
+    return Number(apr);
   }
 }

--- a/src/apps/umami-finance/common/umami-finance.marinate.token-definition-resolver.ts
+++ b/src/apps/umami-finance/common/umami-finance.marinate.token-definition-resolver.ts
@@ -3,11 +3,15 @@ import Axios from 'axios';
 
 import { Cache } from '~cache/cache.decorator';
 
+type UmamiMetric = {
+  key: 'apy' | 'apr';
+  label: string;
+  value: string;
+  context: string;
+};
+
 export type UmamiApiResponse = {
-  marinate: {
-    apr: string;
-    apy: string;
-  };
+  metrics: Array<UmamiMetric>;
 };
 
 @Injectable()
@@ -17,7 +21,12 @@ export class UmamiFinanceYieldResolver {
     ttl: 5 * 60, // 60 minutes
   })
   async getYield() {
-    const { data } = await Axios.get<UmamiApiResponse>(`https://api.umami.finance/api/v1/marinate`);
-    return data;
+    const { data } = await Axios.get<UmamiApiResponse>(
+      `https://api.umami.finance/api/v2/staking/metrics/current?keys=apy&keys=apr`,
+    );
+    return {
+      apy: data.metrics[0].value,
+      apr: data.metrics[1].value,
+    };
   }
 }


### PR DESCRIPTION
## Description

We just deployed our v2 API for Umami, switched the v1 requests to use v2 endpoints.

[API doc](https://github.com/UmamiDAO/metrics-api)

Also removing a ghost `umami` app folder form the first implementation.

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: clonescody.eth
- [X] (optional) As a contributor, my Twitter handle is: [Clonescody](https://twitter.com/Clonescody)

## How to test?

App id `umami-finance`

`console.log()` the APR/Y values sent from the API and `pnpm dev`
