### PR TITLE
fix(schedule): Use only 1 metadata attribute for @Schedule

### DIFF
--- a/src/scheduler/scheduler.decorator.ts
+++ b/src/scheduler/scheduler.decorator.ts
@@ -1,14 +1,11 @@
 import { applyDecorators, SetMetadata } from '@nestjs/common';
 
-import { SCHEDULER_INTERVAL, SCHEDULER_IS_SCHEDULED_OPERATION } from './scheduler.constants';
+export const SCHEDULER_OPTIONS = 'SCHEDULER_OPTIONS';
 
 export type ScheduleOptions = {
   every: number;
 };
 
 export const Schedule = (options: ScheduleOptions) => {
-  return applyDecorators(
-    SetMetadata(SCHEDULER_IS_SCHEDULED_OPERATION, true),
-    SetMetadata(SCHEDULER_INTERVAL, options.every),
-  );
+  return applyDecorators(SetMetadata(SCHEDULER_OPTIONS, options));
 };

--- a/src/scheduler/scheduler.service.ts
+++ b/src/scheduler/scheduler.service.ts
@@ -2,8 +2,7 @@ import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nest
 import { DiscoveryService, MetadataScanner, Reflector } from '@nestjs/core';
 import chalk from 'chalk';
 
-import { SCHEDULER_INTERVAL } from './scheduler.constants';
-import { ScheduleOptions } from './scheduler.decorator';
+import { ScheduleOptions, SCHEDULER_OPTIONS } from './scheduler.decorator';
 
 @Injectable()
 export class SchedulerService implements OnModuleInit, OnModuleDestroy {
@@ -38,10 +37,10 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
   private registerSchedule(instance: any, methodName: string) {
     const logger = this.logger;
     const methodRef = instance[methodName];
-    const intervalTimeout: ScheduleOptions['every'] = this.reflector.get(SCHEDULER_INTERVAL, methodRef);
+    const opts = this.reflector.get<ScheduleOptions | undefined>(SCHEDULER_OPTIONS, methodRef);
 
     // Don't register interval when missing parameters
-    if (!intervalTimeout) return;
+    if (!opts) return;
 
     let liveData = methodRef.apply(instance);
     // Duck typing shennanigans
@@ -64,7 +63,7 @@ export class SchedulerService implements OnModuleInit, OnModuleDestroy {
         logger.error(`@Schedule target error for ${instance.constructor.name}#${methodName}: ${e.message}`);
         logger.error(chalk.gray(e.stack));
       });
-    }, intervalTimeout);
+    }, opts.every);
 
     this.intervals.push(interval);
   }


### PR DESCRIPTION
## Description

This is to make sure the APIs on both api & studio are fully aligned.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
