### PR TITLE
feat(convex): Show deposits in explore and TVL

### DIFF
--- a/src/apps/convex/common/convex.deposit-sidechain.token-fetcher.ts
+++ b/src/apps/convex/common/convex.deposit-sidechain.token-fetcher.ts
@@ -26,9 +26,6 @@ export abstract class ConvexDepositSidechainTokenFetcher extends AppTokenTemplat
 > {
   abstract boosterAddress: string;
 
-  isExcludedFromExplore = true;
-  isExcludedFromTvl = true;
-
   constructor(
     @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
     @Inject(ConvexContractFactory) protected readonly contractFactory: ConvexContractFactory,


### PR DESCRIPTION
## Description

Convex on sidechains/L2 works differently. It is tokenized, so include them in the TVL since they're not double-counted in the farms.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
