### PR TITLE
fix(positions): Normalize position key generation

### DIFF
--- a/src/app-toolkit/app-toolkit.interface.ts
+++ b/src/app-toolkit/app-toolkit.interface.ts
@@ -52,10 +52,7 @@ export interface IAppToolkit {
 
   // Position Key
 
-  getPositionKey(
-    position: ContractPosition | AppTokenPosition | BaseToken | NonFungibleToken,
-    pickFields?: string[],
-  ): string;
+  getPositionKey(position: ContractPosition | AppTokenPosition | BaseToken | NonFungibleToken): string;
 
   // Cache
 

--- a/src/app-toolkit/app-toolkit.service.ts
+++ b/src/app-toolkit/app-toolkit.service.ts
@@ -92,11 +92,8 @@ export class AppToolkit implements IAppToolkit {
 
   // Position Key
 
-  getPositionKey(
-    position: ContractPosition | AppTokenPosition | BaseToken | NonFungibleToken,
-    pickFields: string[] = [],
-  ) {
-    return this.positionKeyService.getPositionKey(position, pickFields);
+  getPositionKey(position: ContractPosition | AppTokenPosition | BaseToken | NonFungibleToken) {
+    return this.positionKeyService.getPositionKey(position);
   }
 
   // Cache

--- a/src/app-toolkit/helpers/master-chef/master-chef.contract-position-helper.ts
+++ b/src/app-toolkit/helpers/master-chef/master-chef.contract-position-helper.ts
@@ -275,6 +275,7 @@ export class MasterChefContractPositionHelper {
           dailyROI,
           weeklyROI,
           yearlyROI,
+          positionKey: `${poolIndex}`,
         };
 
         // Resolve display properties
@@ -303,7 +304,7 @@ export class MasterChefContractPositionHelper {
           displayProps,
         };
 
-        position.key = this.appToolkit.getPositionKey(position, ['poolIndex']);
+        position.key = this.appToolkit.getPositionKey(position);
         return position;
       }),
     );

--- a/src/apps/atlendis-v1/common/atlendis-v1.pool.contract-position-fetcher.ts
+++ b/src/apps/atlendis-v1/common/atlendis-v1.pool.contract-position-fetcher.ts
@@ -7,7 +7,7 @@ import { compact, merge } from 'lodash';
 import { drillBalance } from '~app-toolkit';
 import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
 import { ContractPositionBalance } from '~position/position-balance.interface';
-import { ContractPosition, MetaType, Standard } from '~position/position.interface';
+import { MetaType, Standard } from '~position/position.interface';
 import {
   GetTokenDefinitionsParams,
   GetDisplayPropsParams,
@@ -70,6 +70,7 @@ export type AtlendisV1PoolDataProps = {
   assetStandard: Standard;
   label: string;
   id: string;
+  positionKey: string;
 };
 
 export type AtlendisV1PoolDefinition = {
@@ -121,17 +122,13 @@ export abstract class AtlendisV1PoolContractPositionFetcher extends CustomContra
   async getDataProps({
     definition,
   }: GetDataPropsParams<AtlendisPositionManager, AtlendisV1PoolDataProps, AtlendisV1PoolDefinition>) {
-    return { assetStandard: Standard.ERC_721, id: definition.id, label: definition.label };
+    return { assetStandard: Standard.ERC_721, id: definition.id, label: definition.label, positionKey: definition.id };
   }
 
   async getLabel({
     contractPosition,
   }: GetDisplayPropsParams<AtlendisPositionManager, AtlendisV1PoolDataProps, AtlendisV1PoolDefinition>) {
     return contractPosition.dataProps.label;
-  }
-
-  getKey({ contractPosition }: { contractPosition: ContractPosition<AtlendisV1PoolDataProps> }) {
-    return this.appToolkit.getPositionKey(contractPosition, ['id']);
   }
 
   async getTokenBalancesPerPosition(): Promise<BigNumberish[]> {
@@ -171,11 +168,11 @@ export abstract class AtlendisV1PoolContractPositionFetcher extends CustomContra
         const positionBalance = merge({}, position, {
           tokens: [tokenBalance],
           balanceUSD: tokenBalance.balanceUSD,
-          dataProps: { ...position.dataProps, tokenId },
+          dataProps: { ...position.dataProps, tokenId, positionKey: tokenId },
           displayProps: { label },
         });
 
-        positionBalance.key = this.appToolkit.getPositionKey(positionBalance, ['tokenId']);
+        positionBalance.key = this.appToolkit.getPositionKey(positionBalance);
         return positionBalance;
       }),
     );

