### PR TITLE
fix(mycelium): Remove indexToken from list of underlying tokens

### DIFF
--- a/src/apps/mycelium/helpers/mycelium.lev-trades.contract-position-helper.ts
+++ b/src/apps/mycelium/helpers/mycelium.lev-trades.contract-position-helper.ts
@@ -17,6 +17,7 @@ export type MyceliumLevTradesContractPositionDataProps = {
   collateralTokenAddress: string;
   indexTokenAddress: string;
   isLong: boolean;
+  positionKey: string;
 };
 
 type MyceliumLevTradesContractPositionHelperParams = {
@@ -41,7 +42,7 @@ export class MyceliumLevTradesContractPositionHelper {
       address: MLP_VAULT_ADDRESS,
       network,
     });
-    // const test = await multicall.wrap(vaultContract).getPositions();
+
     const whitelistedTokenLengthRaw = await multicall.wrap(vaultContract).allWhitelistedTokensLength();
 
     const whitelistedTokens = await Promise.all(
@@ -63,17 +64,17 @@ export class MyceliumLevTradesContractPositionHelper {
               appId,
               groupId,
               address: LEV_TRADES_VAULT_ADDRESS,
-              key: `${collateralToken.symbol}:${indexToken.symbol}:short`,
               network,
-              tokens: [supplied(collateralToken), indexToken],
+              tokens: [supplied(collateralToken)],
               dataProps: {
                 collateralTokenAddress: collateralToken.address,
                 indexTokenAddress: indexToken.address,
                 isLong: false,
+                positionKey: `${collateralToken.address}:${indexToken.address}:short`,
               },
               displayProps: {
                 label: `Short ${indexToken.symbol}`,
-                images: [getTokenImg(collateralToken.address, network), getTokenImg(indexToken.address, network)],
+                images: [getTokenImg(collateralToken.address, network)],
                 statsItems: [],
               },
             };
@@ -83,17 +84,17 @@ export class MyceliumLevTradesContractPositionHelper {
               appId,
               groupId,
               address: LEV_TRADES_VAULT_ADDRESS,
-              key: `${collateralToken.symbol}:${indexToken.symbol}:long`,
               network,
-              tokens: [supplied(collateralToken), indexToken],
+              tokens: [supplied(collateralToken)],
               dataProps: {
                 collateralTokenAddress: collateralToken.address,
                 indexTokenAddress: indexToken.address,
                 isLong: true,
+                positionKey: `${collateralToken.address}:${indexToken.address}:long`,
               },
               displayProps: {
                 label: `Long ${indexToken.symbol}`,
-                images: [getTokenImg(collateralToken.address, network), getTokenImg(indexToken.address, network)],
+                images: [getTokenImg(collateralToken.address, network)],
                 statsItems: [],
               },
             };


### PR DESCRIPTION
## Description

IndexToken in mycelium is not really a supplied token, but a token to inform what the position is shorting/longing. Instead we can keep it only in the dataProps since it's used to calculate the balance of the supplied token.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
