### PR TITLE
feat(presenter): Split async/non-async presenter logic

### DIFF
--- a/src/app-toolkit/decorators/balance-product-meta.decorator.ts
+++ b/src/app-toolkit/decorators/balance-product-meta.decorator.ts
@@ -1,7 +1,0 @@
-import { applyDecorators, SetMetadata } from '@nestjs/common';
-
-export const BALANCE_PRODUCT_META_SELECTOR = 'BALANCE_PRODUCT_META_SELECTOR';
-
-export const BalanceProductMeta = (groupSelector: string) => {
-  return applyDecorators(SetMetadata(BALANCE_PRODUCT_META_SELECTOR, groupSelector));
-};

--- a/src/app-toolkit/decorators/index.ts
+++ b/src/app-toolkit/decorators/index.ts
@@ -4,7 +4,6 @@ import { PositionBalanceFetcher } from '~position/position-balance-fetcher.decor
 import { PositionFetcher } from '~position/position-fetcher.decorator';
 
 import { BalanceFetcher } from './balance-fetcher.decorator';
-import { BalanceProductMeta } from './balance-product-meta.decorator';
 import { PositionTemplate } from './position-template.decorator';
 import { PresenterTemplate } from './presenter-template.decorator';
 
@@ -12,7 +11,6 @@ export const Register = {
   AppDefinition,
   AppModule,
   BalanceFetcher,
-  BalanceProductMeta,
   ContractPositionBalanceFetcher: PositionBalanceFetcher(ContractType.POSITION),
   ContractPositionFetcher: PositionFetcher(ContractType.POSITION),
   PositionTemplate,

--- a/src/apps/aave-v2/common/aave-v2.position-presenter.ts
+++ b/src/apps/aave-v2/common/aave-v2.position-presenter.ts
@@ -2,7 +2,7 @@ import { Inject } from '@nestjs/common';
 
 import { PresentationConfig } from '~app/app.interface';
 import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
-import { PositionPresenterTemplate, ReadonlyBalances } from '~position/template/position-presenter.template';
+import { PositionDataPropsParams, PositionPresenterTemplate } from '~position/template/position-presenter.template';
 
 import { AaveV2ContractFactory } from '../contracts';
 
@@ -61,11 +61,7 @@ export abstract class AaveV2PositionPresenter extends PositionPresenterTemplate<
     address,
     groupLabel,
     balances,
-  }: {
-    address: string;
-    groupLabel: string;
-    balances: ReadonlyBalances;
-  }): Promise<AaveV2PositionPresenterDataProps | undefined> {
+  }: PositionDataPropsParams): Promise<AaveV2PositionPresenterDataProps | undefined> {
     if (groupLabel !== 'Lending') return;
     if (!balances.some(balance => balance.balanceUSD < 0)) return;
 

--- a/src/apps/bastion-protocol/aurora/bastion-protocol.position-presenter.ts
+++ b/src/apps/bastion-protocol/aurora/bastion-protocol.position-presenter.ts
@@ -1,13 +1,11 @@
-import { sumBy } from 'lodash';
-
-import { Register } from '~app-toolkit/decorators';
 import { PresenterTemplate } from '~app-toolkit/decorators/presenter-template.decorator';
 import { PresentationConfig } from '~app/app.interface';
 import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
+import { lendingDataProps, LendingDataProps, presentLendingDataProps } from '~position/position-presenter.utils';
 import { PositionPresenterTemplate, ReadonlyBalances } from '~position/template/position-presenter.template';
 
 @PresenterTemplate()
-export class AuroraBastionProtocolPositionPresenter extends PositionPresenterTemplate {
+export class AuroraBastionProtocolPositionPresenter extends PositionPresenterTemplate<LendingDataProps> {
   explorePresentationConfig: PresentationConfig = {
     tabs: [
       {
@@ -82,51 +80,20 @@ export class AuroraBastionProtocolPositionPresenter extends PositionPresenterTem
     ],
   };
 
-  async getLendingMeta(address: string, balances: ReadonlyBalances) {
-    const collaterals = balances.filter(balance => balance.balanceUSD > 0);
-    const debt = balances.filter(balance => balance.balanceUSD < 0);
-    const totalCollateralUSD = sumBy(collaterals, a => a.balanceUSD);
-    const totalDebtUSD = sumBy(debt, a => a.balanceUSD);
-    const utilRatio = (Math.abs(totalDebtUSD) / totalCollateralUSD) * 100;
-
-    const meta: MetadataItemWithLabel[] = [
-      {
-        label: 'Collateral',
-        value: totalCollateralUSD,
-        type: 'dollar',
-      },
-      {
-        label: 'Debt',
-        value: totalDebtUSD,
-        type: 'dollar',
-      },
-      {
-        label: 'Utilization Rate',
-        value: utilRatio,
-        type: 'pct',
-      },
-    ];
-
-    return meta;
+  async positionDataProps({
+    balances,
+    groupLabel,
+  }: {
+    address: string;
+    groupLabel: string;
+    balances: ReadonlyBalances;
+  }): Promise<LendingDataProps | undefined> {
+    if (['Aurora Ecosystem Realm', 'Main Hub Realm', 'Multichain Realm', 'Staked NEAR Realm'].includes(groupLabel)) {
+      return lendingDataProps(balances);
+    }
   }
 
-  @Register.BalanceProductMeta('Aurora Ecosystem Realm')
-  async getAuroraEcosystemMeta(address: string, balances: ReadonlyBalances) {
-    return this.getLendingMeta(address, balances);
-  }
-
-  @Register.BalanceProductMeta('Main Hub Realm')
-  async getMainHubMeta(address: string, balances: ReadonlyBalances) {
-    return this.getLendingMeta(address, balances);
-  }
-
-  @Register.BalanceProductMeta('Multichain Realm')
-  async getMultichainMeta(address: string, balances: ReadonlyBalances) {
-    return this.getLendingMeta(address, balances);
-  }
-
-  @Register.BalanceProductMeta('Staked NEAR Realm')
-  async getStakedNearMeta(address: string, balances: ReadonlyBalances) {
-    return this.getLendingMeta(address, balances);
+  presentDataProps(dataProps: LendingDataProps): MetadataItemWithLabel[] {
+    return presentLendingDataProps(dataProps);
   }
 }

--- a/src/apps/bastion-protocol/aurora/bastion-protocol.position-presenter.ts
+++ b/src/apps/bastion-protocol/aurora/bastion-protocol.position-presenter.ts
@@ -2,7 +2,7 @@ import { PresenterTemplate } from '~app-toolkit/decorators/presenter-template.de
 import { PresentationConfig } from '~app/app.interface';
 import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
 import { lendingDataProps, LendingDataProps, presentLendingDataProps } from '~position/position-presenter.utils';
-import { PositionPresenterTemplate, ReadonlyBalances } from '~position/template/position-presenter.template';
+import { PositionDataPropsParams, PositionPresenterTemplate } from '~position/template/position-presenter.template';
 
 @PresenterTemplate()
 export class AuroraBastionProtocolPositionPresenter extends PositionPresenterTemplate<LendingDataProps> {
@@ -80,14 +80,7 @@ export class AuroraBastionProtocolPositionPresenter extends PositionPresenterTem
     ],
   };
 
-  async positionDataProps({
-    balances,
-    groupLabel,
-  }: {
-    address: string;
-    groupLabel: string;
-    balances: ReadonlyBalances;
-  }): Promise<LendingDataProps | undefined> {
+  async positionDataProps({ balances, groupLabel }: PositionDataPropsParams): Promise<LendingDataProps | undefined> {
     if (['Aurora Ecosystem Realm', 'Main Hub Realm', 'Multichain Realm', 'Staked NEAR Realm'].includes(groupLabel)) {
       return lendingDataProps(balances);
     }

--- a/src/apps/compound/common/compound.position-presenter.ts
+++ b/src/apps/compound/common/compound.position-presenter.ts
@@ -1,7 +1,7 @@
 import { PresentationConfig } from '~app/app.interface';
 import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
 import { lendingDataProps, LendingDataProps, presentLendingDataProps } from '~position/position-presenter.utils';
-import { PositionPresenterTemplate, ReadonlyBalances } from '~position/template/position-presenter.template';
+import { PositionDataPropsParams, PositionPresenterTemplate } from '~position/template/position-presenter.template';
 
 export abstract class CompoundPositionPresenter extends PositionPresenterTemplate<LendingDataProps> {
   explorePresentationConfig?: PresentationConfig = {
@@ -25,14 +25,7 @@ export abstract class CompoundPositionPresenter extends PositionPresenterTemplat
     ],
   };
 
-  async positionDataProps({
-    balances,
-    groupLabel,
-  }: {
-    address: string;
-    groupLabel: string;
-    balances: ReadonlyBalances;
-  }): Promise<LendingDataProps | undefined> {
+  async positionDataProps({ balances, groupLabel }: PositionDataPropsParams): Promise<LendingDataProps | undefined> {
     if (groupLabel === 'Lending') {
       return lendingDataProps(balances);
     }

--- a/src/apps/morpho/ethereum/morpho.position-presenter.ts
+++ b/src/apps/morpho/ethereum/morpho.position-presenter.ts
@@ -8,7 +8,11 @@ import { MorphoContractPositionDataProps } from '~apps/morpho/helpers/position-f
 import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
 import { isMulticallUnderlyingError } from '~multicall/multicall.ethers';
 import { ContractPositionBalance } from '~position/position-balance.interface';
-import { PositionPresenterTemplate, ReadonlyBalances } from '~position/template/position-presenter.template';
+import {
+  PositionDataPropsParams,
+  PositionPresenterTemplate,
+  ReadonlyBalances,
+} from '~position/template/position-presenter.template';
 
 import { MorphoContractFactory } from '../contracts';
 
@@ -45,11 +49,7 @@ export class EthereumMorphoPositionPresenter extends PositionPresenterTemplate<E
     address,
     groupLabel,
     balances,
-  }: {
-    address: string;
-    groupLabel: string;
-    balances: ReadonlyBalances;
-  }): Promise<EthereumMorphoPositionPresenterDataProps | undefined> {
+  }: PositionDataPropsParams): Promise<EthereumMorphoPositionPresenterDataProps | undefined> {
     switch (groupLabel) {
       case 'Morpho Aave': {
         const healthFactor = await this.getMorphoAaveHealthFactor(address);

--- a/src/apps/rari-fuse/common/rari-fuse.position-presenter.ts
+++ b/src/apps/rari-fuse/common/rari-fuse.position-presenter.ts
@@ -1,36 +1,13 @@
-import { sumBy } from 'lodash';
-
-import { Register } from '~app-toolkit/decorators';
 import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
+import { lendingDataProps, LendingDataProps, presentLendingDataProps } from '~position/position-presenter.utils';
 import { PositionPresenterTemplate, ReadonlyBalances } from '~position/template/position-presenter.template';
 
-export abstract class RariFusePositionPresenter extends PositionPresenterTemplate {
-  @Register.BalanceProductMeta('{{ dataProps.marketName }}')
-  async getLendingMeta(address: string, balances: ReadonlyBalances) {
-    const collaterals = balances.filter(balance => balance.balanceUSD > 0);
-    const debt = balances.filter(balance => balance.balanceUSD < 0);
-    const totalCollateralUSD = sumBy(collaterals, a => a.balanceUSD);
-    const totalDebtUSD = sumBy(debt, a => a.balanceUSD);
-    const utilRatio = (Math.abs(totalDebtUSD) / totalCollateralUSD) * 100;
+export abstract class RariFusePositionPresenter extends PositionPresenterTemplate<LendingDataProps> {
+  async positionDataProps({ balances }: { balances: ReadonlyBalances }): Promise<LendingDataProps | undefined> {
+    return lendingDataProps(balances);
+  }
 
-    const meta: MetadataItemWithLabel[] = [
-      {
-        label: 'Collateral',
-        value: totalCollateralUSD,
-        type: 'dollar',
-      },
-      {
-        label: 'Debt',
-        value: totalDebtUSD,
-        type: 'dollar',
-      },
-      {
-        label: 'Utilization Rate',
-        value: utilRatio,
-        type: 'pct',
-      },
-    ];
-
-    return meta;
+  presentDataProps(dataProps: LendingDataProps): MetadataItemWithLabel[] {
+    return presentLendingDataProps(dataProps);
   }
 }

--- a/src/apps/rari-fuse/common/rari-fuse.position-presenter.ts
+++ b/src/apps/rari-fuse/common/rari-fuse.position-presenter.ts
@@ -1,9 +1,9 @@
 import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
 import { lendingDataProps, LendingDataProps, presentLendingDataProps } from '~position/position-presenter.utils';
-import { PositionPresenterTemplate, ReadonlyBalances } from '~position/template/position-presenter.template';
+import { PositionDataPropsParams, PositionPresenterTemplate } from '~position/template/position-presenter.template';
 
 export abstract class RariFusePositionPresenter extends PositionPresenterTemplate<LendingDataProps> {
-  async positionDataProps({ balances }: { balances: ReadonlyBalances }): Promise<LendingDataProps | undefined> {
+  async positionDataProps({ balances }: PositionDataPropsParams): Promise<LendingDataProps | undefined> {
     return lendingDataProps(balances);
   }
 

--- a/src/apps/synthetix/common/synthetix.position-presenter.ts
+++ b/src/apps/synthetix/common/synthetix.position-presenter.ts
@@ -85,7 +85,7 @@ export abstract class SynthetixPositionPresenter extends PositionPresenterTempla
     const escrowed = collateralBalance - unlockedSnx;
     const unescrowed = unlockedSnx;
 
-    return { collateralUSD, debtBalanceUSD, cRatio, escrowed, unescrowed, snxPrice: snxBalance.price };
+    return { collateralUSD, debtBalanceUSD, cRatio, escrowed, unescrowed, snxPrice };
   }
 
   presentDataProps(dataProps: SynthetixPositionPresenterDataProps): MetadataItemWithLabel[] {

--- a/src/apps/synthetix/common/synthetix.position-presenter.ts
+++ b/src/apps/synthetix/common/synthetix.position-presenter.ts
@@ -9,7 +9,7 @@ import {
 } from '~app-toolkit/helpers/presentation/display-item.present';
 import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
 import { ContractType } from '~position/contract.interface';
-import { PositionPresenterTemplate, ReadonlyBalances } from '~position/template/position-presenter.template';
+import { PositionDataPropsParams, PositionPresenterTemplate } from '~position/template/position-presenter.template';
 
 import { SynthetixContractFactory } from '../contracts';
 
@@ -33,11 +33,7 @@ export abstract class SynthetixPositionPresenter extends PositionPresenterTempla
     address,
     groupLabel,
     balances,
-  }: {
-    address: string;
-    groupLabel: string;
-    balances: ReadonlyBalances;
-  }): Promise<SynthetixPositionPresenterDataProps | undefined> {
+  }: PositionDataPropsParams): Promise<SynthetixPositionPresenterDataProps | undefined> {
     if (groupLabel !== 'Mintr') return;
 
     let snxPrice: number | undefined;

--- a/src/balance/balance-presentation.service.ts
+++ b/src/balance/balance-presentation.service.ts
@@ -19,7 +19,7 @@ import { TokenBalanceResponse } from './balance-fetcher.interface';
 
 type Balances = (AppTokenPositionBalance | ContractPositionBalance)[];
 
-type DataPropsByGroupLabel<T extends DefaultDataProps = DefaultDataProps> = { [k: string]: T };
+type DataPropsByGroupLabel = { [k: string]: DefaultDataProps };
 
 interface IAppService {
   getApp(appId: string): Promise<AppDefinition | undefined>;

--- a/src/balance/balance.service.ts
+++ b/src/balance/balance.service.ts
@@ -60,12 +60,22 @@ export class BalanceService {
 
     const addressBalancePairs = await Promise.all(
       addresses.map(async address => {
-        const balances = await Promise.all(balanceEnabledTemplates.map(template => template.getBalances(address)));
-        const presentedBalances = await this.balancePresentationService.presentTemplates({
+        const balances = await Promise.all(balanceEnabledTemplates.map(template => template.getBalances(address))).then(
+          v => v.flat(),
+        );
+
+        const dataPropsByGroupLabel = await this.balancePresentationService.positionDataPropsByGroupLabel({
           appId,
           network,
           address,
-          balances: balances.flat(),
+          balances,
+        });
+
+        const presentedBalances = await this.balancePresentationService.presentTemplates({
+          appId,
+          network,
+          balances,
+          dataPropsByGroupLabel,
         });
         return [address, presentedBalances];
       }),
@@ -118,12 +128,10 @@ export class BalanceService {
           ),
         ]);
 
-        const preprocessed = [...tokenBalances.flat(), ...contractPositionBalances.flat()];
+        const balances = [...tokenBalances.flat(), ...contractPositionBalances.flat()];
         const presentedBalances = await this.balancePresentationService.present({
           appId,
-          network,
-          address,
-          balances: preprocessed,
+          balances,
         });
         return [address, presentedBalances];
       }),

--- a/src/position/position-presenter.registry.ts
+++ b/src/position/position-presenter.registry.ts
@@ -1,64 +1,25 @@
 import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
-import { DiscoveryService, MetadataScanner, Reflector } from '@nestjs/core';
+import { DiscoveryService } from '@nestjs/core';
 
-import { BALANCE_PRODUCT_META_SELECTOR } from '~app-toolkit/decorators/balance-product-meta.decorator';
 import { Network } from '~types/network.interface';
 import { buildTemplateRegistry } from '~utils/build-template-registry';
 
-import { GroupMeta, PositionPresenterTemplate, ReadonlyBalances } from './template/position-presenter.template';
+import { PositionPresenterTemplate } from './template/position-presenter.template';
 
 @Injectable()
 export class PositionPresenterRegistry implements OnModuleInit {
-  private registry = new Map<Network, Map<string, PositionPresenterTemplate>>();
-  private balanceProductMetaResolverRegistry = new Map<
-    Network,
-    Map<string, Map<string, (address: string, balances: ReadonlyBalances) => Promise<GroupMeta>>>
-  >();
+  private registry: Map<string, PositionPresenterTemplate> = new Map();
 
-  constructor(
-    @Inject(DiscoveryService) private readonly discoveryService: DiscoveryService,
-    @Inject(MetadataScanner) private readonly metadataScanner: MetadataScanner,
-    @Inject(Reflector) private readonly reflector: Reflector,
-  ) {}
+  constructor(@Inject(DiscoveryService) private readonly discoveryService: DiscoveryService) {}
 
   onModuleInit() {
     this.registry = buildTemplateRegistry(this.discoveryService, {
       template: PositionPresenterTemplate,
-      keySelector: t => [t.network, t.appId] as const,
+      keySelector: t => [`${t.network}:${t.appId}`] as const,
     });
-
-    // Look for balance product metas on each position presenter
-    this.registry.forEach(r => {
-      r.forEach(presenter => {
-        this.metadataScanner.scanFromPrototype(presenter, Object.getPrototypeOf(presenter), (methodName: string) => {
-          this.registerBalanceProductMeta(presenter, methodName);
-        });
-      });
-    });
-  }
-
-  private registerBalanceProductMeta(instance: PositionPresenterTemplate, methodName: string) {
-    const { network, appId } = instance;
-    const methodRef = instance[methodName];
-    const groupSelector = this.reflector.get(BALANCE_PRODUCT_META_SELECTOR, methodRef);
-    if (!groupSelector) return;
-
-    if (!this.balanceProductMetaResolverRegistry.get(network))
-      this.balanceProductMetaResolverRegistry.set(network, new Map());
-    if (!this.balanceProductMetaResolverRegistry.get(network)?.get(appId))
-      this.balanceProductMetaResolverRegistry.get(network)?.set(appId, new Map());
-
-    this.balanceProductMetaResolverRegistry
-      .get(network)
-      ?.get(appId)
-      ?.set(groupSelector, (...args) => methodRef.apply(instance, args));
   }
 
   get(appId: string, network: Network) {
-    return this.registry.get(network)?.get(appId) ?? null;
-  }
-
-  getBalanceProductMetaResolvers(appId: string, network: Network) {
-    return this.balanceProductMetaResolverRegistry.get(network)?.get(appId) ?? null;
+    return this.registry.get(`${network}:${appId}`);
   }
 }

--- a/src/position/position-presenter.utils.ts
+++ b/src/position/position-presenter.utils.ts
@@ -1,0 +1,46 @@
+import _ from 'lodash';
+
+import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
+
+import { ReadonlyBalances } from './template/position-presenter.template';
+
+export type LendingDataProps = {
+  totalCollateralUSD: number;
+  totalDebtUSD: number;
+  utilRatio: number;
+};
+
+export function lendingDataProps(balances: ReadonlyBalances): LendingDataProps {
+  const collaterals = balances.filter(balance => balance.balanceUSD > 0);
+  const debt = balances.filter(balance => balance.balanceUSD < 0);
+  const totalCollateralUSD = _.sumBy(collaterals, a => a.balanceUSD);
+  const totalDebtUSD = _.sumBy(debt, a => a.balanceUSD);
+  const utilRatio = (Math.abs(totalDebtUSD) / totalCollateralUSD) * 100;
+
+  return {
+    totalCollateralUSD,
+    totalDebtUSD,
+    utilRatio,
+  };
+}
+
+export function presentLendingDataProps(lendingTotals: LendingDataProps): MetadataItemWithLabel[] {
+  const { totalCollateralUSD, totalDebtUSD, utilRatio } = lendingTotals;
+  return [
+    {
+      label: 'Collateral',
+      value: totalCollateralUSD,
+      type: 'dollar',
+    },
+    {
+      label: 'Debt',
+      value: totalDebtUSD,
+      type: 'dollar',
+    },
+    {
+      label: 'Utilization Rate',
+      value: utilRatio,
+      type: 'pct',
+    },
+  ];
+}

--- a/src/position/template/position-presenter.template.ts
+++ b/src/position/template/position-presenter.template.ts
@@ -1,18 +1,27 @@
 import { PresentationConfig } from '~app/app.interface';
 import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
+import { DefaultDataProps } from '~position/display.interface';
 import { ContractPositionBalance, TokenBalance } from '~position/position-balance.interface';
 import { Network } from '~types';
 
-export interface PositionPresenter {
-  explorePresentationConfig?: PresentationConfig;
-}
-
-export abstract class PositionPresenterTemplate implements PositionPresenter {
+export abstract class PositionPresenterTemplate<T extends DefaultDataProps = DefaultDataProps> {
   network: Network;
   appId: string;
 
   positionGroups?: PositionGroup[];
   explorePresentationConfig?: PresentationConfig;
+
+  async positionDataProps(_opts: {
+    address: string;
+    groupLabel: string;
+    balances: ReadonlyBalances;
+  }): Promise<T | undefined> {
+    return undefined;
+  }
+
+  presentDataProps(_dataProps: T): MetadataItemWithLabel[] {
+    return [];
+  }
 }
 
 export type PositionGroup = { label: string; groupIds: string[] };

--- a/src/position/template/position-presenter.template.ts
+++ b/src/position/template/position-presenter.template.ts
@@ -4,6 +4,12 @@ import { DefaultDataProps } from '~position/display.interface';
 import { ContractPositionBalance, TokenBalance } from '~position/position-balance.interface';
 import { Network } from '~types';
 
+export type PositionDataPropsParams = {
+  address: string;
+  groupLabel: string;
+  balances: ReadonlyBalances;
+};
+
 export abstract class PositionPresenterTemplate<T extends DefaultDataProps = DefaultDataProps> {
   network: Network;
   appId: string;
@@ -11,14 +17,11 @@ export abstract class PositionPresenterTemplate<T extends DefaultDataProps = Def
   positionGroups?: PositionGroup[];
   explorePresentationConfig?: PresentationConfig;
 
-  async positionDataProps(_opts: {
-    address: string;
-    groupLabel: string;
-    balances: ReadonlyBalances;
-  }): Promise<T | undefined> {
+  async positionDataProps(_opts: PositionDataPropsParams): Promise<T | undefined> {
     return undefined;
   }
 
+  // NOTE: This method is not async on purpose since it is called inline when rendering each positions.
   presentDataProps(_dataProps: T): MetadataItemWithLabel[] {
     return [];
   }


### PR DESCRIPTION
## Description

This splits out the presentation logic from:
- Mapping the meta to MetadataItems
- Retreiving/Calculating the meta

By splitting the 2 concepts into 2 parts, we can calculate everything in background, and only map it synchronously afterward.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