--- a/src/apps/dopex/common/dopex.ssov.contract-position-fetcher.ts
+++ b/src/apps/dopex/common/dopex.ssov.contract-position-fetcher.ts
@@ -5,7 +5,7 @@ import { isArray, range } from 'lodash';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { getImagesFromToken, getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
-import { ContractPosition, MetaType } from '~position/position.interface';
+import { MetaType } from '~position/position.interface';
 import { isClaimable, isSupplied } from '~position/position.utils';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import {
@@ -28,6 +28,7 @@ export type DopexSsovDefinition = {
 export type DopexSsovDataProps = {
   epoch: number;
   strike: number;
+  positionKey: string;
 };
 
 export type DopexSsovEpochStrikeDefinition = {
@@ -90,7 +91,11 @@ export abstract class DopexSsovContractPositionFetcher<
   }
 
   async getDataProps({ definition }: GetDataPropsParams<T, DopexSsovDataProps, DopexSsovEpochStrikeDefinition>) {
-    return { epoch: definition.epoch, strike: definition.strike };
+    return {
+      epoch: definition.epoch,
+      strike: definition.strike,
+      positionKey: `${definition.epoch}:${definition.strike}`,
+    };
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<T, DopexSsovDataProps>) {
@@ -115,10 +120,6 @@ export abstract class DopexSsovContractPositionFetcher<
       ...extraRewardTokenAddresses.map(v => ({ metaType: MetaType.CLAIMABLE, address: v, network: this.network })),
     );
     return tokens;
-  }
-
-  getKey({ contractPosition }: { contractPosition: ContractPosition<DopexSsovDataProps> }): string {
-    return this.appToolkit.getPositionKey(contractPosition, ['epoch', 'strike']);
   }
 
   async getDepositBalance(params: GetTokenBalancesParams<T, DopexSsovDataProps>) {

--- a/src/apps/gmx/common/gmx.perp.contract-position-fetcher.ts
+++ b/src/apps/gmx/common/gmx.perp.contract-position-fetcher.ts
@@ -3,7 +3,7 @@ import _, { compact } from 'lodash';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { getImagesFromToken, getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
-import { ContractPosition, MetaType } from '~position/position.interface';
+import { MetaType } from '~position/position.interface';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import {
   GetDefinitionsParams,
@@ -25,6 +25,7 @@ export type GmxOptionContractPositionDefinition = {
 
 export type GmxOptionContractPositionDataProps = {
   isLong: boolean;
+  positionKey: string;
 };
 
 @Injectable()
@@ -79,7 +80,7 @@ export abstract class GmxPerpContractPositionFetcher extends ContractPositionTem
   async getDataProps({
     definition,
   }: GetDataPropsParams<GmxVault, GmxOptionContractPositionDataProps, GmxOptionContractPositionDefinition>) {
-    return { isLong: definition.isLong };
+    return { isLong: definition.isLong, positionKey: `${definition.isLong}` };
   }
 
   async getLabel({
@@ -99,10 +100,6 @@ export abstract class GmxPerpContractPositionFetcher extends ContractPositionTem
   }: GetDisplayPropsParams<GmxVault, GmxOptionContractPositionDataProps, DefaultContractPositionDefinition>) {
     const [collateralToken, indexToken] = contractPosition.tokens;
     return [indexToken, collateralToken].flatMap(v => getImagesFromToken(v));
-  }
-
-  getKey({ contractPosition }: { contractPosition: ContractPosition<GmxOptionContractPositionDataProps> }) {
-    return this.appToolkit.getPositionKey(contractPosition, ['isLong']);
   }
 
   async getTokenBalancesPerPosition({

--- a/src/apps/homora-v2/common/homora-v2.farm.contract-position-fetcher.ts
+++ b/src/apps/homora-v2/common/homora-v2.farm.contract-position-fetcher.ts
@@ -6,7 +6,7 @@ import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { ZERO_ADDRESS } from '~app-toolkit/constants/address';
 import { Cache } from '~cache/cache.decorator';
 import { ContractPositionBalance } from '~position/position-balance.interface';
-import { ContractPosition, MetaType } from '~position/position.interface';
+import { MetaType } from '~position/position.interface';
 import { isBorrowed } from '~position/position.utils';
 import {
   GetDataPropsParams,
@@ -100,6 +100,7 @@ export abstract class HomoraV2FarmContractPositionFetcher extends CustomContract
       poolAddress,
       tradingVolume: definition.tradingVolume,
       feeTier,
+      positionKey: key,
     };
   }
 
@@ -116,10 +117,6 @@ export abstract class HomoraV2FarmContractPositionFetcher extends CustomContract
     }
 
     return `[${definition.exchange}] ${definition.poolName}`;
-  }
-
-  getKey({ contractPosition }: { contractPosition: ContractPosition<HomoraV2FarmingPositionDataProps> }) {
-    return this.appToolkit.getPositionKey(contractPosition, ['key']);
   }
 
   async getNativeToken() {

--- a/src/apps/homora-v2/interfaces/interfaces.ts
+++ b/src/apps/homora-v2/interfaces/interfaces.ts
@@ -139,6 +139,7 @@ export type HomoraV2FarmingPositionDataProps = {
   poolAddress: string;
   feeTier?: number;
   key: string;
+  positionKey: string;
 };
 
 export type HomoraV2LendingPositionDefinition = {

--- a/src/apps/kyberswap-elastic/common/kyberswap-elastic.farm.contract-position-builder.ts
+++ b/src/apps/kyberswap-elastic/common/kyberswap-elastic.farm.contract-position-builder.ts
@@ -126,14 +126,16 @@ export class KyberswapElasticFarmContractPositionBuilder {
       );
     }
 
+    const feeTier = Number(fee) / 10 ** 4;
     const dataProps: KyberswapElasticLiquidityPositionDataProps = {
-      feeTier: Number(fee) / 10 ** 4,
+      feeTier,
       rangeStart: range[0],
       rangeEnd: range[1],
       liquidity: totalLiquidity,
       reserves: reserves,
       poolAddress: poolAddr.toLowerCase(),
       assetStandard: Standard.ERC_721,
+      positionKey: `${feeTier}`,
     };
 
     const displayProps = {

--- a/src/apps/kyberswap-elastic/common/kyberswap-elastic.farm.contract-position-fetcher.ts
+++ b/src/apps/kyberswap-elastic/common/kyberswap-elastic.farm.contract-position-fetcher.ts
@@ -5,7 +5,7 @@ import { compact, range } from 'lodash';
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
 import { ContractPositionBalance } from '~position/position-balance.interface';
-import { ContractPosition, MetaType, Standard } from '~position/position.interface';
+import { MetaType, Standard } from '~position/position.interface';
 import {
   GetDataPropsParams,
   GetDefinitionsParams,
@@ -27,6 +27,7 @@ export type KyberswapElasticFarmPositionDataProps = {
   rangeStart?: number;
   rangeEnd?: number;
   apy?: number;
+  positionKey: string;
 };
 
 export type KyberswapElasticFarmPositionDefinition = {
@@ -138,7 +139,7 @@ export abstract class KyberswapElasticFarmContractPositionFetcher extends Custom
     const liquidity = reserves[0] * tokens[0].price + reserves[1] * tokens[1].price;
     const assetStandard = Standard.ERC_721;
 
-    return { feeTier, reserves, liquidity, poolAddress, assetStandard };
+    return { feeTier, reserves, liquidity, poolAddress, assetStandard, positionKey: `${feeTier}` };
   }
 
   async getLabel({
@@ -152,10 +153,6 @@ export abstract class KyberswapElasticFarmContractPositionFetcher extends Custom
     const symbolLabel = contractPosition.tokens.map(t => getLabelFromToken(t)).join(' / ');
     const label = `${symbolLabel} (${definition.feeTier.toFixed(4)}%)`;
     return label;
-  }
-
-  getKey({ contractPosition }: { contractPosition: ContractPosition<KyberswapElasticFarmPositionDataProps> }) {
-    return this.appToolkit.getPositionKey(contractPosition, ['feeTier']);
   }
 
   // @ts-ignore

--- a/src/apps/kyberswap-elastic/common/kyberswap-elastic.liquidity.contract-position-builder.ts
+++ b/src/apps/kyberswap-elastic/common/kyberswap-elastic.liquidity.contract-position-builder.ts
@@ -118,14 +118,16 @@ export class KyberswapElasticLiquidityContractPositionBuilder {
       );
     }
 
+    const feeTier = Number(fee) / 10 ** 4;
     const dataProps: KyberswapElasticLiquidityPositionDataProps = {
-      feeTier: Number(fee) / 10 ** 4,
+      feeTier,
       rangeStart: range[0],
       rangeEnd: range[1],
       liquidity: totalLiquidity,
       reserves: reserves,
       poolAddress: poolAddr.toLowerCase(),
       assetStandard: Standard.ERC_721,
+      positionKey: `${feeTier}`,
     };
 
     const displayProps = {

--- a/src/apps/kyberswap-elastic/common/kyberswap-elastic.liquidity.contract-position-fetcher.ts
+++ b/src/apps/kyberswap-elastic/common/kyberswap-elastic.liquidity.contract-position-fetcher.ts
@@ -5,7 +5,7 @@ import { compact, range } from 'lodash';
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
 import { ContractPositionBalance } from '~position/position-balance.interface';
-import { ContractPosition, MetaType, Standard } from '~position/position.interface';
+import { MetaType, Standard } from '~position/position.interface';
 import {
   GetDataPropsParams,
   GetDisplayPropsParams,
@@ -28,6 +28,7 @@ export type KyberswapElasticLiquidityPositionDataProps = {
   rangeStart?: number;
   rangeEnd?: number;
   apy?: number;
+  positionKey: string;
 };
 
 export type KyberswapElasticLiquidityPositionDefinition = {
@@ -139,7 +140,7 @@ export abstract class KyberswapElasticLiquidityContractPositionFetcher extends C
     const assetStandard = Standard.ERC_721;
     const apy = await this.apyDataLoader.load(poolAddress);
 
-    return { feeTier, reserves, liquidity, poolAddress, assetStandard, apy };
+    return { feeTier, reserves, liquidity, poolAddress, assetStandard, apy, positionKey: `${feeTier}` };
   }
 
   async getLabel({
@@ -153,10 +154,6 @@ export abstract class KyberswapElasticLiquidityContractPositionFetcher extends C
     const symbolLabel = contractPosition.tokens.map(t => getLabelFromToken(t)).join(' / ');
     const label = `${symbolLabel} (${definition.feeTier.toFixed(4)}%)`;
     return label;
-  }
-
-  getKey({ contractPosition }: { contractPosition: ContractPosition<KyberswapElasticLiquidityPositionDataProps> }) {
-    return this.appToolkit.getPositionKey(contractPosition, ['feeTier']);
   }
 
   // @ts-ignore

--- a/src/apps/lyra-avalon/optimism/lyra-avalon.options.contract-position-fetcher.ts
+++ b/src/apps/lyra-avalon/optimism/lyra-avalon.options.contract-position-fetcher.ts
@@ -6,7 +6,7 @@ import _, { flattenDeep, omit } from 'lodash';
 import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
 import { DefaultDataProps } from '~position/display.interface';
-import { ContractPosition, MetaType } from '~position/position.interface';
+import { MetaType } from '~position/position.interface';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import {
   GetTokenDefinitionsParams,
@@ -91,6 +91,7 @@ export interface LyraAvalonOptionContractPositionDataProps extends DefaultDataPr
   callPrice: number;
   putPrice: number;
   strikePriceReadable: string;
+  positionKey: string;
 }
 
 export type LyraAvalonOptionTokenDefinition = {
@@ -202,7 +203,7 @@ export class OptimismLyraAvalonOptionsContractPositionFetcher extends ContractPo
   async getDataProps({
     definition,
   }: GetDataPropsParams<LyraOptionToken, LyraAvalonOptionContractPositionDataProps, LyraAvalonOptionTokenDefinition>) {
-    return omit(definition, 'address');
+    return { ...omit(definition, 'address'), positionKey: `${definition.optionType}:${definition.strikeId}` };
   }
 
   async getLabel({
@@ -217,14 +218,6 @@ export class OptimismLyraAvalonOptionsContractPositionFetcher extends ContractPo
     const baseSymbol = await multicall.wrap(baseContract).symbol();
     const optionLabel = OPTION_TYPES[definition.optionType];
     return `${optionLabel} ${baseSymbol} @ $${definition.strikePriceReadable}`;
-  }
-
-  getKey({
-    contractPosition,
-  }: {
-    contractPosition: ContractPosition<LyraAvalonOptionContractPositionDataProps>;
-  }): string {
-    return this.appToolkit.getPositionKey(contractPosition, ['optionType', 'strikeId']);
   }
 
   async getTokenBalancesPerPosition({

--- a/src/apps/maker/ethereum/maker.vault.contract-position-fetcher.ts
+++ b/src/apps/maker/ethereum/maker.vault.contract-position-fetcher.ts
@@ -1,7 +1,7 @@
 import { Inject } from '@nestjs/common';
 import BigNumber from 'bignumber.js';
 import { ethers } from 'ethers';
-import { compact, omit, range, sumBy } from 'lodash';
+import { compact, range, sumBy } from 'lodash';
 
 import { drillBalance } from '~app-toolkit';
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
@@ -34,6 +34,7 @@ export type MakerVaultDataProps = {
   cRatio?: number;
   cdpId?: number;
   liquidity: number;
+  positionKey?: string;
 };
 
 @PositionTemplate()
@@ -193,7 +194,6 @@ export class EthereumMakerVaultContractPositionFetcher extends CustomContractPos
 
             const positionBalance: ContractPositionBalance<MakerVaultDataProps> = {
               type: ContractType.POSITION,
-              key: position.key,
               address: position.address,
               appId: position.appId,
               groupId: position.groupId,
@@ -206,6 +206,7 @@ export class EthereumMakerVaultContractPositionFetcher extends CustomContractPos
                 cdpId: cdp,
                 cRatio,
                 liquidity: position.dataProps.liquidity,
+                positionKey: `${cdp}`,
               },
 
               displayProps: {
@@ -215,7 +216,7 @@ export class EthereumMakerVaultContractPositionFetcher extends CustomContractPos
               },
             };
 
-            positionBalance.key = this.appToolkit.getPositionKey(omit(positionBalance, 'key'), ['cdpId']);
+            positionBalance.key = this.appToolkit.getPositionKey(positionBalance);
             return positionBalance;
           }),
         );

--- a/src/apps/mean-finance/arbitrum/mean-finance.balance-fetcher.ts
+++ b/src/apps/mean-finance/arbitrum/mean-finance.balance-fetcher.ts
@@ -147,6 +147,7 @@ export class ArbitrumMeanFinanceBalanceFetcher implements BalanceFetcher {
           ? `${STRING_SWAP_INTERVALS[swapInterval].plural(remainingSwaps)} left`
           : 'Position finished';
 
+      const positionId = `${dcaPosition.id}-v${version}`;
       const position: ContractPositionBalance = {
         type: ContractType.POSITION,
         address: dcaHubAddress,
@@ -156,12 +157,13 @@ export class ArbitrumMeanFinanceBalanceFetcher implements BalanceFetcher {
         tokens,
         balanceUSD,
         dataProps: {
-          id: `${dcaPosition.id}-v${version}`,
+          id: positionId,
           positionId: dcaPosition.id,
           toWithdraw,
           remainingLiquidity,
           remainingSwaps,
           totalValueLocked: balanceUSD,
+          positionKey: positionId,
         },
         displayProps: {
           label,
@@ -170,8 +172,7 @@ export class ArbitrumMeanFinanceBalanceFetcher implements BalanceFetcher {
         },
       };
 
-      position.key = this.appToolkit.getPositionKey(position, ['id']);
-
+      position.key = this.appToolkit.getPositionKey(position);
       return position;
     });
 

--- a/src/apps/mean-finance/optimism/mean-finance.balance-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.balance-fetcher.ts
@@ -147,6 +147,7 @@ export class OptimismMeanFinanceBalanceFetcher implements BalanceFetcher {
           ? `${STRING_SWAP_INTERVALS[swapInterval].plural(remainingSwaps)} left`
           : 'Position finished';
 
+      const positionId = `${dcaPosition.id}-v${version}`;
       const position: ContractPositionBalance = {
         type: ContractType.POSITION,
         address: dcaHubAddress,
@@ -156,12 +157,13 @@ export class OptimismMeanFinanceBalanceFetcher implements BalanceFetcher {
         tokens,
         balanceUSD,
         dataProps: {
-          id: `${dcaPosition.id}-v${version}`,
+          id: positionId,
           positionId: dcaPosition.id,
           toWithdraw,
           remainingLiquidity,
           remainingSwaps,
           totalValueLocked: balanceUSD,
+          positionKey: positionId,
         },
         displayProps: {
           label,
@@ -170,7 +172,7 @@ export class OptimismMeanFinanceBalanceFetcher implements BalanceFetcher {
         },
       };
 
-      position.key = this.appToolkit.getPositionKey(position, ['id']);
+      position.key = this.appToolkit.getPositionKey(position);
       return position;
     });
 

--- a/src/apps/mean-finance/polygon/mean-finance.balance-fetcher.ts
+++ b/src/apps/mean-finance/polygon/mean-finance.balance-fetcher.ts
@@ -147,6 +147,7 @@ export class PolygonMeanFinanceBalanceFetcher implements BalanceFetcher {
           ? `${STRING_SWAP_INTERVALS[swapInterval].plural(remainingSwaps)} left`
           : 'Position finished';
 
+      const positionId = `${dcaPosition.id}-v${version}`;
       const position: ContractPositionBalance = {
         type: ContractType.POSITION,
         address: dcaHubAddress,
@@ -156,13 +157,14 @@ export class PolygonMeanFinanceBalanceFetcher implements BalanceFetcher {
         tokens,
         balanceUSD,
         dataProps: {
-          id: `${dcaPosition.id}-v${version}`,
+          id: positionId,
           positionId: dcaPosition.id,
           toWithdraw,
           remainingLiquidity,
           remainingSwaps,
           totalValueLocked: balanceUSD,
           assetStandard: Standard.ERC_721,
+          positionKey: positionId,
         },
         displayProps: {
           label,
@@ -171,8 +173,7 @@ export class PolygonMeanFinanceBalanceFetcher implements BalanceFetcher {
         },
       };
 
-      position.key = this.appToolkit.getPositionKey(position, ['id']);
-
+      position.key = this.appToolkit.getPositionKey(position);
       return position;
     });
 

--- a/src/apps/pickle/common/pickle.jar-univ3.token-fetcher.ts
+++ b/src/apps/pickle/common/pickle.jar-univ3.token-fetcher.ts
@@ -136,7 +136,7 @@ export abstract class PickleJarUniv3TokenFetcher extends AppTokenTemplatePositio
         const displayPropsStageFragment = { ...dataPropsStageFragment, dataProps };
         const displayProps = uniV3Token.displayProps;
         const appToken = { ...displayPropsStageFragment, displayProps };
-        const key = this.getKey({ appToken });
+        const key = this.appToolkit.getPositionKey(appToken);
         return { key, ...appToken };
       }),
     );

--- a/src/apps/polygon-staking/ethereum/polygon-staking.deposit.contract-position-fetcher.ts
+++ b/src/apps/polygon-staking/ethereum/polygon-staking.deposit.contract-position-fetcher.ts
@@ -9,7 +9,7 @@ import { PositionTemplate } from '~app-toolkit/decorators/position-template.deco
 import { getImagesFromToken, getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
 import { CacheOnInterval } from '~cache/cache-on-interval.decorator';
 import { ContractPositionBalance } from '~position/position-balance.interface';
-import { ContractPosition, MetaType } from '~position/position.interface';
+import { MetaType } from '~position/position.interface';
 import { isClaimable, isSupplied } from '~position/position.utils';
 import {
   GetTokenDefinitionsParams,
@@ -78,6 +78,7 @@ type PolygonStakingDepositDataProps = {
   validatorId: number;
   validatorName: string;
   validatorShareAddress: string;
+  positionKey: string;
 };
 
 @PositionTemplate()
@@ -144,6 +145,7 @@ export class EthereumPolygonStakingContractPositionFetcher extends CustomContrac
       validatorId: definition.validatorId,
       validatorName: definition.validatorName,
       validatorShareAddress: definition.validatorShareAddress,
+      positionKey: `${definition.validatorId}`,
     };
   }
 
@@ -154,10 +156,6 @@ export class EthereumPolygonStakingContractPositionFetcher extends CustomContrac
 
   async getImages({ contractPosition }: GetDisplayPropsParams<PolygonStakeManager>) {
     return getImagesFromToken(contractPosition.tokens[0]);
-  }
-
-  getKey({ contractPosition }: { contractPosition: ContractPosition<PolygonStakingDepositDataProps> }) {
-    return this.appToolkit.getPositionKey(contractPosition, ['validatorId']);
   }
 
   // @ts-ignore

--- a/src/apps/qi-dao/common/qi-dao.vault.contract-position-fetcher.ts
+++ b/src/apps/qi-dao/common/qi-dao.vault.contract-position-fetcher.ts
@@ -22,6 +22,7 @@ type QiDaoVaultDataProps = {
   assetStandard: Standard;
   vaultInfoAddress: string;
   tokenId?: string;
+  positionKey?: string;
 };
 
 type QiDaoVaultDefinition = {
@@ -166,7 +167,11 @@ export abstract class QiDaoVaultContractPositionFetcher extends CustomContractPo
 
             const tokens = allTokens.filter(v => Math.abs(v.balanceUSD) > 0.01);
             const balanceUSD = sumBy(tokens, t => t.balanceUSD);
-            const dataProps = { ...contractPosition.dataProps, tokenId: tokenId.toString() };
+            const dataProps = {
+              ...contractPosition.dataProps,
+              tokenId: tokenId.toString(),
+              positionKey: tokenId.toString(),
+            };
             const displayProps = {
               ...contractPosition.displayProps,
               label: `${contractPosition.displayProps.label} (#${tokenId})`,
@@ -180,7 +185,7 @@ export abstract class QiDaoVaultContractPositionFetcher extends CustomContractPo
               balanceUSD,
             };
 
-            balance.key = this.appToolkit.getPositionKey(balance, ['tokenId']);
+            balance.key = this.appToolkit.getPositionKey(balance);
             return balance;
           }),
         );

--- a/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/arbitrum/revert-finance.balance-fetcher.ts
@@ -73,7 +73,7 @@ export class ArbitrumRevertFinanceBalanceFetcher implements BalanceFetcher {
         if (!uniV3Token) return;
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
-          key: this.appToolkit.getPositionKey(position, ['compoundingPositionId']),
+          key: this.appToolkit.getPositionKey(position),
           ...position,
         });
       }),

--- a/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/ethereum/revert-finance.balance-fetcher.ts
@@ -73,7 +73,7 @@ export class EthereumRevertFinanceBalanceFetcher implements BalanceFetcher {
         if (!uniV3Token) return;
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
-          key: this.appToolkit.getPositionKey(position, ['compoundingPositionId']),
+          key: this.appToolkit.getPositionKey(position),
           ...position,
         });
       }),

--- a/src/apps/revert-finance/helpers/contractPositionParser.ts
+++ b/src/apps/revert-finance/helpers/contractPositionParser.ts
@@ -41,6 +41,7 @@ export const getCompoundingContractPosition = (
   balanceUSD: uniV3Lp.balanceUSD,
   dataProps: {
     compoundingPositionId: uniV3Lp.dataProps.id,
+    positionKey: `${uniV3Lp.dataProps.id}`,
   },
   displayProps: {
     label: `Compounding ${uniV3Lp.displayProps.label}`,

--- a/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/optimism/revert-finance.balance-fetcher.ts
@@ -73,7 +73,7 @@ export class OptimismRevertFinanceBalanceFetcher implements BalanceFetcher {
         if (!uniV3Token) return;
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
-          key: this.appToolkit.getPositionKey(position, ['compoundingPositionId']),
+          key: this.appToolkit.getPositionKey(position),
           ...position,
         });
       }),

--- a/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
+++ b/src/apps/revert-finance/polygon/revert-finance.balance-fetcher.ts
@@ -73,7 +73,7 @@ export class PolygonRevertFinanceBalanceFetcher implements BalanceFetcher {
         if (!uniV3Token) return;
         const position = getCompoundingContractPosition(network, uniV3Token);
         compoundingBalances.push({
-          key: this.appToolkit.getPositionKey(position, ['compoundingPositionId']),
+          key: this.appToolkit.getPositionKey(position),
           ...position,
         });
       }),

--- a/src/apps/uniswap-v3/common/uniswap-v3.liquidity.contract-position-builder.ts
+++ b/src/apps/uniswap-v3/common/uniswap-v3.liquidity.contract-position-builder.ts
@@ -98,14 +98,16 @@ export class UniswapV3LiquidityContractPositionBuilder {
       );
     }
 
