### PR TITLE
feat(templates): Enable network and ERC1155 ID in token definitions for Contract Position template

### DIFF
--- a/src/apps/aave-safety-module/ethereum/aave-safety-module.stk-aave-claimable.contract-position-fetcher.ts
+++ b/src/apps/aave-safety-module/ethereum/aave-safety-module.stk-aave-claimable.contract-position-fetcher.ts
@@ -34,7 +34,13 @@ export class EthereumAaveSafetyModuleStkAaveClaimableContractPositionFetcher ext
   }
 
   async getTokenDefinitions(_params: GetTokenDefinitionsParams<AaveStkAave>) {
-    return [{ metaType: MetaType.CLAIMABLE, address: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9' }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<AaveStkAave>) {

--- a/src/apps/aave-safety-module/ethereum/aave-safety-module.stk-abpt-claimable.contract-position-fetcher.ts
+++ b/src/apps/aave-safety-module/ethereum/aave-safety-module.stk-abpt-claimable.contract-position-fetcher.ts
@@ -29,7 +29,13 @@ export class EthereumAaveSafetyModuleStkAbptClaimableContractPositionFetcher ext
   }
 
   async getTokenDefinitions() {
-    return [{ metaType: MetaType.CLAIMABLE, address: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9' }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9',
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<AaveStkAbpt>) {

--- a/src/apps/aave-v2/helpers/aave-v2.claimable.template.contract-position-fetcher.ts
+++ b/src/apps/aave-v2/helpers/aave-v2.claimable.template.contract-position-fetcher.ts
@@ -35,7 +35,13 @@ export abstract class AaveV2ClaimableTemplatePositionFetcher extends ContractPos
   }
 
   async getTokenDefinitions() {
-    return [{ address: this.rewardTokenAddress, metaType: MetaType.CLAIMABLE }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: this.rewardTokenAddress,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel(

--- a/src/apps/abracadabra/common/abracadabra.cauldron.contract-position-fetcher.ts
+++ b/src/apps/abracadabra/common/abracadabra.cauldron.contract-position-fetcher.ts
@@ -55,8 +55,16 @@ export abstract class AbracadabraCauldronContractPositionFetcher extends Contrac
       : collateralAddressRaw.toLowerCase();
 
     return [
-      { metaType: MetaType.SUPPLIED, address: collateralAddress },
-      { metaType: MetaType.BORROWED, address: debtAddressRaw },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: collateralAddress,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.BORROWED,
+        address: debtAddressRaw,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/argo-finance/cronos/argo-finance.pledging.contract-position-fetcher.ts
+++ b/src/apps/argo-finance/cronos/argo-finance.pledging.contract-position-fetcher.ts
@@ -30,9 +30,21 @@ export class CronosArgoFinancePledgingContractPositionFetcher extends ContractPo
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.SUPPLIED, address: '0xb966b5d6a0fcd5b373b180bbe072bbfbbee10552' }, // xARGO
-      { metaType: MetaType.CLAIMABLE, address: '0xb966b5d6a0fcd5b373b180bbe072bbfbbee10552' }, // xARGO
-      { metaType: MetaType.CLAIMABLE, address: '0x5c7f8a570d578ed84e63fdfa7b1ee72deae1ae23' }, // wCRO
+      {
+        metaType: MetaType.SUPPLIED,
+        address: '0xb966b5d6a0fcd5b373b180bbe072bbfbbee10552', // xARGO
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0xb966b5d6a0fcd5b373b180bbe072bbfbbee10552', // xARGO
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x5c7f8a570d578ed84e63fdfa7b1ee72deae1ae23', // wCRO
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/art-gobblers/ethereum/art-gobblers.claimable.contract-position-fetcher.ts
+++ b/src/apps/art-gobblers/ethereum/art-gobblers.claimable.contract-position-fetcher.ts
@@ -28,7 +28,13 @@ export class EthereumArGobblersClaimableContractPositionFetcher extends Contract
   }
 
   async getTokenDefinitions() {
-    return [{ metaType: MetaType.CLAIMABLE, address: '0x600000000a36f3cd48407e35eb7c5c910dc1f7a8' }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x600000000a36f3cd48407e35eb7c5c910dc1f7a8',
+        network: this.network,
+      },
+    ];
   }
 
   getContract(address: string): ArtGobblers {

--- a/src/apps/arth/ethereum/arth.stability-pool.contract-position-fetcher.ts
+++ b/src/apps/arth/ethereum/arth.stability-pool.contract-position-fetcher.ts
@@ -32,9 +32,21 @@ export class EthereumArthStabilityPoolContractPositionFetcher extends ContractPo
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.SUPPLIED, address: '0x8cc0f052fff7ead7f2edcccac895502e884a8a71' }, // ARTH
-      { metaType: MetaType.CLAIMABLE, address: ZERO_ADDRESS }, // ETH
-      { metaType: MetaType.CLAIMABLE, address: '0xb4d930279552397bba2ee473229f89ec245bc365' }, // MAHA
+      {
+        metaType: MetaType.SUPPLIED,
+        address: '0x8cc0f052fff7ead7f2edcccac895502e884a8a71', // ARTH
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: ZERO_ADDRESS, // ETH
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0xb4d930279552397bba2ee473229f89ec245bc365', // MAHA
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/arth/ethereum/arth.trove.contract-position-fetcher.ts
+++ b/src/apps/arth/ethereum/arth.trove.contract-position-fetcher.ts
@@ -31,8 +31,16 @@ export class EthereumArthTroveContractPositionFetcher extends ContractPositionTe
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.SUPPLIED, address: ZERO_ADDRESS }, // ETH
-      { metaType: MetaType.BORROWED, address: '0x8cc0f052fff7ead7f2edcccac895502e884a8a71' }, // ARTH
+      {
+        metaType: MetaType.SUPPLIED,
+        address: ZERO_ADDRESS, // ETH
+        network: this.network,
+      },
+      {
+        metaType: MetaType.BORROWED,
+        address: '0x8cc0f052fff7ead7f2edcccac895502e884a8a71', // ARTH
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/aura/ethereum/aura.locker.contract-position-fetcher.ts
+++ b/src/apps/aura/ethereum/aura.locker.contract-position-fetcher.ts
@@ -40,8 +40,16 @@ export class EthereumAuraLockerContractPositionFetcher extends ContractPositionT
     const rewardTokenAddress = await contract.rewardTokens(0);
 
     return [
-      { metaType: MetaType.SUPPLIED, address: stakedTokenAddress },
-      { metaType: MetaType.CLAIMABLE, address: rewardTokenAddress },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: stakedTokenAddress,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: rewardTokenAddress,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/aurigami/aurora/aurigami.claimable.contract-position-fetcher.ts
+++ b/src/apps/aurigami/aurora/aurigami.claimable.contract-position-fetcher.ts
@@ -44,7 +44,13 @@ export class AuroraAurigamiClaimableContractPositionFetcher extends ContractPosi
   async getTokenDefinitions(
     _opts: GetTokenDefinitionsParams<AurigamiComptroller, DefaultContractPositionDefinition>,
   ): Promise<UnderlyingTokenDefinition[] | null> {
-    return [{ address: this.rewardTokenAddress, metaType: MetaType.CLAIMABLE }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: this.rewardTokenAddress,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<AurigamiComptroller>) {

--- a/src/apps/badger/common/badger.claimable.contract-position-fetcher.ts
+++ b/src/apps/badger/common/badger.claimable.contract-position-fetcher.ts
@@ -46,7 +46,13 @@ export abstract class BadgerClaimableContractPositionFetcher extends ContractPos
   async getTokenDefinitions({
     definition,
   }: GetTokenDefinitionsParams<BadgerTree, BadgerClaimableDefinition>): Promise<UnderlyingTokenDefinition[]> {
-    return [{ address: definition.rewardTokenAddress, metaType: MetaType.CLAIMABLE }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: definition.rewardTokenAddress,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel(params: GetDisplayPropsParams<BadgerTree>): Promise<string> {

--- a/src/apps/balancer-v2/ethereum/balancer-v2.voting-escrow.contract-position-fetcher.ts
+++ b/src/apps/balancer-v2/ethereum/balancer-v2.voting-escrow.contract-position-fetcher.ts
@@ -34,8 +34,13 @@ export class EthereumBalancerV2VotingEscrowContractPositionFetcher extends Contr
   }
 
   async getTokenDefinitions({ contract }: GetTokenDefinitionsParams<BalancerVeBal>) {
-    const tokenAddress = await contract.token();
-    return [{ metaType: MetaType.SUPPLIED, address: tokenAddress }];
+    return [
+      {
+        metaType: MetaType.SUPPLIED,
+        address: await contract.token(),
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<BalancerVeBal>) {

--- a/src/apps/beefy/common/beefy.boost-vault.contract-position-fetcher.ts
+++ b/src/apps/beefy/common/beefy.boost-vault.contract-position-fetcher.ts
@@ -47,8 +47,16 @@ export abstract class BeefyBoostVaultContractPositionFetcher extends ContractPos
     definition,
   }: GetTokenDefinitionsParams<BeefyBoostVault, BeefyBoostVaultDefinition>): Promise<UnderlyingTokenDefinition[]> {
     return [
-      { address: definition.underlyingTokenAddress, metaType: MetaType.SUPPLIED },
-      { address: definition.rewardTokenAddress, metaType: MetaType.CLAIMABLE },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.underlyingTokenAddress,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: definition.rewardTokenAddress,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/chicken-bond/ethereum/chicken-bond.bond.contract-position-fetcher.ts
+++ b/src/apps/chicken-bond/ethereum/chicken-bond.bond.contract-position-fetcher.ts
@@ -29,8 +29,16 @@ export class EthereumChickenBondBondContractPositionFetcher extends ContractPosi
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.SUPPLIED, address: '0x5f98805a4e8be255a32880fdec7f6728c6568ba0' },
-      { metaType: MetaType.CLAIMABLE, address: '0xb9d7dddca9a4ac480991865efef82e01273f79c3' },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: '0x5f98805a4e8be255a32880fdec7f6728c6568ba0',
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0xb9d7dddca9a4ac480991865efef82e01273f79c3',
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/clever/ethereum/clever.furnace.contract-position-fetcher.ts
+++ b/src/apps/clever/ethereum/clever.furnace.contract-position-fetcher.ts
@@ -31,8 +31,16 @@ export class EthereumCleverFurnaceContractPositionFetcher extends ContractPositi
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.LOCKED, address: CLEVCVX },
-      { metaType: MetaType.CLAIMABLE, address: CVX },
+      {
+        metaType: MetaType.LOCKED,
+        address: CLEVCVX,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: CVX,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/clever/ethereum/clever.lock.contract-position-fetcher.ts
+++ b/src/apps/clever/ethereum/clever.lock.contract-position-fetcher.ts
@@ -31,9 +31,21 @@ export class EthereumCleverLockContractPositionFetcher extends ContractPositionT
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.LOCKED, address: CVX },
-      { metaType: MetaType.CLAIMABLE, address: CVX },
-      { metaType: MetaType.BORROWED, address: CLEVCVX },
+      {
+        metaType: MetaType.LOCKED,
+        address: CVX,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: CVX,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.BORROWED,
+        address: CLEVCVX,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/compound/common/compound.borrow.contract-position-fetcher.ts
+++ b/src/apps/compound/common/compound.borrow.contract-position-fetcher.ts
@@ -61,7 +61,14 @@ export abstract class CompoundBorrowContractPositionFetcher<
     });
 
     const underlyingAddress = underlyingAddressRaw.toLowerCase().replace(ETH_ADDR_ALIAS, ZERO_ADDRESS);
-    return [{ address: underlyingAddress, metaType: MetaType.BORROWED }];
+
+    return [
+      {
+        metaType: MetaType.BORROWED,
+        address: underlyingAddress,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({

--- a/src/apps/compound/common/compound.claimable.contract-position-fetcher.ts
+++ b/src/apps/compound/common/compound.claimable.contract-position-fetcher.ts
@@ -42,7 +42,13 @@ export abstract class CompoundClaimableContractPositionFetcher<
   async getTokenDefinitions(
     _opts: GetTokenDefinitionsParams<R, DefaultContractPositionDefinition>,
   ): Promise<UnderlyingTokenDefinition[] | null> {
-    return [{ address: this.rewardTokenAddress, metaType: MetaType.CLAIMABLE }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: this.rewardTokenAddress,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<R>) {

--- a/src/apps/concave/ethereum/concave.liquid-staking.contract-position-fetcher.ts
+++ b/src/apps/concave/ethereum/concave.liquid-staking.contract-position-fetcher.ts
@@ -75,8 +75,16 @@ export class EthereumConcaveLiquidStakingContractPositionFetcher extends Contrac
 
   async getTokenDefinitions(_params: GetTokenDefinitionsParams<Lsdcnv>) {
     return [
-      { metaType: MetaType.SUPPLIED, address: '0x000000007a58f5f58e697e51ab0357bc9e260a04' },
-      { metaType: MetaType.CLAIMABLE, address: '0x000000007a58f5f58e697e51ab0357bc9e260a04' },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: '0x000000007a58f5f58e697e51ab0357bc9e260a04',
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x000000007a58f5f58e697e51ab0357bc9e260a04',
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/convex/ethereum/convex.abracadabra-claimable.contract-position-fetcher.ts
+++ b/src/apps/convex/ethereum/convex.abracadabra-claimable.contract-position-fetcher.ts
@@ -49,9 +49,21 @@ export class EthereumConvexAbracadabraClaimableContractPositionFetcher extends C
 
   async getTokenDefinitions({ contract }: GetTokenDefinitionsParams<ConvexAbracadabraWrapper>) {
     return [
-      { metaType: MetaType.SUPPLIED, address: await contract.convexToken() },
-      { metaType: MetaType.CLAIMABLE, address: '0xd533a949740bb3306d119cc777fa900ba034cd52' },
-      { metaType: MetaType.CLAIMABLE, address: '0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b' },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: await contract.convexToken(),
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0xd533a949740bb3306d119cc777fa900ba034cd52',
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b',
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/convex/ethereum/convex.depositor.contract-position-fetcher.ts
+++ b/src/apps/convex/ethereum/convex.depositor.contract-position-fetcher.ts
@@ -33,7 +33,13 @@ export class EthereumConvexDepositorContractPositionFetcher extends ContractPosi
   }
 
   async getTokenDefinitions(_params: GetTokenDefinitionsParams<ConvexDepositor>) {
-    return [{ metaType: MetaType.SUPPLIED, address: '0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b' }];
+    return [
+      {
+        metaType: MetaType.SUPPLIED,
+        address: '0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b',
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<ConvexDepositor>) {

--- a/src/apps/convex/ethereum/convex.voting-escrow.contract-position-fetcher.ts
+++ b/src/apps/convex/ethereum/convex.voting-escrow.contract-position-fetcher.ts
@@ -39,8 +39,16 @@ export class EthereumConvexVotingEscrowContractPositionFetcher extends ContractP
     const rewardTokenAddress = await contract.rewardTokens(0);
 
     return [
-      { metaType: MetaType.SUPPLIED, address: stakedTokenAddress },
-      { metaType: MetaType.CLAIMABLE, address: rewardTokenAddress },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: stakedTokenAddress,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: rewardTokenAddress,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/dopex/arbitrum/dopex.voting-escrow-rewards.contract-position-fetcher.ts
+++ b/src/apps/dopex/arbitrum/dopex.voting-escrow-rewards.contract-position-fetcher.ts
@@ -34,7 +34,13 @@ export class ArbitrumDopexVotingEscrowRewardsContractPositionFetcher extends Con
   }
 
   async getTokenDefinitions({ contract }: GetTokenDefinitionsParams<DopexVotingEscrowRewards>) {
-    return [{ metaType: MetaType.CLAIMABLE, address: await contract.emittedToken() }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: await contract.emittedToken(),
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<DopexVotingEscrowRewards>) {

--- a/src/apps/dopex/arbitrum/dopex.voting-escrow.contract-position-fetcher.ts
+++ b/src/apps/dopex/arbitrum/dopex.voting-escrow.contract-position-fetcher.ts
@@ -34,7 +34,13 @@ export class ArbitrumDopexVotingEscrowContractPositionFetcher extends ContractPo
   }
 
   async getTokenDefinitions({ contract }: GetTokenDefinitionsParams<DopexVotingEscrow>) {
-    return [{ metaType: MetaType.SUPPLIED, address: await contract.token() }];
+    return [
+      {
+        metaType: MetaType.SUPPLIED,
+        address: await contract.token(),
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<DopexVotingEscrow>) {

--- a/src/apps/dopex/common/dopex.ssov.contract-position-fetcher.ts
+++ b/src/apps/dopex/common/dopex.ssov.contract-position-fetcher.ts
@@ -110,8 +110,10 @@ export abstract class DopexSsovContractPositionFetcher<
   async getTokenDefinitions({ definition }: GetTokenDefinitionsParams<T, DopexSsovEpochStrikeDefinition>) {
     const tokens: UnderlyingTokenDefinition[] = [];
     const { depositTokenAddress, extraRewardTokenAddresses = [] } = definition;
-    tokens.push({ metaType: MetaType.SUPPLIED, address: depositTokenAddress });
-    tokens.push(...extraRewardTokenAddresses.map(v => ({ metaType: MetaType.CLAIMABLE, address: v })));
+    tokens.push({ metaType: MetaType.SUPPLIED, address: depositTokenAddress, network: this.network });
+    tokens.push(
+      ...extraRewardTokenAddresses.map(v => ({ metaType: MetaType.CLAIMABLE, address: v, network: this.network })),
+    );
     return tokens;
   }
 

--- a/src/apps/ethereum-staking/ethereum/ethereum-staking.deposit.contract-position-fetcher.ts
+++ b/src/apps/ethereum-staking/ethereum/ethereum-staking.deposit.contract-position-fetcher.ts
@@ -54,7 +54,13 @@ export class EthereumEthereumStakingDepositContractPositionFetcher extends Contr
   }
 
   async getTokenDefinitions(_params: GetTokenDefinitionsParams<EthereumStakingDeposit>) {
-    return [{ metaType: MetaType.SUPPLIED, address: ZERO_ADDRESS }];
+    return [
+      {
+        metaType: MetaType.SUPPLIED,
+        address: ZERO_ADDRESS,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<EthereumStakingDeposit>) {

--- a/src/apps/geist/fantom/geist.incentives.contract-position-fetcher.ts
+++ b/src/apps/geist/fantom/geist.incentives.contract-position-fetcher.ts
@@ -38,7 +38,13 @@ export class FantomGeistIncentivesPositionFetcher extends ContractPositionTempla
   }
 
   async getTokenDefinitions() {
-    return [{ address: this.geistTokenAddress, metaType: MetaType.CLAIMABLE }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: this.geistTokenAddress,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel(): Promise<string> {

--- a/src/apps/geist/fantom/geist.platform-fees.contract-position-fetcher.ts
+++ b/src/apps/geist/fantom/geist.platform-fees.contract-position-fetcher.ts
@@ -52,10 +52,26 @@ export class FantomGeistPlatformFeesPositionFetcher extends ContractPositionTemp
     ).then(addresses => compact(addresses));
 
     return [
-      { address: this.geistTokenAddress, metaType: MetaType.LOCKED }, // Locked GEIST
-      { address: this.geistTokenAddress, metaType: MetaType.CLAIMABLE }, // Unlocked GEIST
-      { address: this.geistTokenAddress, metaType: MetaType.CLAIMABLE }, // Vested GEIST
-      ...rewardTokenAddresses.map(address => ({ address: address.toLowerCase(), metaType: MetaType.CLAIMABLE })),
+      {
+        metaType: MetaType.LOCKED,
+        address: this.geistTokenAddress, // Locked GEIST
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: this.geistTokenAddress, // Unlocked GEIST
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: this.geistTokenAddress, // Vested GEIST
+        network: this.network,
+      },
+      ...rewardTokenAddresses.map(address => ({
+        metaType: MetaType.CLAIMABLE,
+        address: address.toLowerCase(),
+        network: this.network,
+      })),
     ];
   }
 

--- a/src/apps/good-ghosting/common/good-ghosting.game.contract-position-fetcher.ts
+++ b/src/apps/good-ghosting/common/good-ghosting.game.contract-position-fetcher.ts
@@ -59,8 +59,16 @@ export abstract class GoodGhostingGameContractPositionFetcher extends ContractPo
     UnderlyingTokenDefinition[] | null
   > {
     return [
-      { metaType: MetaType.SUPPLIED, address: definition.stakedTokenAddress },
-      ...definition.rewardTokenAddresses.map(v => ({ metaType: MetaType.CLAIMABLE, address: v })),
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.stakedTokenAddress,
+        network: this.network,
+      },
+      ...definition.rewardTokenAddresses.map(rewardTokenAddress => ({
+        metaType: MetaType.CLAIMABLE,
+        address: rewardTokenAddress,
+        network: this.network,
+      })),
     ];
   }
 

--- a/src/apps/gro/ethereum/gro.vesting.contract-position-fetcher.ts
+++ b/src/apps/gro/ethereum/gro.vesting.contract-position-fetcher.ts
@@ -33,8 +33,16 @@ export class EthereumGroVestingContractPositionFetcher extends ContractPositionT
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.SUPPLIED, address: '0x3ec8798b81485a254928b70cda1cf0a2bb0b74d7' },
-      { metaType: MetaType.CLAIMABLE, address: '0x3ec8798b81485a254928b70cda1cf0a2bb0b74d7' },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: '0x3ec8798b81485a254928b70cda1cf0a2bb0b74d7',
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x3ec8798b81485a254928b70cda1cf0a2bb0b74d7',
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/hector-network/binance-smart-chain/hector-network.bond-no-treasury.contract-position-fetcher.ts
+++ b/src/apps/hector-network/binance-smart-chain/hector-network.bond-no-treasury.contract-position-fetcher.ts
@@ -42,9 +42,21 @@ export class BinanceSmartChainHectorNetworkBondNoTreasuryContractPositionFetcher
     const [principle, claimable] = await Promise.all([contract.principle(), contract.HEC()]);
 
     return [
-      { address: claimable, metaType: MetaType.VESTING },
-      { address: claimable, metaType: MetaType.CLAIMABLE },
-      { address: principle, metaType: MetaType.SUPPLIED },
+      {
+        metaType: MetaType.VESTING,
+        address: claimable,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: claimable,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: principle,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/hector-network/fantom/hector-network.bond-no-treasury.contract-position-fetcher.ts
+++ b/src/apps/hector-network/fantom/hector-network.bond-no-treasury.contract-position-fetcher.ts
@@ -42,9 +42,21 @@ export class FantomHectorNetworkBondNoTreasuryContractPositionFetcher extends Co
     const [principle, claimable] = await Promise.all([contract.principle(), contract.HEC()]);
 
     return [
-      { address: claimable, metaType: MetaType.VESTING },
-      { address: claimable, metaType: MetaType.CLAIMABLE },
-      { address: principle, metaType: MetaType.SUPPLIED },
+      {
+        metaType: MetaType.VESTING,
+        address: claimable,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: claimable,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: principle,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/hector-network/fantom/hector-network.bond.contract-position-fetcher.ts
+++ b/src/apps/hector-network/fantom/hector-network.bond.contract-position-fetcher.ts
@@ -45,9 +45,21 @@ export class FantomHectorNetworkBondContractPositionFetcher extends ContractPosi
     const [principle, claimable] = await Promise.all([contract.principle(), contract.HEC()]);
 
     return [
-      { address: claimable, metaType: MetaType.VESTING },
-      { address: claimable, metaType: MetaType.CLAIMABLE },
-      { address: principle, metaType: MetaType.SUPPLIED },
+      {
+        metaType: MetaType.VESTING,
+        address: claimable,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: claimable,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: principle,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/hector-network/fantom/hector-network.stake-bond.contract-position-fetcher.ts
+++ b/src/apps/hector-network/fantom/hector-network.stake-bond.contract-position-fetcher.ts
@@ -44,9 +44,21 @@ export class FantomHectorNetworkStakeBondContractPositionFetcher extends Contrac
     const [principle, claimable] = await Promise.all([contract.principle(), contract.sHEC()]);
 
     return [
-      { address: claimable, metaType: MetaType.VESTING },
-      { address: claimable, metaType: MetaType.CLAIMABLE },
-      { address: principle, metaType: MetaType.SUPPLIED },
+      {
+        metaType: MetaType.VESTING,
+        address: claimable,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: claimable,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: principle,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/homora-v2/common/homora-v2.farm.contract-position-fetcher.ts
+++ b/src/apps/homora-v2/common/homora-v2.farm.contract-position-fetcher.ts
@@ -71,8 +71,16 @@ export abstract class HomoraV2FarmContractPositionFetcher extends ContractPositi
 
   async getTokenDefinitions({ definition }: GetTokenDefinitionsParams<HomoraBank, HomoraV2FarmingPositionDefinition>) {
     return [
-      { metaType: MetaType.SUPPLIED, address: definition.poolAddress },
-      ...definition.tokenAddresses.map(token => ({ metaType: MetaType.BORROWED, address: token })),
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.poolAddress,
+        network: this.network,
+      },
+      ...definition.tokenAddresses.map(token => ({
+        metaType: MetaType.BORROWED,
+        address: token,
+        network: this.network,
+      })),
     ];
   }
 

--- a/src/apps/impermax/common/impermax.borrow.contract-position-fetcher.ts
+++ b/src/apps/impermax/common/impermax.borrow.contract-position-fetcher.ts
@@ -45,7 +45,13 @@ export abstract class ImpermaxBorrowContractPositionFetcher extends ContractPosi
 
   async getTokenDefinitions({ contract }: GetTokenDefinitionsParams<Borrowable>) {
     const underlyingAddress = await contract.underlying();
-    return [{ address: underlyingAddress, metaType: MetaType.BORROWED }];
+    return [
+      {
+        metaType: MetaType.BORROWED,
+        address: underlyingAddress,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<Borrowable>): Promise<DisplayProps['label']> {

--- a/src/apps/impermax/helpers/impermax.borrow.contract-position-fetcher.ts
+++ b/src/apps/impermax/helpers/impermax.borrow.contract-position-fetcher.ts
@@ -45,7 +45,13 @@ export abstract class ImpermaxBorrowContractPositionFetcher extends ContractPosi
 
   async getTokenDefinitions({ contract }: GetTokenDefinitionsParams<Borrowable>) {
     const underlyingAddress = await contract.underlying();
-    return [{ address: underlyingAddress, metaType: MetaType.BORROWED }];
+    return [
+      {
+        metaType: MetaType.BORROWED,
+        address: underlyingAddress,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<Borrowable>): Promise<DisplayProps['label']> {

--- a/src/apps/kwenta/common/kwenta.perp.contract-position-fetcher.ts
+++ b/src/apps/kwenta/common/kwenta.perp.contract-position-fetcher.ts
@@ -54,7 +54,11 @@ export abstract class OptimismKwentaPerpContractPositionFetcher extends Contract
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.SUPPLIED, address: '0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9' }, // sUSD
+      {
+        address: '0x8c6f28f2f1a3c87f0f938b96d27520d9751ec8d9', // sUSD
+        metaType: MetaType.SUPPLIED,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/kyberswap-elastic/common/kyberswap-elastic.farm.contract-position-fetcher.ts
+++ b/src/apps/kyberswap-elastic/common/kyberswap-elastic.farm.contract-position-fetcher.ts
@@ -93,9 +93,21 @@ export abstract class KyberswapElasticFarmContractPositionFetcher extends Contra
     definition,
   }: GetTokenDefinitionsParams<KyberswapElasticLm, KyberswapElasticFarmPositionDefinition>) {
     return [
-      { metaType: MetaType.SUPPLIED, address: definition.token0Address },
-      { metaType: MetaType.SUPPLIED, address: definition.token1Address },
-      ...definition.rewardTokenAddresses.map(v => ({ metaType: MetaType.CLAIMABLE, address: v })),
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.token0Address,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.token1Address,
+        network: this.network,
+      },
+      ...definition.rewardTokenAddresses.map(v => ({
+        metaType: MetaType.CLAIMABLE,
+        address: v,
+        network: this.network,
+      })),
     ];
   }
 

--- a/src/apps/kyberswap-elastic/common/kyberswap-elastic.liquidity.contract-position-fetcher.ts
+++ b/src/apps/kyberswap-elastic/common/kyberswap-elastic.liquidity.contract-position-fetcher.ts
@@ -103,8 +103,16 @@ export abstract class KyberswapElasticLiquidityContractPositionFetcher extends C
     definition,
   }: GetTokenDefinitionsParams<PositionManager, KyberswapElasticLiquidityPositionDefinition>) {
     return [
-      { metaType: MetaType.SUPPLIED, address: definition.token0Address },
-      { metaType: MetaType.SUPPLIED, address: definition.token1Address },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.token0Address,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.token1Address,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/liquity/ethereum/liquity.stability-pool.contract-position-fetcher.ts
+++ b/src/apps/liquity/ethereum/liquity.stability-pool.contract-position-fetcher.ts
@@ -35,9 +35,21 @@ export class EthereumLiquityStabilityPoolContractPositionFetcher extends Contrac
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.SUPPLIED, address: '0x5f98805a4e8be255a32880fdec7f6728c6568ba0' }, // LUSD
-      { metaType: MetaType.CLAIMABLE, address: ZERO_ADDRESS }, // ETH
-      { metaType: MetaType.CLAIMABLE, address: '0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d' }, // LQTY
+      {
+        metaType: MetaType.SUPPLIED,
+        address: '0x5f98805a4e8be255a32880fdec7f6728c6568ba0', // LUSD
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: ZERO_ADDRESS, // ETH
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d', // LQTY
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/liquity/ethereum/liquity.trove.contract-position-fetcher.ts
+++ b/src/apps/liquity/ethereum/liquity.trove.contract-position-fetcher.ts
@@ -35,8 +35,16 @@ export class EthereumLiquityTroveContractPositionFetcher extends ContractPositio
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.SUPPLIED, address: ZERO_ADDRESS }, // ETH
-      { metaType: MetaType.BORROWED, address: '0x5f98805a4e8be255a32880fdec7f6728c6568ba0' }, // LUSD
+      {
+        metaType: MetaType.SUPPLIED,
+        address: ZERO_ADDRESS, // ETH
+        network: this.network,
+      },
+      {
+        metaType: MetaType.BORROWED,
+        address: '0x5f98805a4e8be255a32880fdec7f6728c6568ba0', // LUSD
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/lyra-avalon/optimism/lyra-avalon.options.contract-position-fetcher.ts
+++ b/src/apps/lyra-avalon/optimism/lyra-avalon.options.contract-position-fetcher.ts
@@ -164,17 +164,37 @@ export class OptimismLyraAvalonOptionsContractPositionFetcher extends ContractPo
 
     if (definition.optionType === 0 || definition.optionType === 1) {
       // Long Call/Long Put
-      const quoteTokenDefinition = { metaType: MetaType.SUPPLIED, address: definition.quoteAddress };
+      const quoteTokenDefinition = {
+        metaType: MetaType.SUPPLIED,
+        address: definition.quoteAddress,
+        network: this.network,
+      };
       return [quoteTokenDefinition];
     } else if (definition.optionType === 2) {
       // Short Call Base
-      const quoteTokenDefinition = { metaType: MetaType.BORROWED, address: definition.quoteAddress };
-      const collateralTokenDefinition = { metaType: MetaType.SUPPLIED, address: definition.baseAddress };
+      const quoteTokenDefinition = {
+        metaType: MetaType.BORROWED,
+        address: definition.quoteAddress,
+        network: this.network,
+      };
+      const collateralTokenDefinition = {
+        metaType: MetaType.SUPPLIED,
+        address: definition.baseAddress,
+        network: this.network,
+      };
       return [quoteTokenDefinition, collateralTokenDefinition];
     } else {
       // Short Call Quote/Short Put Quote
-      const quoteTokenDefinition = { metaType: MetaType.BORROWED, address: definition.quoteAddress };
-      const collateralTokenDefinition = { metaType: MetaType.SUPPLIED, address: definition.quoteAddress };
+      const quoteTokenDefinition = {
+        metaType: MetaType.BORROWED,
+        address: definition.quoteAddress,
+        network: this.network,
+      };
+      const collateralTokenDefinition = {
+        metaType: MetaType.SUPPLIED,
+        address: definition.quoteAddress,
+        network: this.network,
+      };
       return [quoteTokenDefinition, collateralTokenDefinition];
     }
   }

--- a/src/apps/lyra-avalon/optimism/lyra-avalon.stk-lyra-claimable.contract-position-fetcher.ts
+++ b/src/apps/lyra-avalon/optimism/lyra-avalon.stk-lyra-claimable.contract-position-fetcher.ts
@@ -34,7 +34,13 @@ export class OptimismLyraAvalonStkLyraClaimableContractPositionFetcher extends C
   }
 
   async getTokenDefinitions(_params: GetTokenDefinitionsParams<LyraStkLyra>) {
-    return [{ metaType: MetaType.CLAIMABLE, address: '0x50c5725949a6f0c72e6c4a641f24049a917db0cb' }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x50c5725949a6f0c72e6c4a641f24049a917db0cb',
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<LyraStkLyra>) {

--- a/src/apps/maker/ethereum/maker.vault.contract-position-fetcher.ts
+++ b/src/apps/maker/ethereum/maker.vault.contract-position-fetcher.ts
@@ -83,8 +83,16 @@ export class EthereumMakerVaultContractPositionFetcher extends ContractPositionT
     definition,
   }: GetTokenDefinitionsParams<MakerGemJoin, MakerVaultDefinition>): Promise<UnderlyingTokenDefinition[] | null> {
     return [
-      { metaType: MetaType.SUPPLIED, address: definition.collateralTokenAddress }, // Vault Collateral
-      { metaType: MetaType.BORROWED, address: '0x6b175474e89094c44da98b954eedeac495271d0f' }, // DAI
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.collateralTokenAddress, // Vault Collateral
+        network: this.network,
+      },
+      {
+        metaType: MetaType.BORROWED,
+        address: '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/morpho/helpers/position-fetcher.common.ts
+++ b/src/apps/morpho/helpers/position-fetcher.common.ts
@@ -79,8 +79,16 @@ export abstract class BaseEthereumMorphoSupplyContractPositionFetcher<
   ): Promise<BigNumberish[]>;
   async getTokenDefinitions({ definition }: GetTokenDefinitionsParams<T, MorphoContractPositionDefinition>) {
     return [
-      { metaType: MetaType.SUPPLIED, address: definition.supplyTokenAddress },
-      { metaType: MetaType.BORROWED, address: definition.supplyTokenAddress },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.supplyTokenAddress,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.BORROWED,
+        address: definition.supplyTokenAddress,
+        network: this.network,
+      },
     ];
   }
 }

--- a/src/apps/origin-dollar/ethereum/origin-dollar.rewards.contract-position-fetcher.ts
+++ b/src/apps/origin-dollar/ethereum/origin-dollar.rewards.contract-position-fetcher.ts
@@ -36,7 +36,13 @@ export class EthereumOriginDollarRewardsContractPositionFetcher extends Contract
   }
 
   async getTokenDefinitions(): Promise<UnderlyingTokenDefinition[] | null> {
-    return [{ address: '0x9c354503c38481a7a7a51629142963f98ecc12d0', metaType: MetaType.CLAIMABLE }];
+    return [
+      {
+        address: '0x9c354503c38481a7a7a51629142963f98ecc12d0',
+        metaType: MetaType.CLAIMABLE,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<Veogv>) {

--- a/src/apps/origin-story/common/origin-story.series.contract-position-fetcher.ts
+++ b/src/apps/origin-story/common/origin-story.series.contract-position-fetcher.ts
@@ -35,7 +35,13 @@ export abstract class OriginStorySeriesContractPositionFetcher extends ContractP
   }
 
   async getTokenDefinitions(): Promise<UnderlyingTokenDefinition[]> {
-    return [{ address: '0x8207c1ffc5b6804f6024322ccf34f29c3541ae26', metaType: MetaType.SUPPLIED }];
+    return [
+      {
+        address: '0x8207c1ffc5b6804f6024322ccf34f29c3541ae26',
+        metaType: MetaType.SUPPLIED,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel(params: GetDisplayPropsParams<Series>): Promise<string> {

--- a/src/apps/pickle/ethereum/pickle.voting-escrow.contract-position-fetcher.ts
+++ b/src/apps/pickle/ethereum/pickle.voting-escrow.contract-position-fetcher.ts
@@ -64,9 +64,21 @@ export class EthereumPickleVotingEscrowContractPositionFetcher extends VotingEsc
     const reward = multicall.wrap(this.getRewardContract(this.rewardAddress));
 
     return [
-      { metaType: MetaType.SUPPLIED, address: await this.getEscrowedTokenAddress(escrow) },
-      { metaType: MetaType.CLAIMABLE, address: await this.getRewardTokenAddress(reward) },
-      { metaType: MetaType.CLAIMABLE, address: ZERO_ADDRESS },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: await this.getEscrowedTokenAddress(escrow),
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: await this.getRewardTokenAddress(reward),
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: ZERO_ADDRESS,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/plutus/arbitrum/plutus.tge-claimable.contract-position-fetcher.ts
+++ b/src/apps/plutus/arbitrum/plutus.tge-claimable.contract-position-fetcher.ts
@@ -33,7 +33,13 @@ export class ArbitrumPlutusTgeClaimableContractPositionFetcher extends ContractP
   }
 
   async getTokenDefinitions(_params: GetTokenDefinitionsParams<PlutusPrivateTgeVester>) {
-    return [{ metaType: MetaType.CLAIMABLE, address: '0x51318b7d00db7acc4026c88c3952b66278b6a67f' }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x51318b7d00db7acc4026c88c3952b66278b6a67f',
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<PlutusPrivateTgeVester>) {

--- a/src/apps/pods-yield/ethereum/pods-yield.queue.contract-position-fetcher.ts
+++ b/src/apps/pods-yield/ethereum/pods-yield.queue.contract-position-fetcher.ts
@@ -43,7 +43,13 @@ export class EthereumPodsYieldQueueContractPositionFetcher extends ContractPosit
   }
 
   async getTokenDefinitions({ contract }: GetTokenDefinitionsParams<PodsYieldVault>) {
-    return [{ metaType: MetaType.SUPPLIED, address: await contract.asset() }];
+    return [
+      {
+        metaType: MetaType.SUPPLIED,
+        address: await contract.asset(),
+        network: this.network,
+      },
+    ];
   }
 
   async getDataProps({ contract }: GetDataPropsParams<PodsYieldVault>): Promise<PodsYieldQueueDataProps> {

--- a/src/apps/polygon-staking/ethereum/polygon-staking.deposit.contract-position-fetcher.ts
+++ b/src/apps/polygon-staking/ethereum/polygon-staking.deposit.contract-position-fetcher.ts
@@ -122,8 +122,17 @@ export class EthereumPolygonStakingContractPositionFetcher extends ContractPosit
 
   async getTokenDefinitions(_params: GetTokenDefinitionsParams<PolygonStakeManager>) {
     return [
-      { metaType: MetaType.SUPPLIED, address: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0' },
-      { metaType: MetaType.CLAIMABLE, address: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0' },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0',
+        network: this.network,
+      },
+
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0',
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/pool-together-v3/common/pool-together-v3.airdrop.contract-position-fetcher.ts
+++ b/src/apps/pool-together-v3/common/pool-together-v3.airdrop.contract-position-fetcher.ts
@@ -55,7 +55,13 @@ export abstract class PoolTogetherV3AirdropContractPositionFetcher extends Contr
   async getTokenDefinitions(
     _opts: GetTokenDefinitionsParams<PoolTogetherMerkleDistributor, DefaultContractPositionDefinition>,
   ): Promise<UnderlyingTokenDefinition[] | null> {
-    return [{ address: this.airdropTokenAddress, metaType: MetaType.CLAIMABLE }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: this.airdropTokenAddress,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<PoolTogetherMerkleDistributor>) {

--- a/src/apps/pool-together-v3/common/pool-together-v3.claimable.contract-position-fetcher.ts
+++ b/src/apps/pool-together-v3/common/pool-together-v3.claimable.contract-position-fetcher.ts
@@ -44,7 +44,13 @@ export abstract class PoolTogetherV3ClaimableContractPositionFetcher extends Con
     UnderlyingTokenDefinition[] | null
   > {
     const rewardTokenAddressRaw = await contract.asset().then(addr => addr.toLowerCase());
-    return [{ address: rewardTokenAddressRaw, metaType: MetaType.CLAIMABLE }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: rewardTokenAddressRaw,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<PoolTogetherV3TokenFaucet>) {

--- a/src/apps/qi-dao/common/qi-dao.vault.contract-position-fetcher.ts
+++ b/src/apps/qi-dao/common/qi-dao.vault.contract-position-fetcher.ts
@@ -78,8 +78,16 @@ export abstract class QiDaoVaultContractPositionFetcher extends ContractPosition
     if (!collateralTokenAddressRaw || !debtTokenAddressRaw) return null;
 
     return [
-      { metaType: MetaType.SUPPLIED, address: collateralTokenAddressRaw.toLowerCase() },
-      { metaType: MetaType.BORROWED, address: debtTokenAddressRaw.toLowerCase() },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: collateralTokenAddressRaw.toLowerCase(),
+        network: this.network,
+      },
+      {
+        metaType: MetaType.BORROWED,
+        address: debtTokenAddressRaw.toLowerCase(),
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/rari-fuse/common/rari-fuse.borrow.contract-position-fetcher.ts
+++ b/src/apps/rari-fuse/common/rari-fuse.borrow.contract-position-fetcher.ts
@@ -80,7 +80,13 @@ export abstract class RariFuseBorrowContractPositionFetcher<
   }
 
   async getTokenDefinitions({ contract }: GetTokenDefinitionsParams<R>) {
-    return [{ metaType: MetaType.BORROWED, address: await this.getUnderlyingTokenAddress(contract) }];
+    return [
+      {
+        metaType: MetaType.BORROWED,
+        address: await this.getUnderlyingTokenAddress(contract),
+        network: this.network,
+      },
+    ];
   }
 
   async getDataProps({

--- a/src/apps/redacted-cartel/ethereum/redacted-cartel.bond.contract-position-fetcher.ts
+++ b/src/apps/redacted-cartel/ethereum/redacted-cartel.bond.contract-position-fetcher.ts
@@ -40,9 +40,21 @@ export class EthereumRedactedCartelBondContractPositionFetcher extends ContractP
     const [principle, claimable] = await Promise.all([contract.principal(), contract.BTRFLY()]);
 
     return [
-      { address: claimable, metaType: MetaType.VESTING },
-      { address: claimable, metaType: MetaType.CLAIMABLE },
-      { address: principle, metaType: MetaType.SUPPLIED },
+      {
+        metaType: MetaType.VESTING,
+        address: claimable,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: claimable,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: principle,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/ren/ethereum/ren.darknode.contract-position-fetcher.ts
+++ b/src/apps/ren/ethereum/ren.darknode.contract-position-fetcher.ts
@@ -40,8 +40,16 @@ export class EthereumRenDarknodeContractPositionFetcher extends ContractPosition
     const claimable = [ZERO_ADDRESS, ...assets.map(v => v.tokenAddress)];
 
     return [
-      { address: '0x408e41876cccdc0f92210600ef50372656052a38', metaType: MetaType.SUPPLIED },
-      ...claimable.map(address => ({ address, metaType: MetaType.CLAIMABLE })),
+      {
+        metaType: MetaType.SUPPLIED,
+        address: '0x408e41876cccdc0f92210600ef50372656052a38',
+        network: this.network,
+      },
+      ...claimable.map(claimableTokenAddress => ({
+        metaType: MetaType.CLAIMABLE,
+        address: claimableTokenAddress,
+        network: this.network,
+      })),
     ];
   }
 

--- a/src/apps/rhino-fi/ethereum/rhino-fi.deposit.contract-position-fetcher.ts
+++ b/src/apps/rhino-fi/ethereum/rhino-fi.deposit.contract-position-fetcher.ts
@@ -53,8 +53,16 @@ export class EthereumRhinoFiDepositContractPositionFetcher extends ContractPosit
 
   async getTokenDefinitions({ definition }: GetTokenDefinitionsParams<RhinoFiStarkEx, RhinoFiDepositDefinition>) {
     return [
-      { metaType: MetaType.SUPPLIED, address: definition.tokenAddress },
-      { metaType: MetaType.LOCKED, address: definition.tokenAddress },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.tokenAddress,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.LOCKED,
+        address: definition.tokenAddress,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/rocket-pool/ethereum/rocket-pool.minipool.contract-position-fetcher.ts
+++ b/src/apps/rocket-pool/ethereum/rocket-pool.minipool.contract-position-fetcher.ts
@@ -30,7 +30,13 @@ export class EthereumRocketPoolMinipoolContractPositionFetcher extends ContractP
   }
 
   async getTokenDefinitions() {
-    return [{ metaType: MetaType.SUPPLIED, address: ZERO_ADDRESS }];
+    return [
+      {
+        metaType: MetaType.SUPPLIED,
+        address: ZERO_ADDRESS,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<RocketMinipoolManager>) {

--- a/src/apps/rocket-pool/ethereum/rocket-pool.oracle-dao-bond.contract-position-fetcher.ts
+++ b/src/apps/rocket-pool/ethereum/rocket-pool.oracle-dao-bond.contract-position-fetcher.ts
@@ -28,7 +28,13 @@ export class EthereumRocketPoolOracleDaoBondContractPositionFetcher extends Cont
   }
 
   async getTokenDefinitions() {
-    return [{ metaType: MetaType.SUPPLIED, address: '0xd33526068d116ce69f19a9ee46f0bd304f21a51f' }];
+    return [
+      {
+        metaType: MetaType.SUPPLIED,
+        address: '0xd33526068d116ce69f19a9ee46f0bd304f21a51f',
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel() {

--- a/src/apps/rocket-pool/ethereum/rocket-pool.staking.contract-position-fetcher.ts
+++ b/src/apps/rocket-pool/ethereum/rocket-pool.staking.contract-position-fetcher.ts
@@ -29,7 +29,13 @@ export class EthereumRocketPoolStakingContractPositionFetcher extends ContractPo
   }
 
   async getTokenDefinitions() {
-    return [{ metaType: MetaType.SUPPLIED, address: '0xd33526068d116ce69f19a9ee46f0bd304f21a51f' }];
+    return [
+      {
+        metaType: MetaType.SUPPLIED,
+        address: '0xd33526068d116ce69f19a9ee46f0bd304f21a51f',
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<RocketNodeStaking>) {

--- a/src/apps/rook/ethereum/rook.claimable.contract-position-fetcher.ts
+++ b/src/apps/rook/ethereum/rook.claimable.contract-position-fetcher.ts
@@ -82,7 +82,13 @@ export class EthereumRookClaimableContractPositionFetcher extends ContractPositi
   }
 
   async getTokenDefinitions(): Promise<UnderlyingTokenDefinition[] | null> {
-    return [{ metaType: MetaType.CLAIMABLE, address: '0xfa5047c9c78b8877af97bdcb85db743fd7313d4a' }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0xfa5047c9c78b8877af97bdcb85db743fd7313d4a',
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<RookLiquidityPoolDistributor>) {

--- a/src/apps/sablier/ethereum/sablier.stream-legacy.contract-position-fetcher.ts
+++ b/src/apps/sablier/ethereum/sablier.stream-legacy.contract-position-fetcher.ts
@@ -55,7 +55,13 @@ export class EthereumSablierStreamLegacyContractPositionFetcher extends Contract
   async getTokenDefinitions({
     definition,
   }: GetTokenDefinitionsParams<SablierStream, SablierStreamLegacyContractPositionDefinition>) {
-    return [{ address: definition.tokenAddress, metaType: MetaType.SUPPLIED }];
+    return [
+      {
+        address: definition.tokenAddress,
+        metaType: MetaType.SUPPLIED,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({

--- a/src/apps/sablier/ethereum/sablier.stream.contract-position-fetcher.ts
+++ b/src/apps/sablier/ethereum/sablier.stream.contract-position-fetcher.ts
@@ -55,7 +55,13 @@ export class EthereumSablierStreamContractPositionFetcher extends ContractPositi
   async getTokenDefinitions({
     definition,
   }: GetTokenDefinitionsParams<SablierStream, SablierStreamContractPositionDefinition>) {
-    return [{ address: definition.tokenAddress, metaType: MetaType.SUPPLIED }];
+    return [
+      {
+        address: definition.tokenAddress,
+        metaType: MetaType.SUPPLIED,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<SablierStream, SablierStreamContractPositionDataProps>) {

--- a/src/apps/stakefish/ethereum/stakefish.staking.contract-position-fetcher.ts
+++ b/src/apps/stakefish/ethereum/stakefish.staking.contract-position-fetcher.ts
@@ -45,9 +45,21 @@ export class EthereumStakefishStakingContractPositionFetcher extends ContractPos
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.SUPPLIED, address: ZERO_ADDRESS },
-      { metaType: MetaType.VESTING, address: ZERO_ADDRESS },
-      { metaType: MetaType.CLAIMABLE, address: ZERO_ADDRESS },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: ZERO_ADDRESS,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.VESTING,
+        address: ZERO_ADDRESS,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: ZERO_ADDRESS,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/sushiswap-kashi/common/sushiswap-kashi.leverage.contract-position-fetcher.ts
+++ b/src/apps/sushiswap-kashi/common/sushiswap-kashi.leverage.contract-position-fetcher.ts
@@ -56,8 +56,16 @@ export class SushiswapKashiLeverageContractPositionFetcher extends ContractPosit
     definition,
   }: GetTokenDefinitionsParams<SushiswapKashiLendingToken, SushiswapKashiLeverageDefinition>) {
     return [
-      { metaType: MetaType.BORROWED, address: definition.assetAddress },
-      { metaType: MetaType.SUPPLIED, address: definition.collateralAddress },
+      {
+        metaType: MetaType.BORROWED,
+        address: definition.assetAddress,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.collateralAddress,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/synthetix/common/synthetix.loan.contract-position-fetcher.ts
+++ b/src/apps/synthetix/common/synthetix.loan.contract-position-fetcher.ts
@@ -61,9 +61,21 @@ export abstract class SynthetixLoanContractPositionFetcher extends ContractPosit
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.SUPPLIED, address: ZERO_ADDRESS },
-      { metaType: MetaType.BORROWED, address: this.sUSDAddress },
-      { metaType: MetaType.BORROWED, address: this.sETHAddress },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: ZERO_ADDRESS,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.BORROWED,
+        address: this.sUSDAddress,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.BORROWED,
+        address: this.sETHAddress,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/synthetix/common/synthetix.mintr.contract-position-fetcher.ts
+++ b/src/apps/synthetix/common/synthetix.mintr.contract-position-fetcher.ts
@@ -45,8 +45,16 @@ export abstract class SynthetixMintrContractPositionFetcher extends ContractPosi
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.SUPPLIED, address: this.snxAddress },
-      { metaType: MetaType.BORROWED, address: this.sUSDAddress },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: this.snxAddress,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.BORROWED,
+        address: this.sUSDAddress,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/tarot/fantom/tarot.borrow.contract-position-fetcher.ts
+++ b/src/apps/tarot/fantom/tarot.borrow.contract-position-fetcher.ts
@@ -69,7 +69,13 @@ export class FantomTarotBorrowContractPositionFetcher extends ContractPositionTe
 
   async getTokenDefinitions({ contract }: GetTokenDefinitionsParams<TarotBorrowable>) {
     const underlyingAddress = await contract.underlying();
-    return [{ address: underlyingAddress, metaType: MetaType.BORROWED }];
+    return [
+      {
+        metaType: MetaType.BORROWED,
+        address: underlyingAddress,
+        network: this.network,
+      },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<TarotBorrowable>): Promise<DisplayProps['label']> {

--- a/src/apps/teddy-cash/avalanche/teddy-cash.stability-pool.contract-position-fetcher.ts
+++ b/src/apps/teddy-cash/avalanche/teddy-cash.stability-pool.contract-position-fetcher.ts
@@ -36,9 +36,21 @@ export class AvalancheTeddyCashStabilityPoolContractPositionFetcher extends Cont
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.SUPPLIED, address: '0x4fbf0429599460d327bd5f55625e30e4fc066095' }, // TSD
-      { metaType: MetaType.CLAIMABLE, address: ZERO_ADDRESS }, // AVAX
-      { metaType: MetaType.CLAIMABLE, address: '0x094bd7b2d99711a1486fb94d4395801c6d0fddcc' }, // TEDDY
+      {
+        metaType: MetaType.SUPPLIED,
+        address: '0x4fbf0429599460d327bd5f55625e30e4fc066095', // TSD
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: ZERO_ADDRESS, // AVAX
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x094bd7b2d99711a1486fb94d4395801c6d0fddcc', // TEDDY
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/teddy-cash/avalanche/teddy-cash.trove.contract-position-fetcher.ts
+++ b/src/apps/teddy-cash/avalanche/teddy-cash.trove.contract-position-fetcher.ts
@@ -35,8 +35,16 @@ export class AvalancheTeddyCashTroveContractPositionFetcher extends ContractPosi
 
   async getTokenDefinitions() {
     return [
-      { metaType: MetaType.SUPPLIED, address: ZERO_ADDRESS }, // AVAX
-      { metaType: MetaType.BORROWED, address: '0x4fbf0429599460d327bd5f55625e30e4fc066095' }, // TSD
+      {
+        metaType: MetaType.SUPPLIED,
+        address: ZERO_ADDRESS, // AVAX
+        network: this.network,
+      },
+      {
+        metaType: MetaType.BORROWED,
+        address: '0x4fbf0429599460d327bd5f55625e30e4fc066095', // TSD
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/umami-finance/arbitrum/umami-finance.marinate.contract-position-fetcher.ts
+++ b/src/apps/umami-finance/arbitrum/umami-finance.marinate.contract-position-fetcher.ts
@@ -35,8 +35,16 @@ export class ArbitrumUmamiFinanceMarinateContractPositionFetcher extends Contrac
 
   async getTokenDefinitions(_params: GetTokenDefinitionsParams<UmamiFinanceMarinate>) {
     return [
-      { metaType: MetaType.SUPPLIED, address: '0x2adabd6e8ce3e82f52d9998a7f64a90d294a92a4' },
-      { metaType: MetaType.CLAIMABLE, address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1' },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: '0x2adabd6e8ce3e82f52d9998a7f64a90d294a92a4',
+        network: this.network,
+      },
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/unipilot/common/unipilot.vault.token-fetcher.ts
+++ b/src/apps/unipilot/common/unipilot.vault.token-fetcher.ts
@@ -57,8 +57,16 @@ export abstract class UnipilotVaultTokenFetcher extends AppTokenTemplatePosition
 
   async getTokenDefinitions({ definition }: GetTokenDefinitionsParams<UnipilotVault, UnipilotVaultDefinition>) {
     return [
-      { metaType: MetaType.SUPPLIED, address: definition.token0Address },
-      { metaType: MetaType.SUPPLIED, address: definition.token1Address },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.token0Address,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.token1Address,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/uniswap-v3/common/uniswap-v3.liquidity.contract-position-fetcher.ts
+++ b/src/apps/uniswap-v3/common/uniswap-v3.liquidity.contract-position-fetcher.ts
@@ -104,8 +104,16 @@ export abstract class UniswapV3LiquidityContractPositionFetcher extends Contract
     definition,
   }: GetTokenDefinitionsParams<UniswapV3PositionManager, UniswapV3LiquidityPositionDefinition>) {
     return [
-      { metaType: MetaType.SUPPLIED, address: definition.token0Address },
-      { metaType: MetaType.SUPPLIED, address: definition.token1Address },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.token0Address,
+        network: this.network,
+      },
+      {
+        metaType: MetaType.SUPPLIED,
+        address: definition.token1Address,
+        network: this.network,
+      },
     ];
   }
 

--- a/src/apps/wolf-game/ethereum/wolf-game.wool-pouch.contract-position-fetcher.ts
+++ b/src/apps/wolf-game/ethereum/wolf-game.wool-pouch.contract-position-fetcher.ts
@@ -1,5 +1,4 @@
 import { Inject } from '@nestjs/common';
-import { BigNumberish } from 'ethers';
 import { gql } from 'graphql-request';
 
 import { drillBalance } from '~app-toolkit';
@@ -11,12 +10,9 @@ import { ContractPositionBalance } from '~position/position-balance.interface';
 import { MetaType } from '~position/position.interface';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import {
-  GetDefinitionsParams,
   DefaultContractPositionDefinition,
   GetTokenDefinitionsParams,
   UnderlyingTokenDefinition,
-  GetDisplayPropsParams,
-  GetTokenBalancesParams,
 } from '~position/template/contract-position.template.types';
 
 import { WolfGameContractFactory, WolfGameWoolPouch } from '../contracts';
@@ -41,7 +37,7 @@ export class EthereumWolfGameWoolPouchContractPositionFetcher extends ContractPo
   ) {
     super(appToolKit);
   }
-  async getDefinitions(params: GetDefinitionsParams): Promise<DefaultContractPositionDefinition[]> {
+  async getDefinitions(): Promise<DefaultContractPositionDefinition[]> {
     return [{ address: '0xb76fbbb30e31f2c3bdaa2466cfb1cfe39b220d06' }];
   }
   getContract(address: string): WolfGameWoolPouch {
@@ -50,21 +46,23 @@ export class EthereumWolfGameWoolPouchContractPositionFetcher extends ContractPo
   async getTokenDefinitions(
     _params: GetTokenDefinitionsParams<WolfGameWoolPouch, DefaultContractPositionDefinition>,
   ): Promise<UnderlyingTokenDefinition[] | null> {
-    return [{ metaType: MetaType.CLAIMABLE, address: '0x8355dbe8b0e275abad27eb843f3eaf3fc855e525' }];
+    return [
+      {
+        metaType: MetaType.CLAIMABLE,
+        address: '0x8355dbe8b0e275abad27eb843f3eaf3fc855e525',
+        network: this.network,
+      },
+    ];
   }
-  async getLabel(
-    params: GetDisplayPropsParams<WolfGameWoolPouch, DefaultDataProps, DefaultContractPositionDefinition>,
-  ): Promise<string> {
+  async getLabel(): Promise<string> {
     return 'Wool Pouch';
   }
-  getTokenBalancesPerPosition({
-    address,
-    contractPosition,
-    contract,
-    multicall,
-  }: GetTokenBalancesParams<WolfGameWoolPouch, DefaultDataProps>): Promise<BigNumberish[]> {
+
+  // @ts-ignore
+  async getTokenBalancesPerPosition() {
     throw new Error('Method not implemented.');
   }
+
   async getBalances(address: string): Promise<ContractPositionBalance<DefaultDataProps>[]> {
     const multicall = this.appToolkit.getMulticall(this.network);
     const contractPositions = await this.appToolkit.getAppContractPositions({

--- a/src/position/template/contract-position.template.types.ts
+++ b/src/position/template/contract-position.template.types.ts
@@ -4,14 +4,17 @@ import { IMulticallWrapper } from '~multicall/multicall.interface';
 import { DefaultDataProps } from '~position/display.interface';
 import { ContractPosition, MetaType } from '~position/position.interface';
 import { TokenDependencySelector } from '~position/selectors/token-dependency-selector.interface';
+import { Network } from '~types';
 
 export type DefaultContractPositionDefinition = {
   address: string;
 };
 
 export type UnderlyingTokenDefinition = {
-  address: string;
   metaType: MetaType;
+  address: string;
+  network: Network;
+  tokenId?: number;
 };
 
 // PHASE 1: List definitions

--- a/src/position/template/master-chef-v2.template.contract-position-fetcher.ts
+++ b/src/position/template/master-chef-v2.template.contract-position-fetcher.ts
@@ -69,7 +69,9 @@ export abstract class MasterChefV2TemplateContractPositionFetcher<
 
     const rewarderContract = multicall.wrap(this.getExtraRewarderContract(extraRewarderAddress));
     const extraRewardTokenAddresses = await this.getExtraRewardTokenAddresses(rewarderContract, definition.poolIndex);
-    tokenDefinitions.push(...extraRewardTokenAddresses.map(v => ({ metaType: MetaType.CLAIMABLE, address: v })));
+    tokenDefinitions.push(
+      ...extraRewardTokenAddresses.map(v => ({ metaType: MetaType.CLAIMABLE, address: v, network: this.network })),
+    );
 
     return tokenDefinitions;
   }

--- a/src/position/template/master-chef.template.contract-position-fetcher.ts
+++ b/src/position/template/master-chef.template.contract-position-fetcher.ts
@@ -100,8 +100,10 @@ export abstract class MasterChefTemplateContractPositionFetcher<
 
     if (!stakedTokenAddress || !rewardTokenAddresses) return null;
 
-    tokenDefinitions.push({ metaType: MetaType.SUPPLIED, address: stakedTokenAddress });
-    rewardTokenAddresses.forEach(v => tokenDefinitions.push({ metaType: MetaType.CLAIMABLE, address: v }));
+    tokenDefinitions.push({ metaType: MetaType.SUPPLIED, address: stakedTokenAddress, network: this.network });
+    rewardTokenAddresses.forEach(v =>
+      tokenDefinitions.push({ metaType: MetaType.CLAIMABLE, address: v, network: this.network }),
+    );
     return tokenDefinitions;
   }
 

--- a/src/position/template/merkle.template.contract-position-fetcher.ts
+++ b/src/position/template/merkle.template.contract-position-fetcher.ts
@@ -31,7 +31,7 @@ export abstract class MerkleTemplateContractPositionFetcher<
   }
 
   async getTokenDefinitions({ definition }: GetTokenDefinitionsParams<T, MerkleContractPositionDefinition>) {
-    return [{ metaType: MetaType.CLAIMABLE, address: definition.rewardTokenAddress }];
+    return [{ metaType: MetaType.CLAIMABLE, address: definition.rewardTokenAddress, network: this.network }];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<T>) {

--- a/src/position/template/single-staking.dynamic.template.contract-position-fetcher.ts
+++ b/src/position/template/single-staking.dynamic.template.contract-position-fetcher.ts
@@ -48,8 +48,21 @@ export abstract class SingleStakingFarmDynamicTemplateContractPositionFetcher<
     const rewardTokenAddresses = await this.getRewardTokenAddresses(params).then(v => (isArray(v) ? v : [v]));
 
     const tokens: UnderlyingTokenDefinition[] = [];
-    tokens.push({ metaType: MetaType.SUPPLIED, address: stakedTokenAddress.toLowerCase() });
-    tokens.push(...rewardTokenAddresses.map(v => ({ metaType: MetaType.CLAIMABLE, address: v.toLowerCase() })));
+
+    tokens.push({
+      metaType: MetaType.SUPPLIED,
+      address: stakedTokenAddress.toLowerCase(),
+      network: this.network,
+    });
+
+    tokens.push(
+      ...rewardTokenAddresses.map(v => ({
+        metaType: MetaType.CLAIMABLE,
+        address: v.toLowerCase(),
+        network: this.network,
+      })),
+    );
+
     return tokens;
   }
 

--- a/src/position/template/single-staking.template.contract-position-fetcher.ts
+++ b/src/position/template/single-staking.template.contract-position-fetcher.ts
@@ -49,8 +49,21 @@ export abstract class SingleStakingFarmTemplateContractPositionFetcher<
 
   async getTokenDefinitions({ definition }: GetTokenDefinitionsParams<T, SingleStakingFarmDefinition>) {
     const tokenDefinitions: UnderlyingTokenDefinition[] = [];
-    tokenDefinitions.push({ metaType: MetaType.SUPPLIED, address: definition.stakedTokenAddress });
-    tokenDefinitions.push(...definition.rewardTokenAddresses.map(v => ({ metaType: MetaType.CLAIMABLE, address: v })));
+
+    tokenDefinitions.push({
+      metaType: MetaType.SUPPLIED,
+      address: definition.stakedTokenAddress,
+      network: this.network,
+    });
+
+    tokenDefinitions.push(
+      ...definition.rewardTokenAddresses.map(v => ({
+        metaType: MetaType.CLAIMABLE,
+        address: v,
+        network: this.network,
+      })),
+    );
+
     return tokenDefinitions;
   }
 

--- a/src/position/template/voting-escrow-with-rewards.template.contract-position-fetcher.ts
+++ b/src/position/template/voting-escrow-with-rewards.template.contract-position-fetcher.ts
@@ -37,8 +37,8 @@ export abstract class VotingEscrowWithRewardsTemplateContractPositionFetcher<
     const reward = multicall.wrap(this.getRewardContract(this.rewardAddress));
 
     return [
-      { metaType: MetaType.SUPPLIED, address: await this.getEscrowedTokenAddress(escrow) },
-      { metaType: MetaType.CLAIMABLE, address: await this.getRewardTokenAddress(reward) },
+      { metaType: MetaType.SUPPLIED, address: await this.getEscrowedTokenAddress(escrow), network: this.network },
+      { metaType: MetaType.CLAIMABLE, address: await this.getRewardTokenAddress(reward), network: this.network },
     ];
   }
 

--- a/src/position/template/voting-escrow.template.contract-position-fetcher.ts
+++ b/src/position/template/voting-escrow.template.contract-position-fetcher.ts
@@ -28,7 +28,9 @@ export abstract class VotingEscrowTemplateContractPositionFetcher<
   }
 
   async getTokenDefinitions(params: GetTokenDefinitionsParams<T>) {
-    return [{ metaType: MetaType.SUPPLIED, address: await this.getEscrowedTokenAddress(params) }];
+    return [
+      { metaType: MetaType.SUPPLIED, address: await this.getEscrowedTokenAddress(params), network: this.network },
+    ];
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<T>) {


### PR DESCRIPTION
## Description

- Enable `network` and `tokenId` as part of the token definitions. Its an edge case, but some positions/tokens have underlying tokens on other networks (i.e.: bridged gOHM), and some positions/tokens have underlying ERC1155 tokens (i.e.: Notional Finance fCASH)

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
