### PR TITLE
feat(contract-position): Detect duplicated underlying tokens

### DIFF
--- a/src/app-toolkit/app-toolkit.interface.ts
+++ b/src/app-toolkit/app-toolkit.interface.ts
@@ -19,6 +19,10 @@ import { AppToolkitHelperRegistry } from './app-toolkit.helpers';
 
 export const APP_TOOLKIT = Symbol('APP_TOOLKIT');
 
+export interface AppToolkitLogger {
+  log(message: string);
+}
+
 export interface IAppToolkit {
   // Apps
   getApps(): Promise<AppDefinition[]>;
@@ -62,6 +66,8 @@ export interface IAppToolkit {
   // Global Helpers
 
   get helpers(): AppToolkitHelperRegistry;
+
+  get logger(): AppToolkitLogger;
 
   getBigNumber(source: BigNumberJS.Value | ethers.BigNumber): BigNumberJS;
 }

--- a/src/app-toolkit/app-toolkit.service.ts
+++ b/src/app-toolkit/app-toolkit.service.ts
@@ -1,4 +1,4 @@
-import { CACHE_MANAGER, forwardRef, Inject, Injectable } from '@nestjs/common';
+import { CACHE_MANAGER, forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import { BigNumber as BigNumberJS } from 'bignumber.js';
 import { Cache } from 'cache-manager';
 import { ethers } from 'ethers';
@@ -18,7 +18,16 @@ import { PriceSelectorService } from '~token/selectors/token-price-selector.serv
 import { Network } from '~types/network.interface';
 
 import { AppToolkitHelperRegistry } from './app-toolkit.helpers';
-import { IAppToolkit } from './app-toolkit.interface';
+import { AppToolkitLogger, IAppToolkit } from './app-toolkit.interface';
+
+@Injectable()
+class NestJsLogger implements AppToolkitLogger {
+  private readonly logger = new Logger(NestJsLogger.name);
+
+  log(message: string) {
+    this.logger.log(message);
+  }
+}
 
 @Injectable()
 export class AppToolkit implements IAppToolkit {
@@ -36,6 +45,7 @@ export class AppToolkit implements IAppToolkit {
     private readonly tokenDependencySelectorService: TokenDependencySelectorService,
     @Inject(MulticallService) private readonly multicallService: MulticallService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    @Inject(NestJsLogger) private readonly appToolkitLogger: AppToolkitLogger,
   ) {
     this.contractFactory = new ContractFactory((network: Network) => this.networkProviderService.getProvider(network));
   }
@@ -112,6 +122,10 @@ export class AppToolkit implements IAppToolkit {
 
   get helpers() {
     return this.helperRegistry;
+  }
+
+  get logger() {
+    return this.appToolkitLogger;
   }
 
   getBigNumber(source: BigNumberJS.Value | ethers.BigNumber): BigNumberJS {


### PR DESCRIPTION
## Description

We need to be able to detect underlying token definitions since they are not being displayed correctly in zapper frontend. Since they share the same key, they can't be uniquely identified, causing duplicated balances to be displayed.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
