### PR TITLE
fix(olympus): Fix olympus missing bond tokens

### DIFF
--- a/src/apps/olympus/helpers/olympus.bond-v1.contract-position-balance-helper.ts
+++ b/src/apps/olympus/helpers/olympus.bond-v1.contract-position-balance-helper.ts
@@ -5,6 +5,7 @@ import { sumBy } from 'lodash';
 
 import { drillBalance } from '~app-toolkit';
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
+import { BALANCE_LOCALSTORAGE_FLAGS } from '~balance/balance.utils';
 import { IMulticallWrapper } from '~multicall/multicall.interface';
 import { DefaultDataProps } from '~position/display.interface';
 import { ContractPositionBalance } from '~position/position-balance.interface';
@@ -65,7 +66,13 @@ export class OlympusBondV1ContractPositionBalanceHelper {
           : '0';
         const claimableTokenBalance = drillBalance(claimableToken, claimableBalanceRaw.toString());
         const vestingTokenBalance = drillBalance(vestingToken, vestingBalanceRaw);
-        const tokens = [claimableTokenBalance, vestingTokenBalance].filter(v => v.balanceUSD > 0);
+
+        const storage = BALANCE_LOCALSTORAGE_FLAGS.getStore();
+        const { includeZeroBalances } = storage ?? { includeZeroBalances: false };
+
+        const tokens = [claimableTokenBalance, vestingTokenBalance].filter(
+          v => includeZeroBalances || v.balanceUSD > 0,
+        );
         const balanceUSD = sumBy(tokens, t => t.balanceUSD);
 
         return { ...contractPosition, tokens, balanceUSD };

--- a/src/apps/olympus/helpers/olympus.bond-v2.contract-position-balance-helper.ts
+++ b/src/apps/olympus/helpers/olympus.bond-v2.contract-position-balance-helper.ts
@@ -4,6 +4,7 @@ import { sumBy } from 'lodash';
 
 import { drillBalance } from '~app-toolkit';
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
+import { BALANCE_LOCALSTORAGE_FLAGS } from '~balance/balance.utils';
 import { ContractPositionBalance } from '~position/position-balance.interface';
 import { isClaimable, isVesting } from '~position/position.utils';
 import { Network } from '~types/network.interface';
@@ -48,7 +49,13 @@ export class OlympusBondV2ContractPositionBalanceHelper {
         }, BigNumber.from('0'));
         const claimableTokenBalance = drillBalance(claimableToken, claimableAmount.toString());
         const vestingTokenBalance = drillBalance(vestingToken, vestingAmount.toString());
-        const tokens = [claimableTokenBalance, vestingTokenBalance].filter(v => v.balanceUSD > 0);
+
+        const storage = BALANCE_LOCALSTORAGE_FLAGS.getStore();
+        const { includeZeroBalances } = storage ?? { includeZeroBalances: false };
+
+        const tokens = [claimableTokenBalance, vestingTokenBalance].filter(
+          v => includeZeroBalances || v.balanceUSD > 0,
+        );
         const balanceUSD = sumBy(tokens, t => t.balanceUSD);
 
         return { ...contractPosition, tokens, balanceUSD };


### PR DESCRIPTION
## Description

We no longer need to strip zero balance underlying tokens. Otherwise we are not able to map it back to their respective position since the key of the position is generated based off of it's children tokens.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
