### PR TITLE
fix(convex): Combine minted and bonus claimable CVX

### DIFF
--- a/src/apps/convex/common/convex.farm.contract-position-fetcher.ts
+++ b/src/apps/convex/common/convex.farm.contract-position-fetcher.ts
@@ -1,7 +1,7 @@
 import { Inject } from '@nestjs/common';
 import BigNumber from 'bignumber.js';
-import { BigNumberish } from 'ethers';
-import { range } from 'lodash';
+import { BigNumberish, ethers } from 'ethers';
+import { compact, range } from 'lodash';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { isClaimable } from '~position/position.utils';
@@ -19,7 +19,8 @@ import { Network } from '~types';
 import { ConvexContractFactory } from '../contracts';
 import { ConvexSingleStakingRewards } from '../contracts/ethers/ConvexSingleStakingRewards';
 
-// CVX is minted whenever CRV is claimed
+// CVX is minted whenever CRV is claimed.
+// We're dealing with floating poing arithmetic, so use BigNumber.js, but return an ethers.BigNumber
 // See: https://docs.convexfinance.com/convexfinanceintegration/cvx-minting
 export const claimedCrvToMintedCvx = (claimedCrvAmount: string, currentCvxSupply: string) => {
   const claimedCrvAmountBN = new BigNumber(claimedCrvAmount);
@@ -30,7 +31,7 @@ export const claimedCrvToMintedCvx = (claimedCrvAmount: string, currentCvxSupply
   const maxCvxSupply = new BigNumber(100000000).times(1e18);
   const currentCliff = currentCvxSupplyBN.div(tokensPerCliff);
 
-  if (currentCliff.gte(maxCliffCount)) return '0';
+  if (currentCliff.gte(maxCliffCount)) return ethers.BigNumber.from(0);
   const remainingCliffs = maxCliffCount.minus(currentCliff);
   const remainingCliffRatio = remainingCliffs.div(maxCliffCount);
   const remainingCvxToMint = maxCvxSupply.minus(currentCvxSupplyBN);
@@ -40,7 +41,7 @@ export const claimedCrvToMintedCvx = (claimedCrvAmount: string, currentCvxSupply
     ? remainingCvxToMint
     : maybeCvxRewardTokenBalanceRaw;
 
-  return cvxRewardTokenBalanceRaw.toFixed(0);
+  return ethers.BigNumber.from(cvxRewardTokenBalanceRaw.toFixed(0));
 };
 
 export abstract class ConvexFarmContractPositionFetcher extends SingleStakingFarmDynamicTemplateContractPositionFetcher<ConvexSingleStakingRewards> {
@@ -72,11 +73,17 @@ export abstract class ConvexFarmContractPositionFetcher extends SingleStakingFar
       range(0, Number(numExtraRewards)).map(async v => {
         const vbpAddress = await contract.extraRewards(v);
         const vbp = this.contractFactory.convexVirtualBalanceRewardPool({ address: vbpAddress, network: this.network });
-        return multicall.wrap(vbp).rewardToken();
+        const rewardTokenAddressRaw = await multicall.wrap(vbp).rewardToken();
+        const rewardTokenAddress = rewardTokenAddressRaw.toLowerCase();
+
+        // We will combine CVX extra rewards with the amount minted
+        if (rewardTokenAddress === primaryRewardTokenAddresses[1]) return null;
+
+        return rewardTokenAddressRaw.toLowerCase();
       }),
     );
 
-    return [...primaryRewardTokenAddresses, ...extraRewardTokenAddresses];
+    return [...primaryRewardTokenAddresses, ...compact(extraRewardTokenAddresses)];
   }
 
   async getRewardRates({
@@ -84,12 +91,14 @@ export abstract class ConvexFarmContractPositionFetcher extends SingleStakingFar
     contractPosition,
     multicall,
   }: GetDataPropsParams<ConvexSingleStakingRewards, SingleStakingFarmDataProps>) {
-    const cvxToken = contractPosition.tokens.find(v => v.symbol === 'CVX')!;
-    const cvxTokenContract = this.contractFactory.erc20(cvxToken);
+    const rewardTokens = contractPosition.tokens.filter(isClaimable);
+    const [, cvxRewardToken] = rewardTokens;
+
+    const cvxTokenContract = this.contractFactory.erc20(cvxRewardToken);
     const cvxSupplyRaw = await multicall.wrap(cvxTokenContract).totalSupply();
 
     const crvRewardRate = await multicall.wrap(contract).rewardRate();
-    const cvxRewardRate = claimedCrvToMintedCvx(crvRewardRate.toString(), cvxSupplyRaw.toString());
+    let cvxRewardRate = claimedCrvToMintedCvx(crvRewardRate.toString(), cvxSupplyRaw.toString());
 
     const numExtraRewards = await multicall.wrap(contract).extraRewardsLength().then(Number);
     const extraRewardRates = await Promise.all(
@@ -101,11 +110,21 @@ export abstract class ConvexFarmContractPositionFetcher extends SingleStakingFar
           network: Network.ETHEREUM_MAINNET,
         });
 
-        return multicall.wrap(vbpContract).rewardRate();
+        const extraRewardRate = await multicall.wrap(vbpContract).rewardRate();
+        const extraRewardTokenAddressRaw = await multicall.wrap(vbpContract).rewardToken();
+        const extraRewardTokenAddress = extraRewardTokenAddressRaw.toLowerCase();
+
+        // We will combine CVX extra rewards with the amount minted
+        if (extraRewardTokenAddress === cvxRewardToken.address) {
+          cvxRewardRate = cvxRewardRate.add(extraRewardRate);
+          return null;
+        }
+
+        return extraRewardRate;
       }),
     );
 
