### PR TITLE
fix(yield-protocol): Add missing meta type for borrowed positions

### DIFF
--- a/src/apps/yield-protocol/common/yield-protocol.borrow.contract-position-fetcher.ts
+++ b/src/apps/yield-protocol/common/yield-protocol.borrow.contract-position-fetcher.ts
@@ -10,8 +10,8 @@ import { getImagesFromToken, getLabelFromToken } from '~app-toolkit/helpers/pres
 import { ContractType } from '~position/contract.interface';
 import { ContractPositionBalance } from '~position/position-balance.interface';
 import { MetaType } from '~position/position.interface';
+import { borrowed, supplied } from '~position/position.utils';
 import { GetDefinitionsParams } from '~position/template/app-token.template.types';
-import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import {
   GetTokenDefinitionsParams,
   GetDisplayPropsParams,
@@ -269,8 +269,13 @@ export abstract class YieldProtocolBorrowContractPositionFetcher extends CustomC
         if (!art || !ilk) return null;
 
         // data props
-        const collateral = drillBalance(ilk, parseUnits(collateralAmount.toString(), ilk.decimals).toString());
-        const debt = drillBalance(art, parseUnits(debtAmount.toString(), art.decimals).toString(), { isDebt: true });
+        const collateral = drillBalance(
+          supplied(ilk),
+          parseUnits(collateralAmount.toString(), ilk.decimals).toString(),
+        );
+        const debt = drillBalance(borrowed(art), parseUnits(debtAmount.toString(), art.decimals).toString(), {
+          isDebt: true,
+        });
         const tokens = [collateral, debt];
         const balanceUSD = sumBy(tokens, v => v.balanceUSD);
         const collateralizationRatio =


### PR DESCRIPTION
## Description

The meta type was missing for the different positions, causing the debt badge to be missing, and dept total calculation to be missing.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
