### PR TITLE
fix(spool): Make list of underlying tokens order the same as balances

### DIFF
--- a/src/apps/spool/ethereum/spool.balance-fetcher.ts
+++ b/src/apps/spool/ethereum/spool.balance-fetcher.ts
@@ -70,7 +70,10 @@ export class EthereumSpoolBalanceFetcher implements BalanceFetcher {
         // balanceRaw[4]: user's funds in underlying asset
         const pendingDeposit = balanceRaw[5].add(balanceRaw[7]);
         const balance = balanceRaw[4].add(pendingDeposit);
-        return [drillBalance(suppliedToken, balance.toString())];
+        return [
+          drillBalance(suppliedToken, balance.toString()),
+          ...props.contractPosition.tokens.slice(1).map(t => drillBalance(t, '0')),
+        ];
       },
     });
   }

--- a/src/apps/spool/ethereum/spool.staking.contract-position-fetcher.ts
+++ b/src/apps/spool/ethereum/spool.staking.contract-position-fetcher.ts
@@ -87,20 +87,20 @@ export class EthereumSpoolStakingContractPositionFetcher implements PositionFetc
       rewardAddresses.map(address => this.appToolkit.getBaseTokenPrice({ network, address })),
     );
 
-    const tokens = rewardTokens.filter((token): token is BaseToken => token !== null).map(claimable);
-    tokens.push(supplied(stakedToken!));
-    tokens.push(vesting(govToken));
+    const claimableTokens = rewardTokens.filter((token): token is BaseToken => token !== null).map(claimable);
+
+    const tokens = [supplied(stakedToken), vesting(govToken), ...claimableTokens];
 
     const spoolContract = this.spoolContractFactory.erc20({ network, address: spoolTokenAddress });
     const totalStaked = await spoolContract.balanceOf(STAKING_ADDRESS);
-    const spoolStaked = totalStaked.div(big10.pow(stakedToken!.decimals)).toNumber();
+    const spoolStaked = totalStaked.div(big10.pow(stakedToken.decimals)).toNumber();
     const totalAccVoSpool = votingPowerRaw.div(big10.pow(voSpoolDecimals)).toNumber();
 
     const pricePrecision = 10 ** 10;
-    const tvl = BigNumber.from(pricePrecision * stakedToken!.price)
+    const tvl = BigNumber.from(pricePrecision * stakedToken.price)
       .mul(totalStaked)
       .div(pricePrecision)
-      .div(big10.pow(stakedToken!.decimals))
+      .div(big10.pow(stakedToken.decimals))
       .toNumber();
 
     const position: ContractPosition = {


### PR DESCRIPTION
## Description

Since the key generation of the different positions rely on the ordering of the tokens, we need to make sure the order of the tokens is the same in both the balance fetcher & contract-position fetcher.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