+    const feeTier = Number(fee) / 10 ** 4;
     const dataProps: UniswapV3LiquidityPositionDataProps = {
-      feeTier: Number(fee) / 10 ** 4,
+      feeTier,
       rangeStart: range[0],
       rangeEnd: range[1],
       liquidity: totalLiquidity,
       reserves: reserves,
       poolAddress: poolAddr.toLowerCase(),
       assetStandard: Standard.ERC_721,
+      positionKey: `${feeTier}`,
     };
 
     const displayProps = {

--- a/src/apps/uniswap-v3/common/uniswap-v3.liquidity.contract-position-fetcher.ts
+++ b/src/apps/uniswap-v3/common/uniswap-v3.liquidity.contract-position-fetcher.ts
@@ -5,7 +5,7 @@ import { compact, range } from 'lodash';
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
 import { ContractPositionBalance } from '~position/position-balance.interface';
-import { ContractPosition, MetaType, Standard } from '~position/position.interface';
+import { MetaType, Standard } from '~position/position.interface';
 import {
   GetDataPropsParams,
   GetDisplayPropsParams,
@@ -25,6 +25,7 @@ export type UniswapV3LiquidityPositionDataProps = {
   assetStandard: Standard.ERC_721;
   rangeStart?: number;
   rangeEnd?: number;
+  positionKey: string;
 };
 
 export type UniswapV3LiquidityPositionDefinition = {
@@ -139,7 +140,7 @@ export abstract class UniswapV3LiquidityContractPositionFetcher extends CustomCo
     const liquidity = reserves[0] * tokens[0].price + reserves[1] * tokens[1].price;
     const assetStandard = Standard.ERC_721;
 
-    return { feeTier, reserves, liquidity, poolAddress, assetStandard };
+    return { feeTier, reserves, liquidity, poolAddress, assetStandard, positionKey: `${feeTier}` };
   }
 
   async getLabel({
@@ -153,10 +154,6 @@ export abstract class UniswapV3LiquidityContractPositionFetcher extends CustomCo
     const symbolLabel = contractPosition.tokens.map(t => getLabelFromToken(t)).join(' / ');
     const label = `${symbolLabel} (${definition.feeTier.toFixed(2)}%)`;
     return label;
-  }
-
-  getKey({ contractPosition }: { contractPosition: ContractPosition<UniswapV3LiquidityPositionDataProps> }) {
-    return this.appToolkit.getPositionKey(contractPosition, ['feeTier']);
   }
 
   // @ts-ignore

--- a/src/position/position-key.service.ts
+++ b/src/position/position-key.service.ts
@@ -19,10 +19,7 @@ export class PositionKeyService {
     return murmur.murmur3(input).toString();
   }
 
-  getPositionKey(
-    position: ContractPosition | AppTokenPosition | BaseToken | NonFungibleToken,
-    pickFields: string[] = [],
-  ) {
+  getPositionKey(position: ContractPosition | AppTokenPosition | BaseToken | NonFungibleToken) {
     if ('key' in position) return position.key!;
 
     switch (position.type) {
@@ -33,7 +30,7 @@ export class PositionKeyService {
             position.network,
             position.appId,
             position.tokens.map(token => [token.address, token.network, token.metaType].join(':')),
-            pickFields.map(v => position.dataProps[v]).join(':'),
+            (position.dataProps.positionKey as any)?.toString() || '',
           ].join(':'),
         );
       case ContractType.APP_TOKEN:
@@ -43,7 +40,7 @@ export class PositionKeyService {
             position.address,
             position.network,
             MetaType.SUPPLIED,
-            pickFields.map(v => position.dataProps[v]).join(':'),
+            (position.dataProps.positionKey as any)?.toString() || '',
           ].join(':'),
         );
       default:

--- a/src/position/template/app-token.template.position-fetcher.ts
+++ b/src/position/template/app-token.template.position-fetcher.ts
@@ -160,10 +160,6 @@ export abstract class AppTokenTemplatePositionFetcher<
     return statsItems;
   }
 
-  getKey({ appToken }: { appToken: AppTokenPosition<V> }): string {
-    return this.appToolkit.getPositionKey(appToken);
-  }
-
   // Default (adapted) Template Runner
   // Note: This will be removed in favour of an orchestrator at a higher level once all groups are migrated
   async getPositions(): Promise<AppTokenPosition<V>[]> {
@@ -269,7 +265,7 @@ export abstract class AppTokenTemplatePositionFetcher<
           };
 
           const appToken = { ...displayPropsStageFragment, displayProps };
-          const key = this.getKey({ appToken });
+          const key = this.appToolkit.getPositionKey(appToken);
           return { key, ...appToken };
         }),
       );

