### PR TITLE
fix(balances): Fix double counting for underlying app-tokens

### DIFF
--- a/src/position/template/contract-position.template.position-fetcher.ts
+++ b/src/position/template/contract-position.template.position-fetcher.ts
@@ -130,7 +130,7 @@ export abstract class ContractPositionTemplatePositionFetcher<
     const tokenDependencies = await tokenLoader.getMany(underlyingTokenRequests).then(tokenDeps => compact(tokenDeps));
 
     const skeletonsWithResolvedTokens = await Promise.all(
-      compact(skeletons).map(async ({ address, tokenDefinitions, definition }) => {
+      compact(skeletons).map(({ address, tokenDefinitions, definition }) => {
         const maybeTokens = tokenDefinitions.map(definition => {
           const match = tokenDependencies.find(token => {
             const isAddressMatch = token.address === definition.address;
@@ -141,7 +141,21 @@ export abstract class ContractPositionTemplatePositionFetcher<
             return isAddressMatch && isNetworkMatch && isMaybeErc1155TokenIdMatch;
           });
 
-          return match ? metatyped(match, definition.metaType) : null;
+          if (match) {
+            const tokenWithMetaType = metatyped(match, definition.metaType);
+
+            // Since the key generation is stateful and the key is already generated for an app token, we need to
+            // regenerate the key for underlying app tokens. Otherwise, we may end up in situations where underlying
+            // app tokens balances are double counted.
+            if (tokenWithMetaType.type === ContractType.APP_TOKEN) {
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              const { key, ...token } = tokenWithMetaType;
+              return { ...token, key: this.appToolkit.getPositionKey(token) };
+            }
+
+            return tokenWithMetaType;
+          }
+          return null;
         });
 
         const tokens = compact(maybeTokens);


### PR DESCRIPTION
## Description

Underlying app tokens are double counted since they use the same underlying key. E.g.

before:
```json
{
  "groupId": "farm-pls-dpx-v2",
  "balances": [
    {
      "key": "0x75c143460f6e3e22f439dff947e25c9ccb72d2e8:arbitrum:plutus:0xf236ea74b515ef96a9898f5a4ed4aa591f253ce1:arbitrum:supplied,0x51318b7d00db7acc4026c88c3952b66278b6a67f:arbitrum:claimable,0xf236ea74b515ef96a9898f5a4ed4aa591f253ce1:arbitrum:claimable,0xe7f6c3c1f0018e4c08acc52965e5cbff99e34a44:arbitrum:claimable,0x6c2c06790b3e3e3c38e12ee22f8183b37a13ee55:arbitrum:claimable:",
      "tokens": [
        {
          "key": "plutus:0xf236ea74b515ef96a9898f5a4ed4aa591f253ce1:arbitrum:supplied:",
          "balance": "501739962884776094812"
        },
        {
          "key": "0x51318b7d00db7acc4026c88c3952b66278b6a67f:arbitrum:claimable",
          "balance": "3369229421569993636398"
        },
        {
// THE FOLLOWING LINE IS INCORRECT, THIS IS A CLAIMABLE VALUE
          "key": "plutus:0xf236ea74b515ef96a9898f5a4ed4aa591f253ce1:arbitrum:supplied:",
          "balance": "113272232987391290"
        },
        {
          "key": "plutus:0xe7f6c3c1f0018e4c08acc52965e5cbff99e34a44:arbitrum:claimable:",
          "balance": "2695196995064702"
        },
        {
          "key": "0x6c2c06790b3e3e3c38e12ee22f8183b37a13ee55:arbitrum:claimable",
          "balance": "10109351117946136917"
        }
      ]
    }
  ]
}
```

before:
```json
{
  "groupId": "farm-pls-dpx-v2",
  "balances": [
    {
      "key": "0x75c143460f6e3e22f439dff947e25c9ccb72d2e8:arbitrum:plutus:0xf236ea74b515ef96a9898f5a4ed4aa591f253ce1:arbitrum:supplied,0x51318b7d00db7acc4026c88c3952b66278b6a67f:arbitrum:claimable,0xf236ea74b515ef96a9898f5a4ed4aa591f253ce1:arbitrum:claimable,0xe7f6c3c1f0018e4c08acc52965e5cbff99e34a44:arbitrum:claimable,0x6c2c06790b3e3e3c38e12ee22f8183b37a13ee55:arbitrum:claimable:",
      "tokens": [
        {
          "key": "plutus:0xf236ea74b515ef96a9898f5a4ed4aa591f253ce1:arbitrum:supplied:",
          "balance": "501739962884776094812"
        },
        {
          "key": "0x51318b7d00db7acc4026c88c3952b66278b6a67f:arbitrum:claimable",
          "balance": "3369229421569993636398"
        },
        {
          "key": "plutus:0xf236ea74b515ef96a9898f5a4ed4aa591f253ce1:arbitrum:claimable:",
          "balance": "113272232987391290"
        },
        {
          "key": "plutus:0xe7f6c3c1f0018e4c08acc52965e5cbff99e34a44:arbitrum:claimable:",
          "balance": "2695196995064702"
        },
        {
          "key": "0x6c2c06790b3e3e3c38e12ee22f8183b37a13ee55:arbitrum:claimable",
          "balance": "10109351117946136917"
        }
      ]
    }
  ]
}
```

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