-    return [crvRewardRate, cvxRewardRate, ...extraRewardRates];
+    return [crvRewardRate, cvxRewardRate, ...compact(extraRewardRates)];
   }
 
   getStakedTokenBalance({
@@ -132,20 +151,31 @@ export abstract class ConvexFarmContractPositionFetcher extends SingleStakingFar
     const crvBalanceBN = await contract.earned(address);
     const crvBalanceRaw = crvBalanceBN.toString();
     const cvxBalanceRaw = claimedCrvToMintedCvx(crvBalanceRaw, currentCvxSupply.toString());
+    // const cvxBalanceRawBN =
 
     const extraRewardBalances = await Promise.all(
       extraRewards.map(async (_, i) => {
-        const extraRewardAddress = await contract.extraRewards(i);
-        const extraRewardContract = this.contractFactory.convexVirtualBalanceRewardPool({
-          address: extraRewardAddress,
+        const vbpAddress = await contract.extraRewards(i);
+
+        const vbpContract = this.contractFactory.convexVirtualBalanceRewardPool({
+          address: vbpAddress,
           network: this.network,
         });
 
-        const earnedBN = await multicall.wrap(extraRewardContract).earned(address);
-        return earnedBN.toString();
+        const earnedBN = await multicall.wrap(vbpContract).earned(address);
+        const extraRewardTokenAddressRaw = await multicall.wrap(vbpContract).rewardToken();
+        const extraRewardTokenAddress = extraRewardTokenAddressRaw.toLowerCase();
+
+        // We will combine CVX extra rewards with the amount minted
+        if (extraRewardTokenAddress === cvxRewardToken.address) {
+          cvxBalanceRaw.add(earnedBN);
+          return null;
+        }
+
+        return earnedBN;
       }),
     );
 
-    return [crvBalanceRaw, cvxBalanceRaw, ...extraRewardBalances];
+    return [crvBalanceRaw, cvxBalanceRaw, ...compact(extraRewardBalances)];
   }
 }


### PR DESCRIPTION
## Description

If the bonus rewards include CVX, combine this with the minted CVX amount. Prevents confusion on the FE and better supported by balance snapshots since they keys are identical currently for the nested CVX rewards.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
