### PR TITLE
feat(templates): Adjust app token template for flexibility with ERC1155

### DIFF
--- a/src/apps/balancer-v2/common/balancer-v2.pool.token-fetcher.ts
+++ b/src/apps/balancer-v2/common/balancer-v2.pool.token-fetcher.ts
@@ -91,7 +91,7 @@ export abstract class BalancerV2PoolTokenFetcher extends AppTokenTemplatePositio
     contract,
     definition,
     multicall,
-  }: GetTokenPropsParams<BalancerPool, BalancerV2PoolTokenDefinition>) {
+  }: GetTokenPropsParams<BalancerPool, BalancerV2PoolTokenDataProps, BalancerV2PoolTokenDefinition>) {
     // Logic derived from https://github.com/balancer-labs/frontend-v2/blob/f22a7bf8f7adfbf1158178322ce9aa12034b5894/src/services/balancer/contracts/contracts/vault.ts#L86-L93
     if (
       definition.poolType === 'StablePhantom' ||

--- a/src/apps/beethoven-x/common/beethoven-x.pool.token-fetcher.ts
+++ b/src/apps/beethoven-x/common/beethoven-x.pool.token-fetcher.ts
@@ -1,6 +1,7 @@
 import { gql } from 'graphql-request';
 
 import {
+  BalancerV2PoolTokenDataProps,
   BalancerV2PoolTokenDefinition,
   BalancerV2PoolTokenFetcher,
 } from '~apps/balancer-v2/common/balancer-v2.pool.token-fetcher';
@@ -56,7 +57,7 @@ export abstract class BeethovenXPoolTokenFetcher extends BalancerV2PoolTokenFetc
     contract,
     definition,
     multicall,
-  }: GetTokenPropsParams<BalancerPool, BalancerV2PoolTokenDefinition>) {
+  }: GetTokenPropsParams<BalancerPool, BalancerV2PoolTokenDataProps, BalancerV2PoolTokenDefinition>) {
     // Logic derived from https://github.com/beethovenxfi/beethovenx-backend/blob/89242560f444f6f29ceb09155b905f783fda9481/modules/pool/lib/pool-on-chain-data.service.ts#L154-L163
     if (
       (definition.poolType === 'PHANTOM_STABLE' && definition.factory === this.composablePoolFactory) ||

--- a/src/apps/pool-together-v3/common/pool-together-v3.sponsorship.token-fetcher.ts
+++ b/src/apps/pool-together-v3/common/pool-together-v3.sponsorship.token-fetcher.ts
@@ -2,7 +2,7 @@ import { Inject } from '@nestjs/common';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { Erc20 } from '~contract/contracts';
-import { GetTokenPropsParams } from '~position/template/app-token.template.types';
+import { DefaultAppTokenDataProps, GetTokenPropsParams } from '~position/template/app-token.template.types';
 
 import { PoolTogetherV3ContractFactory } from '../contracts';
 
@@ -35,7 +35,10 @@ export abstract class PoolTogetherV3SponsorshipTokenFetcher extends PoolTogether
     });
   }
 
-  async getSupply({ contract, definition }: GetTokenPropsParams<Erc20, PoolTogetherV3PrizePoolDefinition>) {
+  async getSupply({
+    contract,
+    definition,
+  }: GetTokenPropsParams<Erc20, DefaultAppTokenDataProps, PoolTogetherV3PrizePoolDefinition>) {
     const ticketContract = this.contractFactory.poolTogetherV3Ticket({
       network: this.network,
       address: definition.ticketAddress,

--- a/src/apps/rubicon/common/rubicon.bath.token-fetcher.ts
+++ b/src/apps/rubicon/common/rubicon.bath.token-fetcher.ts
@@ -53,7 +53,11 @@ export abstract class RubiconBathTokenFetcher extends AppTokenTemplatePositionFe
     return definition.underlyingTokenAddress;
   }
 
-  async getSupply({ multicall, definition, contract }: GetTokenPropsParams<BathToken, RubiconPoolDefinition>) {
+  async getSupply({
+    multicall,
+    definition,
+    contract,
+  }: GetTokenPropsParams<BathToken, DefaultAppTokenDataProps, RubiconPoolDefinition>) {
     const underlyingAssetContract = this.contractFactory.erc20({
       address: definition.underlyingTokenAddress,
       network: this.network,

--- a/src/position/template/app-token.template.types.ts
+++ b/src/position/template/app-token.template.types.ts
@@ -43,7 +43,16 @@ type PositionBuilderContextWithAppToken<
 
 export type GetUnderlyingTokensParams<T, R = DefaultAppTokenDefinition> = PositionBuilderContext<T, R>;
 
-export type GetTokenPropsParams<T, R = DefaultAppTokenDefinition> = PositionBuilderContext<T, R>;
+export type GetTokenPropsParams<
+  T,
+  V = DefaultAppTokenDataProps,
+  R = DefaultAppTokenDefinition,
+> = PositionBuilderContextWithAppToken<
+  T,
+  V,
+  R,
+  'symbol' | 'decimals' | 'supply' | 'pricePerShare' | 'price' | 'dataProps' | 'displayProps'
+>;
 
 export type GetPricePerShareParams<
   T,


### PR DESCRIPTION
## Description

ERC-1155 needs better support for `definitions` since many tokens can exist on a single contract. Adjust the template to treat definitions list as the source of truth for enumerating tokens (i.e.: 1 definition per token, rather than 1 address per token).

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
