### PR TITLE
fix(synthetix): Use synth asset's logo instead of underlying

### DIFF
--- a/src/apps/synthetix/common/synthetix.synth.token-fetcher.ts
+++ b/src/apps/synthetix/common/synthetix.synth.token-fetcher.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { ethers } from 'ethers';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
-import { getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
+import { getAppAssetImage } from '~app-toolkit/helpers/presentation/image.present';
 import { AppTokenTemplatePositionFetcher } from '~position/template/app-token.template.position-fetcher';
 import {
   GetAddressesParams,
@@ -14,6 +14,7 @@ import {
 } from '~position/template/app-token.template.types';
 
 import { SynthetixContractFactory, SynthetixSynthToken } from '../contracts';
+import { SYNTHETIX_DEFINITION } from '../synthetix.definition';
 
 type SynthetixSynthDataProps = DefaultAppTokenDataProps & {
   exchangeable: boolean;
@@ -123,6 +124,6 @@ export abstract class SynthetixSynthTokenFetcher extends AppTokenTemplatePositio
   }
 
   async getImages({ appToken }: GetDisplayPropsParams<SynthetixSynthToken>) {
-    return [getTokenImg(appToken.address, this.network)];
+    return [getAppAssetImage(SYNTHETIX_DEFINITION.id, appToken.symbol)];
   }
 }


### PR DESCRIPTION
## Description

- Use synth asset logo instead underlying

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
