### PR TITLE
feat(contract-positions): Custom contract positions

### DIFF
--- a/src/apps/balancer-v2/common/balancer-v2.claimable.contract-position-fetcher.ts
+++ b/src/apps/balancer-v2/common/balancer-v2.claimable.contract-position-fetcher.ts
@@ -15,13 +15,14 @@ import {
   GetDisplayPropsParams,
   UnderlyingTokenDefinition,
 } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { BalancerMerkleOrchard, BalancerV2ContractFactory } from '../contracts';
 
 import { BalancerV2ClaimableCacheManager } from './balancer-v2.claimable.cache-manager';
 import { BALANCER_V2_CLAIMABLE_CONFIG } from './balancer-v2.claimable.config';
 
-export abstract class BalancerV2ClaimableContractPositionFetcher extends ContractPositionTemplatePositionFetcher<BalancerMerkleOrchard> {
+export abstract class BalancerV2ClaimableContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<BalancerMerkleOrchard> {
   constructor(
     @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
     @Inject(BalancerV2ContractFactory) protected readonly contractFactory: BalancerV2ContractFactory,

--- a/src/apps/bend-dao/ethereum/bend-dao.variable-debt.token-fetcher.ts
+++ b/src/apps/bend-dao/ethereum/bend-dao.variable-debt.token-fetcher.ts
@@ -22,6 +22,7 @@ export class EthereumBendDaoVariableDebtTokenFetcher extends AppTokenTemplatePos
   debtTokenAddress = '0x87dde3a3f4b629e389ce5894c9a1f34a7eec5648';
   wethAddress = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
   dataProviderAddress = '0x0b54cdf07d5467012a2d5731c5f87f9c6945bea9';
+  isDebt: true;
 
   constructor(
     @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
@@ -72,24 +73,5 @@ export class EthereumBendDaoVariableDebtTokenFetcher extends AppTokenTemplatePos
 
   async getTertiaryLabel({ appToken }: GetDisplayPropsParams<BendDaoDebtToken>) {
     return `${appToken.dataProps.apy.toFixed(3)}% APR (variable)`;
-  }
-
-  async getBalances(address: string): Promise<AppTokenPositionBalance<DefaultAppTokenDataProps>[]> {
-    const multicall = this.appToolkit.getMulticall(this.network);
-    const appTokens = await this.appToolkit.getAppTokenPositions<DefaultAppTokenDataProps>({
-      appId: this.appId,
-      network: this.network,
-      groupIds: [this.groupId],
-    });
-
-    const balances = await Promise.all(
-      appTokens.map(async appToken => {
-        const balanceRaw = await this.getBalancePerToken({ multicall, address, appToken });
-        const tokenBalance = drillBalance(appToken, balanceRaw.toString(), { isDebt: true });
-        return tokenBalance;
-      }),
-    );
-
-    return balances as AppTokenPositionBalance<DefaultAppTokenDataProps>[];
   }
 }

--- a/src/apps/bend-dao/ethereum/bend-dao.variable-debt.token-fetcher.ts
+++ b/src/apps/bend-dao/ethereum/bend-dao.variable-debt.token-fetcher.ts
@@ -22,7 +22,7 @@ export class EthereumBendDaoVariableDebtTokenFetcher extends AppTokenTemplatePos
   debtTokenAddress = '0x87dde3a3f4b629e389ce5894c9a1f34a7eec5648';
   wethAddress = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
   dataProviderAddress = '0x0b54cdf07d5467012a2d5731c5f87f9c6945bea9';
-  isDebt: true;
+  isDebt = true;
 
   constructor(
     @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,

--- a/src/apps/chicken-bond/ethereum/chicken-bond.bond.contract-position-fetcher.ts
+++ b/src/apps/chicken-bond/ethereum/chicken-bond.bond.contract-position-fetcher.ts
@@ -10,6 +10,7 @@ import { ContractPositionBalance } from '~position/position-balance.interface';
 import { MetaType } from '~position/position.interface';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import { DefaultContractPositionDefinition } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { ChickenBondBondNft, ChickenBondContractFactory } from '../contracts';
 
@@ -20,7 +21,7 @@ enum BondStatus {
 }
 
 @PositionTemplate()
-export class EthereumChickenBondBondContractPositionFetcher extends ContractPositionTemplatePositionFetcher<ChickenBondBondNft> {
+export class EthereumChickenBondBondContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<ChickenBondBondNft> {
   groupLabel = 'Bond';
 
   constructor(

--- a/src/apps/concave/ethereum/concave.liquid-staking.contract-position-fetcher.ts
+++ b/src/apps/concave/ethereum/concave.liquid-staking.contract-position-fetcher.ts
@@ -15,6 +15,7 @@ import { MetaType } from '~position/position.interface';
 import { isClaimable, isSupplied } from '~position/position.utils';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import { GetTokenBalancesParams, GetTokenDefinitionsParams } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { ConcaveContractFactory, Lsdcnv } from '../contracts';
 
@@ -55,7 +56,7 @@ export type ConcaveLsdcnvContractPositionDataProps = {
 };
 
 @PositionTemplate()
-export class EthereumConcaveLiquidStakingContractPositionFetcher extends ContractPositionTemplatePositionFetcher<Lsdcnv> {
+export class EthereumConcaveLiquidStakingContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<Lsdcnv> {
   groupLabel = 'Liquid Staking';
 
   constructor(

--- a/src/apps/euler/common/euler.d-token.token-fetcher.ts
+++ b/src/apps/euler/common/euler.d-token.token-fetcher.ts
@@ -20,7 +20,7 @@ export abstract class EulerDTokenTokenFetcher extends AppTokenTemplatePositionFe
   DefaultAppTokenDataProps,
   EulerTokenDefinition
 > {
-  isDebt: true;
+  isDebt = true;
   abstract tokenType: EulerTokenType;
 
   constructor(

--- a/src/apps/euler/common/euler.d-token.token-fetcher.ts
+++ b/src/apps/euler/common/euler.d-token.token-fetcher.ts
@@ -20,6 +20,7 @@ export abstract class EulerDTokenTokenFetcher extends AppTokenTemplatePositionFe
   DefaultAppTokenDataProps,
   EulerTokenDefinition
 > {
+  isDebt: true;
   abstract tokenType: EulerTokenType;
 
   constructor(
@@ -65,24 +66,5 @@ export abstract class EulerDTokenTokenFetcher extends AppTokenTemplatePositionFe
   async getApy({ appToken }: GetDataPropsParams<EulerDtokenContract>) {
     const market = await this.tokenDefinitionsResolver.getMarket(appToken.address, this.tokenType);
     return (Number(market!.borrowAPY) * 100) / 1e27;
-  }
-
-  async getBalances(address: string): Promise<AppTokenPositionBalance<DefaultAppTokenDataProps>[]> {
-    const multicall = this.appToolkit.getMulticall(this.network);
-    const appTokens = await this.appToolkit.getAppTokenPositions<DefaultAppTokenDataProps>({
-      appId: this.appId,
-      network: this.network,
-      groupIds: [this.groupId],
-    });
-
-    const balances = await Promise.all(
-      appTokens.map(async appToken => {
-        const balanceRaw = await this.getBalancePerToken({ multicall, address, appToken });
-        const tokenBalance = drillBalance(appToken, balanceRaw.toString(), { isDebt: true });
-        return tokenBalance;
-      }),
-    );
-
-    return balances as AppTokenPositionBalance<DefaultAppTokenDataProps>[];
   }
 }

--- a/src/apps/euler/common/euler.e-token.token-fetcher.ts
+++ b/src/apps/euler/common/euler.e-token.token-fetcher.ts
@@ -1,9 +1,11 @@
 import { Inject } from '@nestjs/common';
 import { ethers } from 'ethers';
+import _ from 'lodash';
 
 import { drillBalance } from '~app-toolkit';
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
-import { AppTokenPositionBalance } from '~position/position-balance.interface';
+import { DefaultDataProps } from '~position/display.interface';
+import { AppTokenPositionBalance, RawTokenBalance } from '~position/position-balance.interface';
 import { AppTokenTemplatePositionFetcher } from '~position/template/app-token.template.position-fetcher';
 import {
   GetUnderlyingTokensParams,
@@ -82,7 +84,7 @@ export abstract class EulerETokenTokenFetcher extends AppTokenTemplatePositionFe
     return (Number(market!.supplyAPY) * 100) / 1e27;
   }
 
-  async getBalances(address: string): Promise<AppTokenPositionBalance<DefaultAppTokenDataProps>[]> {
+  async getRawBalances(address: string): Promise<RawTokenBalance[]> {
     const multicall = this.appToolkit.getMulticall(this.network);
     const appTokens = await this.appToolkit.getAppTokenPositions<DefaultAppTokenDataProps>({
       appId: this.appId,
@@ -90,19 +92,52 @@ export abstract class EulerETokenTokenFetcher extends AppTokenTemplatePositionFe
       groupIds: [this.groupId],
     });
 
-    const balances = await Promise.all(
-      appTokens.map(async appToken => {
-        const balanceRaw = await this.getBalancePerToken({ multicall, address, appToken });
-        const underlyingBalance = await multicall
-          .wrap(this.getContract(appToken.address))
-          .convertBalanceToUnderlying(balanceRaw);
+    return (
+      await Promise.all(
+        appTokens.map(async appToken => {
+          const balanceRaw = await this.getBalancePerToken({ multicall, address, appToken });
+          const underlyingBalance = await multicall
+            .wrap(this.getContract(appToken.address))
+            .convertBalanceToUnderlying(balanceRaw);
 
-        const appTokenBalance = drillBalance(appToken, balanceRaw.toString());
-        const tokenBalance = drillBalance(appToken.tokens[0], underlyingBalance.toString());
-        return { ...appTokenBalance, tokens: [tokenBalance] };
-      }),
-    );
+          return [
+            {
+              key: this.appToolkit.getPositionKey(appToken),
+              balance: (await this.getBalancePerToken({ multicall, address, appToken })).toString(),
+            },
+            {
+              key: `${this.appToolkit.getPositionKey(appToken)}-underlying`,
+              balance: underlyingBalance.toString(),
+            },
+          ];
+        }),
+      )
+    ).flat();
+  }
 
-    return balances as AppTokenPositionBalance<DefaultAppTokenDataProps>[];
+  async drillRawBalances(balances: RawTokenBalance[]): Promise<AppTokenPositionBalance<DefaultAppTokenDataProps>[]> {
+    const appTokens = await this.getPositionsForBalances();
+
+    const appTokenBalances = appTokens.map(token => {
+      const tokenBalance = balances.find(b => b.key === this.appToolkit.getPositionKey(token));
+      const underlyingTokenBalance = balances.find(
+        b => b.key === `${this.appToolkit.getPositionKey(token)}-underlying`,
+      );
+
+      if (!tokenBalance || !underlyingTokenBalance) return null;
+
+      const result = drillBalance<typeof token, DefaultAppTokenDataProps>(token, tokenBalance.balance, {
+        isDebt: this.isDebt,
+      });
+
+      const underlyingToken = drillBalance<typeof token, DefaultAppTokenDataProps>(
+        appTokens[0],
+        underlyingTokenBalance.balance,
+      );
+
+      return { ...result, tokens: [underlyingToken] };
+    });
+
+    return _.compact(appTokenBalances);
   }
 }

--- a/src/apps/good-ghosting/common/good-ghosting.game.contract-position-fetcher.ts
+++ b/src/apps/good-ghosting/common/good-ghosting.game.contract-position-fetcher.ts
@@ -14,6 +14,7 @@ import {
   UnderlyingTokenDefinition,
   GetDisplayPropsParams,
 } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 import { Network } from '~types';
 
 import { GoodGhostingContractFactory, GoodghostingAbiV001 } from '../contracts';
@@ -31,7 +32,7 @@ export type GoodGhostingGameDefinition = {
 };
 
 @Injectable()
-export abstract class GoodGhostingGameContractPositionFetcher extends ContractPositionTemplatePositionFetcher<
+export abstract class GoodGhostingGameContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<
   GoodghostingAbiV001,
   DefaultDataProps,
   GoodGhostingGameDefinition

--- a/src/apps/homora-v2/common/homora-v2.farm.contract-position-fetcher.ts
+++ b/src/apps/homora-v2/common/homora-v2.farm.contract-position-fetcher.ts
@@ -14,6 +14,7 @@ import {
   GetDisplayPropsParams,
   GetTokenDefinitionsParams,
 } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 import { Network, NETWORK_IDS } from '~types';
 
 import { HomoraBank, HomoraV2ContractFactory } from '../contracts';
@@ -27,7 +28,7 @@ import {
   PoolPosition,
 } from '../interfaces/interfaces';
 
-export abstract class HomoraV2FarmContractPositionFetcher extends ContractPositionTemplatePositionFetcher<
+export abstract class HomoraV2FarmContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<
   HomoraBank,
   HomoraV2FarmingPositionDataProps,
   HomoraV2FarmingPositionDefinition

--- a/src/apps/kyberswap-elastic/common/kyberswap-elastic.farm.contract-position-fetcher.ts
+++ b/src/apps/kyberswap-elastic/common/kyberswap-elastic.farm.contract-position-fetcher.ts
@@ -13,6 +13,7 @@ import {
   GetDisplayPropsParams,
   GetTokenDefinitionsParams,
 } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { KyberswapElasticContractFactory, KyberswapElasticLm } from '../contracts';
 
@@ -38,7 +39,7 @@ export type KyberswapElasticFarmPositionDefinition = {
   feeTier: number;
 };
 
-export abstract class KyberswapElasticFarmContractPositionFetcher extends ContractPositionTemplatePositionFetcher<
+export abstract class KyberswapElasticFarmContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<
   KyberswapElasticLm,
   KyberswapElasticFarmPositionDataProps,
   KyberswapElasticFarmPositionDefinition

--- a/src/apps/kyberswap-elastic/common/kyberswap-elastic.liquidity.contract-position-fetcher.ts
+++ b/src/apps/kyberswap-elastic/common/kyberswap-elastic.liquidity.contract-position-fetcher.ts
@@ -12,6 +12,7 @@ import {
   GetDisplayPropsParams,
   GetTokenDefinitionsParams,
 } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { KyberswapElasticContractFactory, PositionManager } from '../contracts';
 
@@ -51,7 +52,7 @@ type GetTopPoolsResponse = {
   }[];
 };
 
-export abstract class KyberswapElasticLiquidityContractPositionFetcher extends ContractPositionTemplatePositionFetcher<
+export abstract class KyberswapElasticLiquidityContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<
   PositionManager,
   KyberswapElasticLiquidityPositionDataProps,
   KyberswapElasticLiquidityPositionDefinition

--- a/src/apps/maker/ethereum/maker.vault.contract-position-fetcher.ts
+++ b/src/apps/maker/ethereum/maker.vault.contract-position-fetcher.ts
@@ -20,6 +20,7 @@ import {
   GetTokenDefinitionsParams,
   UnderlyingTokenDefinition,
 } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { MakerContractFactory, MakerGemJoin } from '../contracts';
 
@@ -37,7 +38,7 @@ export type MakerVaultDataProps = {
 };
 
 @PositionTemplate()
-export class EthereumMakerVaultContractPositionFetcher extends ContractPositionTemplatePositionFetcher<
+export class EthereumMakerVaultContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<
   MakerGemJoin,
   MakerVaultDataProps,
   MakerVaultDefinition

--- a/src/apps/polygon-staking/ethereum/polygon-staking.deposit.contract-position-fetcher.ts
+++ b/src/apps/polygon-staking/ethereum/polygon-staking.deposit.contract-position-fetcher.ts
@@ -18,6 +18,7 @@ import {
   GetTokenBalancesParams,
   GetDataPropsParams,
 } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { PolygonStakingContractFactory } from '../contracts';
 import { PolygonStakeManager } from '../contracts/ethers/PolygonStakeManager';
@@ -81,7 +82,7 @@ type PolygonStakingDepositDataProps = {
 };
 
 @PositionTemplate()
-export class EthereumPolygonStakingContractPositionFetcher extends ContractPositionTemplatePositionFetcher<
+export class EthereumPolygonStakingContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<
   PolygonStakeManager,
   PolygonStakingDepositDataProps,
   PolygonStakingDepositDefinition

--- a/src/apps/qi-dao/common/qi-dao.vault.contract-position-fetcher.ts
+++ b/src/apps/qi-dao/common/qi-dao.vault.contract-position-fetcher.ts
@@ -14,6 +14,7 @@ import {
   GetDisplayPropsParams,
   GetDataPropsParams,
 } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { QiDaoContractFactory, QiDaoVaultNft } from '../contracts';
 
@@ -30,7 +31,7 @@ type QiDaoVaultDefinition = {
 };
 
 @Injectable()
-export abstract class QiDaoVaultContractPositionFetcher extends ContractPositionTemplatePositionFetcher<
+export abstract class QiDaoVaultContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<
   QiDaoVaultNft,
   QiDaoVaultDataProps,
   QiDaoVaultDefinition

--- a/src/apps/rari-fuse/common/rari-fuse.borrow.contract-position-fetcher.ts
+++ b/src/apps/rari-fuse/common/rari-fuse.borrow.contract-position-fetcher.ts
@@ -15,6 +15,7 @@ import {
   GetDisplayPropsParams,
   GetTokenBalancesParams,
 } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 export type RariFuseBorrowContractPositionDataProps = {
   apy: number;
@@ -34,7 +35,7 @@ export abstract class RariFuseBorrowContractPositionFetcher<
   V extends Contract,
   R extends Contract,
   S extends Contract,
-> extends ContractPositionTemplatePositionFetcher<
+> extends CustomContractPositionTemplatePositionFetcher<
   R,
   RariFuseBorrowContractPositionDataProps,
   RariFuseBorrowContractPositionDefinition

--- a/src/apps/ren/ethereum/ren.darknode.contract-position-fetcher.ts
+++ b/src/apps/ren/ethereum/ren.darknode.contract-position-fetcher.ts
@@ -11,12 +11,13 @@ import { MetaType } from '~position/position.interface';
 import { isClaimable, isSupplied } from '~position/position.utils';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import { GetDisplayPropsParams } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { RenApiClient } from '../common/ren.api.client';
 import { RenContractFactory, RenDarknodeRegistry } from '../contracts';
 
 @PositionTemplate()
-export class EthereumRenDarknodeContractPositionFetcher extends ContractPositionTemplatePositionFetcher<RenDarknodeRegistry> {
+export class EthereumRenDarknodeContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<RenDarknodeRegistry> {
   groupLabel = 'Darknodes';
 
   constructor(

--- a/src/apps/rhino-fi/ethereum/rhino-fi.deposit.contract-position-fetcher.ts
+++ b/src/apps/rhino-fi/ethereum/rhino-fi.deposit.contract-position-fetcher.ts
@@ -12,6 +12,7 @@ import { ContractPositionBalance } from '~position/position-balance.interface';
 import { MetaType } from '~position/position.interface';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import { GetDisplayPropsParams, GetTokenDefinitionsParams } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { RhinoFiApiClient } from '../common/rhino-fi.api-client';
 import { RhinoFiCacheManager } from '../common/rhino-fi.cache-manager';
@@ -23,7 +24,7 @@ type RhinoFiDepositDefinition = {
 };
 
 @PositionTemplate()
-export class EthereumRhinoFiDepositContractPositionFetcher extends ContractPositionTemplatePositionFetcher<
+export class EthereumRhinoFiDepositContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<
   RhinoFiStarkEx,
   DefaultDataProps,
   RhinoFiDepositDefinition

--- a/src/apps/sablier/ethereum/sablier.stream-legacy.contract-position-fetcher.ts
+++ b/src/apps/sablier/ethereum/sablier.stream-legacy.contract-position-fetcher.ts
@@ -12,6 +12,7 @@ import { ContractPositionBalance } from '~position/position-balance.interface';
 import { MetaType } from '~position/position.interface';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import { GetDisplayPropsParams, GetTokenDefinitionsParams } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { SablierStreamApiClient } from '../common/sablier.stream.api-client';
 import { SablierContractFactory, SablierStream } from '../contracts';
@@ -27,7 +28,7 @@ export type SablierStreamLegacyContractPositionDefinition = {
 };
 
 @PositionTemplate()
-export class EthereumSablierStreamLegacyContractPositionFetcher extends ContractPositionTemplatePositionFetcher<
+export class EthereumSablierStreamLegacyContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<
   SablierStream,
   SablierStreamLegacyContractPositionDataProps,
   SablierStreamLegacyContractPositionDefinition

--- a/src/apps/sablier/ethereum/sablier.stream.contract-position-fetcher.ts
+++ b/src/apps/sablier/ethereum/sablier.stream.contract-position-fetcher.ts
@@ -12,6 +12,7 @@ import { ContractPositionBalance } from '~position/position-balance.interface';
 import { MetaType } from '~position/position.interface';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import { GetDisplayPropsParams, GetTokenDefinitionsParams } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { SablierStreamApiClient } from '../common/sablier.stream.api-client';
 import { SablierContractFactory, SablierStream } from '../contracts';
@@ -27,7 +28,7 @@ export type SablierStreamContractPositionDefinition = {
 };
 
 @PositionTemplate()
-export class EthereumSablierStreamContractPositionFetcher extends ContractPositionTemplatePositionFetcher<
+export class EthereumSablierStreamContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<
   SablierStream,
   SablierStreamContractPositionDataProps,
   SablierStreamContractPositionDefinition

--- a/src/apps/uniswap-v3/common/uniswap-v3.liquidity.contract-position-fetcher.ts
+++ b/src/apps/uniswap-v3/common/uniswap-v3.liquidity.contract-position-fetcher.ts
@@ -12,6 +12,7 @@ import {
   GetDisplayPropsParams,
   GetTokenDefinitionsParams,
 } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { UniswapV3ContractFactory, UniswapV3PositionManager } from '../contracts';
 
@@ -63,7 +64,7 @@ const GET_TOP_POOLS_QUERY = gql`
   }
 `;
 
-export abstract class UniswapV3LiquidityContractPositionFetcher extends ContractPositionTemplatePositionFetcher<
+export abstract class UniswapV3LiquidityContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<
   UniswapV3PositionManager,
   UniswapV3LiquidityPositionDataProps,
   UniswapV3LiquidityPositionDefinition

--- a/src/apps/wolf-game/ethereum/wolf-game.wool-pouch.contract-position-fetcher.ts
+++ b/src/apps/wolf-game/ethereum/wolf-game.wool-pouch.contract-position-fetcher.ts
@@ -14,6 +14,7 @@ import {
   GetTokenDefinitionsParams,
   UnderlyingTokenDefinition,
 } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { WolfGameContractFactory, WolfGameWoolPouch } from '../contracts';
 
@@ -29,7 +30,7 @@ const pouchesQuery = gql`
 `;
 
 @PositionTemplate()
-export class EthereumWolfGameWoolPouchContractPositionFetcher extends ContractPositionTemplatePositionFetcher<WolfGameWoolPouch> {
+export class EthereumWolfGameWoolPouchContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<WolfGameWoolPouch> {
   groupLabel = 'Wool Pouches';
   constructor(
     @Inject(APP_TOOLKIT) protected readonly appToolKit: AppToolkit,

--- a/src/apps/yield-protocol/common/yield-protocol.borrow.contract-position-fetcher.ts
+++ b/src/apps/yield-protocol/common/yield-protocol.borrow.contract-position-fetcher.ts
@@ -17,6 +17,7 @@ import {
   GetDisplayPropsParams,
   GetDataPropsParams,
 } from '~position/template/contract-position.template.types';
+import { CustomContractPositionTemplatePositionFetcher } from '~position/template/custom-contract-position.template.position-fetcher';
 
 import { YieldProtocolContractFactory, YieldProtocolLadle } from '../contracts';
 
@@ -132,7 +133,7 @@ const vaultsQuery = gql`
 
 // TESTTT: 0x35e057137060cd397bd82e3dff54beba480e7012
 
-export abstract class YieldProtocolBorrowContractPositionFetcher extends ContractPositionTemplatePositionFetcher<
+export abstract class YieldProtocolBorrowContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<
   YieldProtocolLadle,
   YieldProtocolBorrowDataProps,
   YieldProtocolBorrowDefinition

--- a/src/position/position-fetcher.template-registry.ts
+++ b/src/position/position-fetcher.template-registry.ts
@@ -11,7 +11,10 @@ import { AppTokenTemplatePositionFetcher } from './template/app-token.template.p
 import { ContractPositionTemplatePositionFetcher } from './template/contract-position.template.position-fetcher';
 import { CustomContractPositionTemplatePositionFetcher } from './template/custom-contract-position.template.position-fetcher';
 
-type Template = AppTokenTemplatePositionFetcher<Erc20> | ContractPositionTemplatePositionFetcher<Erc20>;
+type Template =
+  | AppTokenTemplatePositionFetcher<Erc20>
+  | ContractPositionTemplatePositionFetcher<Erc20>
+  | CustomContractPositionTemplatePositionFetcher<Erc20>;
 
 @Injectable()
 export class PositionFetcherTemplateRegistry implements OnModuleInit {

--- a/src/position/position-fetcher.template-registry.ts
+++ b/src/position/position-fetcher.template-registry.ts
@@ -9,6 +9,7 @@ import { buildTemplateRegistry } from '~utils/build-template-registry';
 import { ContractType } from './contract.interface';
 import { AppTokenTemplatePositionFetcher } from './template/app-token.template.position-fetcher';
 import { ContractPositionTemplatePositionFetcher } from './template/contract-position.template.position-fetcher';
+import { CustomContractPositionTemplatePositionFetcher } from './template/custom-contract-position.template.position-fetcher';
 
 type Template = AppTokenTemplatePositionFetcher<Erc20> | ContractPositionTemplatePositionFetcher<Erc20>;
 
@@ -24,6 +25,11 @@ export class PositionFetcherTemplateRegistry implements OnModuleInit {
     Map<Network, Map<string, ContractPositionTemplatePositionFetcher<Erc20>>>
   >();
 
+  private customContractPositionTemplateRegistry = new Map<
+    string,
+    Map<Network, Map<string, CustomContractPositionTemplatePositionFetcher<Erc20>>>
+  >();
+
   constructor(@Inject(DiscoveryService) private readonly discoveryService: DiscoveryService) {}
 
   onModuleInit() {
@@ -34,6 +40,11 @@ export class PositionFetcherTemplateRegistry implements OnModuleInit {
 
     this.contractPositionTemplateRegistry = buildTemplateRegistry(this.discoveryService, {
       template: ContractPositionTemplatePositionFetcher,
+      keySelector: t => [t.appId, t.network, t.groupId] as const,
+    });
+
+    this.customContractPositionTemplateRegistry = buildTemplateRegistry(this.discoveryService, {
+      template: CustomContractPositionTemplatePositionFetcher,
       keySelector: t => [t.appId, t.network, t.groupId] as const,
     });
   }
@@ -58,10 +69,19 @@ export class PositionFetcherTemplateRegistry implements OnModuleInit {
     return Array.from(this.contractPositionTemplateRegistry.get(appId)?.get(network)?.values() ?? []);
   }
 
+  getCustomContractPositionTemplate({ network, appId, groupId }: { network: Network; appId: string; groupId: string }) {
+    return this.customContractPositionTemplateRegistry.get(appId)?.get(network)?.get(groupId) ?? null;
+  }
+
+  getCustomContractPositionTemplates({ network, appId }: { network: Network; appId: string }) {
+    return Array.from(this.customContractPositionTemplateRegistry.get(appId)?.get(network)?.values() ?? []);
+  }
+
   getTemplatesForApp(appId: string) {
     const appTokenNetworks = Array.from(this.appTokenTemplateRegistry.get(appId)?.keys() ?? []);
     const contractPositionNetworks = Array.from(this.contractPositionTemplateRegistry.get(appId)?.keys() ?? []);
-    const networks = uniq([...appTokenNetworks, ...contractPositionNetworks]);
+    const customPositions = Array.from(this.customContractPositionTemplateRegistry.get(appId)?.keys() ?? []);
+    const networks = uniq([...appTokenNetworks, ...contractPositionNetworks, ...customPositions]);
 
     return networks.flatMap(network => this.getTemplatesForAppOnNetwork(appId, network));
   }
@@ -69,7 +89,8 @@ export class PositionFetcherTemplateRegistry implements OnModuleInit {
   getAppHasTemplates(appId: string) {
     const appTokenNetworks = Array.from(this.appTokenTemplateRegistry.get(appId)?.keys() ?? []);
     const contractPositionNetworks = Array.from(this.contractPositionTemplateRegistry.get(appId)?.keys() ?? []);
-    const networks = uniq([...appTokenNetworks, ...contractPositionNetworks]);
+    const customPositions = Array.from(this.customContractPositionTemplateRegistry.get(appId)?.keys() ?? []);
+    const networks = uniq([...appTokenNetworks, ...contractPositionNetworks, ...customPositions]);
 
     return networks.some(network => this.getAppHasTemplatesOnNetwork(appId, network));
   }
@@ -77,19 +98,26 @@ export class PositionFetcherTemplateRegistry implements OnModuleInit {
   getTemplatesForAppOnNetwork(appId: string, network: Network) {
     const appTokenTemplates = this.appTokenTemplateRegistry.get(appId)?.get(network);
     const contractPositionTemplates = this.contractPositionTemplateRegistry.get(appId)?.get(network);
-    return [...Array.from(appTokenTemplates?.values() ?? []), ...Array.from(contractPositionTemplates?.values() ?? [])];
+    const customPositions = this.customContractPositionTemplateRegistry.get(appId)?.get(network);
+    return [
+      ...Array.from(appTokenTemplates?.values() ?? []),
+      ...Array.from(contractPositionTemplates?.values() ?? []),
+      ...Array.from(customPositions?.values() ?? []),
+    ];
   }
 
   getAppHasTemplatesOnNetwork(appId: string, network: Network) {
     const appTokenTemplates = this.appTokenTemplateRegistry.get(appId)?.get(network);
     const contractPositionTemplates = this.contractPositionTemplateRegistry.get(appId)?.get(network);
-    return !!appTokenTemplates || !!contractPositionTemplates;
+    const customPositionTemplates = this.customContractPositionTemplateRegistry.get(appId)?.get(network);
+    return !!appTokenTemplates || !!contractPositionTemplates || !!customPositionTemplates;
   }
 
   getAllTemplates() {
     const appTokenAppIds = Array.from(this.appTokenTemplateRegistry.keys() ?? []);
     const contractAppIds = Array.from(this.contractPositionTemplateRegistry.keys() ?? []);
-    const appIds = uniq([...appTokenAppIds, ...contractAppIds]);
+    const customAppIds = Array.from(this.customContractPositionTemplateRegistry.keys() ?? []);
+    const appIds = uniq([...appTokenAppIds, ...contractAppIds, ...customAppIds]);
 
     return appIds.flatMap(appId => this.getTemplatesForApp(appId));
   }

--- a/src/position/template/custom-contract-position.template.position-fetcher.ts
+++ b/src/position/template/custom-contract-position.template.position-fetcher.ts
@@ -1,0 +1,191 @@
+import { Inject, NotImplementedException } from '@nestjs/common';
+import { BigNumberish, Contract } from 'ethers/lib/ethers';
+import { compact, sumBy } from 'lodash';
+
+import { drillBalance } from '~app-toolkit';
+import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
+import {
+  buildDollarDisplayItem,
+  buildPercentageDisplayItem,
+} from '~app-toolkit/helpers/presentation/display-item.present';
+import { getImagesFromToken } from '~app-toolkit/helpers/presentation/image.present';
+import { ContractType } from '~position/contract.interface';
+import { DefaultDataProps, DisplayProps, StatsItem } from '~position/display.interface';
+import { ContractPositionBalance, RawContractPositionBalance } from '~position/position-balance.interface';
+import { PositionFetcher } from '~position/position-fetcher.interface';
+import { ContractPosition, MetaType } from '~position/position.interface';
+import { metatyped } from '~position/position.utils';
+import { Network } from '~types/network.interface';
+
+import {
+  DefaultContractPositionDefinition,
+  GetDataPropsParams,
+  GetDefinitionsParams,
+  GetDisplayPropsParams,
+  GetTokenBalancesParams,
+  GetTokenDefinitionsParams,
+  UnderlyingTokenDefinition,
+} from './contract-position.template.types';
+import { PositionFetcherTemplateCommons } from './position-fetcher.template.types';
+
+export abstract class CustomContractPositionTemplatePositionFetcher<
+  T extends Contract,
+  V extends DefaultDataProps = DefaultDataProps,
+  R extends DefaultContractPositionDefinition = DefaultContractPositionDefinition,
+> implements PositionFetcher<ContractPosition<V>>, PositionFetcherTemplateCommons
+{
+  appId: string;
+  groupId: string;
+  network: Network;
+  abstract groupLabel: string;
+
+  isExcludedFromBalances = false;
+  isExcludedFromExplore = false;
+  isExcludedFromTvl = false;
+
+  constructor(@Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit) {}
+
+  // 1. Get contract position definitions (i.e.: contract addresses and additional context)
+  abstract getDefinitions(params: GetDefinitionsParams): Promise<R[]>;
+
+  // 2. Get contract instance
+  abstract getContract(address: string): T;
+
+  // 3. Get token definitions (supplied tokens, borrowed tokens, claimable tokens, etc.)
+  abstract getTokenDefinitions(_params: GetTokenDefinitionsParams<T, R>): Promise<UnderlyingTokenDefinition[] | null>;
+
+  // 4. Get additional data properties
+  async getDataProps(_params: GetDataPropsParams<T, V, R>): Promise<V> {
+    return {} as V;
+  }
+
+  // 5. Get display properties
+  abstract getLabel(params: GetDisplayPropsParams<T, V, R>): Promise<string>;
+
+  async getLabelDetailed(_params: GetDisplayPropsParams<T, V>): Promise<DisplayProps['labelDetailed']> {
+    return undefined;
+  }
+
+  async getSecondaryLabel(_params: GetDisplayPropsParams<T, V>): Promise<DisplayProps['secondaryLabel']> {
+    return undefined;
+  }
+
+  async getTertiaryLabel({ contractPosition }: GetDisplayPropsParams<T, V>): Promise<DisplayProps['tertiaryLabel']> {
+    if (typeof contractPosition.dataProps.apy === 'number') return `${contractPosition.dataProps.apy.toFixed(3)}% APY`;
+    return undefined;
+  }
+
+  async getImages({ contractPosition }: GetDisplayPropsParams<T, V>): Promise<DisplayProps['images']> {
+    return contractPosition.tokens.flatMap(v => getImagesFromToken(v));
+  }
+
+  async getStatsItems({ contractPosition }: GetDisplayPropsParams<T, V>): Promise<DisplayProps['statsItems']> {
+    const statsItems: StatsItem[] = [];
+
+    // Standardized Fields
+    if (typeof contractPosition.dataProps.liquidity === 'number' && Math.abs(contractPosition.dataProps.liquidity) > 0)
+      statsItems.push({ label: 'Liquidity', value: buildDollarDisplayItem(contractPosition.dataProps.liquidity) });
+    if (typeof contractPosition.dataProps.apy === 'number' && contractPosition.dataProps.apy > 0)
+      statsItems.push({ label: 'APY', value: buildPercentageDisplayItem(contractPosition.dataProps.apy) });
+
+    return statsItems;
+  }
+
+  getKey({ contractPosition }: { contractPosition: ContractPosition<V> }): string {
+    return this.appToolkit.getPositionKey(contractPosition);
+  }
+
+  // Default (adapted) Template Runner
+  // Note: This will be removed in favour of an orchestrator at a higher level once all groups are migrated
+  async getPositions() {
+    const multicall = this.appToolkit.getMulticall(this.network);
+    const tokenLoader = this.appToolkit.getTokenDependencySelector({
+      tags: { network: this.network, context: `${this.appId}__template` },
+    });
+
+    const definitions = await this.getDefinitions({ multicall, tokenLoader });
+
+    const skeletons = await Promise.all(
+      definitions.map(async definition => {
+        const address = definition.address.toLowerCase();
+        const contract = multicall.wrap(this.getContract(definition.address));
+        const context = { address, contract, definition, multicall, tokenLoader };
+
+        const maybeTokenDefinitions = await this.getTokenDefinitions(context);
+        if (!maybeTokenDefinitions) return null;
+
+        const tokenDefinitionsArr = Array.isArray(maybeTokenDefinitions)
+          ? maybeTokenDefinitions
+          : [maybeTokenDefinitions];
+        const tokenDefinitions = tokenDefinitionsArr.map(t => ({ ...t, address: t.address.toLowerCase() }));
+
+        return { address, definition, tokenDefinitions };
+      }),
+    );
+
+    const underlyingTokenRequests = compact(skeletons)
+      .flatMap(v => v.tokenDefinitions)
+      .map(v => ({ address: v.address, network: v.network, tokenId: v.tokenId }));
+    const tokenDependencies = await tokenLoader.getMany(underlyingTokenRequests).then(tokenDeps => compact(tokenDeps));
+
+    const skeletonsWithResolvedTokens = await Promise.all(
+      compact(skeletons).map(async ({ address, tokenDefinitions, definition }) => {
+        const maybeTokens = tokenDefinitions.map(v => {
+          const match = tokenDependencies.find(t => t.address === v.address);
+          return match ? metatyped(match, v.metaType) : null;
+        });
+
+        const tokens = compact(maybeTokens);
+        if (maybeTokens.length !== tokens.length) return null;
+        return { address, tokens, definition };
+      }),
+    );
+
+    const tokens = await Promise.all(
+      compact(skeletonsWithResolvedTokens).map(async ({ address, tokens, definition }) => {
+        const contract = multicall.wrap(this.getContract(address));
+        const baseContext = { address, contract, multicall, tokenLoader, definition };
+
+        const baseFragment: GetDataPropsParams<T, V>['contractPosition'] = {
+          type: ContractType.POSITION,
+          appId: this.appId,
+          groupId: this.groupId,
+          network: this.network,
+          address,
+          tokens,
+        };
+
+        // Resolve Data Props Stage
+        const dataPropsStageParams = { ...baseContext, contractPosition: baseFragment };
+        const dataProps = await this.getDataProps(dataPropsStageParams);
+
+        // Resolve Display Props Stage
+        const displayPropsStageFragment = { ...baseFragment, dataProps };
+        const displayPropsStageParams = { ...dataPropsStageParams, contractPosition: displayPropsStageFragment };
+        const displayProps = {
+          label: await this.getLabel(displayPropsStageParams),
+          labelDetailed: await this.getLabelDetailed(displayPropsStageParams),
+          secondaryLabel: await this.getSecondaryLabel(displayPropsStageParams),
+          tertiaryLabel: await this.getTertiaryLabel(displayPropsStageParams),
+          images: await this.getImages(displayPropsStageParams),
+          statsItems: await this.getStatsItems(displayPropsStageParams),
+        };
+
+        const contractPosition = { ...baseFragment, dataProps, displayProps };
+        const key = this.getKey({ contractPosition });
+        return { key, ...contractPosition };
+      }),
+    );
+
+    return tokens;
+  }
+
+  abstract getTokenBalancesPerPosition({
+    address,
+    contractPosition,
+    contract,
+    multicall,
+  }: GetTokenBalancesParams<T, V>): Promise<BigNumberish[]>;
+
+  abstract getBalances(address: string): Promise<ContractPositionBalance<V>[]>;
+}


### PR DESCRIPTION
## Description

This PR introduces a new template called `CustomPositionTemplatePositionFetcher`. This template forces the implementer to write the `getBalances` method that directly returns the `ContractPositionBalance` instead of using the `getBalanceRaw` and `drillBalanceRaw` methods from the base template.

The goal is to be able to identify Apps with custom needs that don't fit in our model and treat them as such.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
