### PR TITLE
feat(presenter): lazily filter out zero balances and map to TokenBalanceResponse type

### DIFF
--- a/src/balance/balance-fetcher.interface.ts
+++ b/src/balance/balance-fetcher.interface.ts
@@ -15,6 +15,8 @@ export interface TokenBalanceResponse {
   error?: string;
 }
 
+export type LazyTokenBalanceResponse = (includeZeroBalances?: true) => TokenBalanceResponse;
+
 export interface BalanceFetcher {
-  getBalances(address: string): Promise<TokenBalanceResponse>;
+  getBalances(address: string): Promise<LazyTokenBalanceResponse>;
 }

--- a/src/balance/balance-presentation.service.ts
+++ b/src/balance/balance-presentation.service.ts
@@ -53,19 +53,19 @@ export class BalancePresentationService {
       this.balancePresenterRegistry.get(appId, network) ??
       this.defaultBalancePresenterFactory.build({ appId, network });
 
-    return presenter.present(address, balances);
+    return presenter.present(address, balances).then(v => v());
   }
 
   async presentTemplates({ address, appId, network, balances }: PresentParams): Promise<TokenBalanceResponse> {
     // Use default presenter when no custom presenter
     const customPresenter = this.positionPresenterRegistry.get(appId, network);
     const defaultPresenter = this.defaultPositionPresenterFactory.build({ appId, network });
-    if (!customPresenter) return defaultPresenter.presentBalances(balances);
+    if (!customPresenter) return defaultPresenter.presentBalances(balances).then(v => v());
 
     // When balance product meta resolvers, use default presenter with position groups from either the custom or default presenter
     const positionGroups = customPresenter.positionGroups ?? defaultPresenter.getBalanceProductGroups();
     const balanceProductMetaResolvers = this.positionPresenterRegistry.getBalanceProductMetaResolvers(appId, network);
-    if (!balanceProductMetaResolvers) return defaultPresenter.presentBalances(balances, positionGroups);
+    if (!balanceProductMetaResolvers) return defaultPresenter.presentBalances(balances, positionGroups).then(v => v());
 
     // Try to resolve balance product metas, grouping balances by group selector specified in the custom presenter
     const presentedBalances = await Promise.all(
@@ -86,6 +86,6 @@ export class BalancePresentationService {
       }),
     );
 
-    return presentBalanceFetcherResponse(presentedBalances.flat());
+    return presentBalanceFetcherResponse(presentedBalances.flat())();
   }
 }

--- a/src/balance/balance-presenter.interface.ts
+++ b/src/balance/balance-presenter.interface.ts
@@ -1,7 +1,7 @@
 import { PositionBalance } from '~position/position-balance.interface';
 
-import { TokenBalanceResponse } from './balance-fetcher.interface';
+import { LazyTokenBalanceResponse } from './balance-fetcher.interface';
 
 export interface BalancePresenter {
-  present(address: string, balances: PositionBalance[]): Promise<TokenBalanceResponse>;
+  present(address: string, balances: PositionBalance[]): Promise<LazyTokenBalanceResponse>;
 }


### PR DESCRIPTION
## Description

I need to be able to preserve zero positions in some very specific cases. Since the input type to the function `presentBalanceFetcherResponse` are not completely aligned in our system, I'm relying on the fact that the function has a similar interface of `(includeZeroBalances?: true) => TokenBalanceResponse`.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