--- a/src/position/template/contract-position.template.position-fetcher.ts
+++ b/src/position/template/contract-position.template.position-fetcher.ts
@@ -92,10 +92,6 @@ export abstract class ContractPositionTemplatePositionFetcher<
     return statsItems;
   }
 
-  getKey({ contractPosition }: { contractPosition: ContractPosition<V> }): string {
-    return this.appToolkit.getPositionKey(contractPosition);
-  }
-
   // Default (adapted) Template Runner
   // Note: This will be removed in favour of an orchestrator at a higher level once all groups are migrated
   async getPositions() {
@@ -181,7 +177,7 @@ export abstract class ContractPositionTemplatePositionFetcher<
         };
 
         const contractPosition = { ...baseFragment, dataProps, displayProps };
-        const key = this.getKey({ contractPosition });
+        const key = this.appToolkit.getPositionKey(contractPosition);
         return { key, ...contractPosition };
       }),
     );

--- a/src/position/template/custom-contract-position.template.position-fetcher.ts
+++ b/src/position/template/custom-contract-position.template.position-fetcher.ts
@@ -90,10 +90,6 @@ export abstract class CustomContractPositionTemplatePositionFetcher<
     return statsItems;
   }
 
-  getKey({ contractPosition }: { contractPosition: ContractPosition<V> }): string {
-    return this.appToolkit.getPositionKey(contractPosition);
-  }
-
   // Default (adapted) Template Runner
   // Note: This will be removed in favour of an orchestrator at a higher level once all groups are migrated
   async getPositions() {
@@ -171,7 +167,7 @@ export abstract class CustomContractPositionTemplatePositionFetcher<
         };
 
         const contractPosition = { ...baseFragment, dataProps, displayProps };
