### PR TITLE
fix(template): Fix balance mistmatch for contract position template

### DIFF
--- a/src/position/template/contract-position.template.position-fetcher.ts
+++ b/src/position/template/contract-position.template.position-fetcher.ts
@@ -244,15 +244,11 @@ export abstract class ContractPositionTemplatePositionFetcher<
         const contract = multicall.wrap(this.getContract(contractPosition.address));
         const balancesRaw = await this.getTokenBalancesPerPosition({ address, contract, contractPosition, multicall });
 
-        if (contractPosition.tokens.length > balancesRaw.length) {
-          throw new Error(`Balance mismatch for ${contractPosition.appId}:${contractPosition.groupId}`);
-        }
-
         return {
           key: this.appToolkit.getPositionKey(contractPosition),
           tokens: contractPosition.tokens.map((token, i) => ({
             key: this.appToolkit.getPositionKey(token),
-            balance: balancesRaw[i].toString(),
+            balance: balancesRaw[i]?.toString() ?? '0',
           })),
         };
       }),


### PR DESCRIPTION
## Description

In the `getBalances` method, we default the raw balance to `0` if the array returned by `getTokenBalancesPerPosition` returns less balances than the amount of tokens in the contract position.

We added a `throw` statement in the getRawBalances because we thought this was an invalid scenario, but it looks like we should just return 0 in this case. 

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
