### PR TITLE
Replace deprecated subgraph URL

### DIFF
--- a/src/apps/lyra-avalon/optimism/helpers/graph.ts
+++ b/src/apps/lyra-avalon/optimism/helpers/graph.ts
@@ -54,7 +54,7 @@ const OPTIONS_QUERY = gql`
     }
   }
 `;
-const subgraphUrl = 'https://api.thegraph.com/subgraphs/name/lyra-finance/mainnet';
+const subgraphUrl = 'https://subgraph.satsuma-prod.com/lyra/optimism-mainnet/api';
 
 export const runQuery = <T>(graphHelper: TheGraphHelper, query) => {
   return graphHelper.requestGraph<T>({


### PR DESCRIPTION
No longer using the hosted service, new API has been added

## Description

<!-- Provide a description of your changeset -->

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