-        const key = this.getKey({ contractPosition });
+        const key = this.appToolkit.getPositionKey(contractPosition);
         return { key, ...contractPosition };
       }),
     );

--- a/src/position/template/master-chef.template.contract-position-fetcher.ts
+++ b/src/position/template/master-chef.template.contract-position-fetcher.ts
@@ -8,7 +8,7 @@ import { RewardRateUnit } from '~app-toolkit/helpers/master-chef/master-chef.con
 import { getImagesFromToken, getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
 import { IMulticallWrapper } from '~multicall';
 import { isMulticallUnderlyingError } from '~multicall/multicall.ethers';
-import { ContractPosition, MetaType } from '~position/position.interface';
+import { MetaType } from '~position/position.interface';
 import { isClaimable, isSupplied } from '~position/position.utils';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import {
@@ -24,6 +24,7 @@ export type MasterChefContractPositionDataProps = {
   liquidity: number;
   isActive: boolean;
   apy: number;
+  positionKey: string;
 };
 
 export type MasterChefContractPositionDefinition = {
@@ -149,7 +150,7 @@ export abstract class MasterChefTemplateContractPositionFetcher<
     const apy = dailyReturn * 365 * 100;
     const isActive = apy > 0;
 
-    return { poolIndex, liquidity, apy, isActive } as V;
+    return { poolIndex, liquidity, apy, isActive, positionKey: `${poolIndex}` } as V;
   }
 
   async getLabel({ contractPosition }: GetDisplayPropsParams<T>) {
@@ -159,10 +160,6 @@ export abstract class MasterChefTemplateContractPositionFetcher<
 
   async getImages({ contractPosition }: GetDisplayPropsParams<T, V>) {
     return contractPosition.tokens.filter(isSupplied).flatMap(v => getImagesFromToken(v));
-  }
-
-  getKey({ contractPosition }: { contractPosition: ContractPosition<V> }): string {
-    return this.appToolkit.getPositionKey(contractPosition, ['poolIndex']);
   }
 
   async getTokenBalancesPerPosition(params: GetTokenBalancesParams<T, MasterChefContractPositionDataProps>) {


### PR DESCRIPTION
## Description

Instead of using a layer of indirection (specify which fields in the dataprops are part of the key), I'm specifying the `positionKey` field explicitely in the data props. It will be used when generating the key and no longer need to be explicitely specified at the call site.

This will allow regenerating the key without knowing the previous context in which the key was generated. E.g. mutate the position, and regenerate the key.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
