### PR TITLE
fix(geist): Fix lowercased token address

### DIFF
--- a/src/apps/geist/fantom/geist.platform-fees.contract-position-fetcher.ts
+++ b/src/apps/geist/fantom/geist.platform-fees.contract-position-fetcher.ts
@@ -63,12 +63,12 @@ export class FantomGeistPlatformFeesPositionFetcher extends ContractPositionTemp
         network: this.network,
       },
       ...rewardTokenAddresses
-        .filter(address => address !== this.geistTokenAddress)
         .map(address => ({
           metaType: MetaType.CLAIMABLE,
           address: address.toLowerCase(),
           network: this.network,
-        })),
+        }))
+        .filter(({ address }) => address !== this.geistTokenAddress),
     ];
   }
 


### PR DESCRIPTION
## Description

The address is actually lowercased and wasn't matching, so the claimable token ended up being duplicated.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
