### PR TITLE
fix(compound): Add missing borrowed metaType

### DIFF
--- a/src/apps/compound/helper/compound.borrow.balance-helper.ts
+++ b/src/apps/compound/helper/compound.borrow.balance-helper.ts
@@ -4,6 +4,7 @@ import { BigNumberish } from 'ethers';
 import { drillBalance } from '~app-toolkit';
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { IMulticallWrapper } from '~multicall/multicall.interface';
+import { borrowed } from '~position/position.utils';
 import { Network } from '~types/network.interface';
 
 import { CompoundCToken } from '../contracts';
@@ -43,7 +44,7 @@ export class CompoundBorrowBalanceHelper {
       borrowPositions.map(async borrowPosition => {
         const borrowContract = getTokenContract({ address: borrowPosition.address, network });
         const balanceRaw = await getBorrowBalanceRaw({ contract: borrowContract, multicall, address });
-        const tokens = [drillBalance(borrowPosition.tokens[0], balanceRaw.toString(), { isDebt: true })];
+        const tokens = [drillBalance(borrowed(borrowPosition.tokens[0]), balanceRaw.toString(), { isDebt: true })];
         return { ...borrowPosition, tokens, balanceUSD: tokens[0].balanceUSD };
       }),
     );


### PR DESCRIPTION
## Description

The metaType is missing for the borrowed token and is defaulting in some cases to a supplied token.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
