### PR TITLE
fix(vendor-finance): fix lender positions after migration

### DIFF
--- a/src/apps/vendor-finance/arbitrum/vendor-finance.pool.contract-position-fetcher.ts
+++ b/src/apps/vendor-finance/arbitrum/vendor-finance.pool.contract-position-fetcher.ts
@@ -76,7 +76,7 @@ export class ArbitrumVendorFinancePoolContractPositionFetcher extends ContractPo
   }
 
   // returning the lendToken with two different status as it'll either be
-  // deposited initially (user = lender) or borrowed (user = borrower)
+  // deposited initially (user = lender) or borrowed (user = borrower).
   async getTokenDefinitions({ definition }: GetTokenDefinitionsParams<VendorFinancePool, VendorFinancePoolDefinition>) {
     return [
       { metaType: MetaType.SUPPLIED, address: definition.colToken, network: this.network },

--- a/src/apps/vendor-finance/arbitrum/vendor-finance.pool.contract-position-fetcher.ts
+++ b/src/apps/vendor-finance/arbitrum/vendor-finance.pool.contract-position-fetcher.ts
@@ -12,6 +12,7 @@ import { MetaType } from '~position/position.interface';
 import { isBorrowed } from '~position/position.utils';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import {
+  GetDataPropsParams,
   GetDisplayPropsParams,
   GetTokenBalancesParams,
   GetTokenDefinitionsParams,
@@ -34,6 +35,12 @@ export type VendorFinancePoolDefinition = {
   lendBalance: string;
   totalBorrowed: string;
 };
+
+type VendorFinancePoolDataProps = DefaultDataProps & {
+  deployer: string;
+  totalDeposited: number;
+};
+
 @PositionTemplate()
 export class ArbitrumVendorFinancePoolContractPositionFetcher extends ContractPositionTemplatePositionFetcher<VendorFinancePool> {
   groupLabel = 'Lending Pools';
@@ -68,10 +75,13 @@ export class ArbitrumVendorFinancePoolContractPositionFetcher extends ContractPo
     }));
   }
 
+  // returning the lendToken with two different status as it'll either be
+  // deposited initially (user = lender) or borrowed (user = borrower)
   async getTokenDefinitions({ definition }: GetTokenDefinitionsParams<VendorFinancePool, VendorFinancePoolDefinition>) {
     return [
       { metaType: MetaType.SUPPLIED, address: definition.colToken, network: this.network },
       { metaType: MetaType.BORROWED, address: definition.lendToken, network: this.network },
+      { metaType: MetaType.SUPPLIED, address: definition.lendToken, network: this.network },
     ];
   }
 
@@ -123,14 +133,30 @@ export class ArbitrumVendorFinancePoolContractPositionFetcher extends ContractPo
       },
     ];
   }
+  async getDataProps(
+    _params: GetDataPropsParams<VendorFinancePool, DefaultDataProps, VendorFinancePoolDefinition>,
+  ): Promise<VendorFinancePoolDataProps> {
+    return {
+      deployer: _params.definition.deployer,
+      totalDeposited: parseInt(_params.definition.lendBalance) + parseInt(_params.definition.totalBorrowed),
+    };
+  }
 
   async getTokenBalancesPerPosition({
     address,
     contractPosition,
-  }: GetTokenBalancesParams<VendorFinancePool, DefaultDataProps>) {
+  }: GetTokenBalancesParams<VendorFinancePool, VendorFinancePoolDataProps>) {
     const collateralToken = contractPosition.tokens[0]!;
     const lentToken = contractPosition.tokens[1]!;
 
+    // --- Lender logic ----
+    // No deposit, no borrow, but lending out
+    if (address === contractPosition.dataProps.deployer.toLowerCase()) {
+      return ['0', '0', contractPosition.dataProps.totalDeposited.toString()];
+    }
+    // --! Lender logic !---
+
+    // --- Borrower logic ----
     const data = await this.appToolkit.helpers.theGraphHelper.requestGraph<VendorBorrowerGraphResponse>({
       endpoint: VENDOR_GRAPH_URL,
       query: borrowerInfosQuery(address),
@@ -144,6 +170,8 @@ export class ArbitrumVendorFinancePoolContractPositionFetcher extends ContractPo
     const suppliedBalanceRaw = suppliedBalance * 10 ** collateralToken.decimals;
     const borrowedBalance = parseInt(borrowerPosition.totalBorrowed);
 
-    return [suppliedBalanceRaw.toString(), borrowedBalance.toString()];
+    // Deposit, borrow, no lending out (not pool creator)
+    return [suppliedBalanceRaw.toString(), borrowedBalance.toString(), '0'];
+    // --! Borrower logic !---
   }
 }


### PR DESCRIPTION
## Description

Following the migration to the new template, one part of the integration was failing.
A vendor pool consist of : 
- 2 tokens
- One lender who only lends out === 1 token in the `ContractPosition`
- Borrowers who deposit + borrow === 2 tokens in the `ContractPosition`

The "lent out" and "borrowed" token is the same, and has to be present with two different status `SUPPLIED` and `BORROWED`. 

For example a wETH/USDC pool where you can borrow USDC against wETH

If the user querying is the lender ( pool creator/deployer ), the returned balances array is 
```
[
  "0", => wETH deposited
  "0", => USDC borrowed
  lentOutBalance => USDC lent out
]
```

If he is a borrower 
```
[
  depositedBalance, => wETH deposited
  borrowedBalance, => USDC borrowed
  "0" => USDC lent out
]
```

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: clonescody.eth
- [x] (optional) As a contributor, my Twitter handle is: [Clonescody](https://twitter.com/Clonescody)

## How to test?

AppId `vendor-finance`

Lender : http://localhost:5001/apps/vendor-finance/balances?addresses%5B%5D=0x38BDa44E85610BB5d737A6ab5CCd09f173b5ecAF&network=arbitrum

Borrower : http://localhost:5001/apps/vendor-finance/balances?addresses%5B%5D=0xcba1a275e2d858ecffaf7a87f606f74b719a8a93&network=arbitrum
