### PR TITLE
feat(base-token): Fix type returned by token dependency selector

### DIFF
--- a/src/position/selectors/token-dependency-selector.interface.ts
+++ b/src/position/selectors/token-dependency-selector.interface.ts
@@ -1,5 +1,5 @@
 import { AppTokenPosition } from '~position/position.interface';
-import { BaseTokenPrice } from '~token/selectors/token-price-selector.interface';
+import { BaseToken } from '~position/token.interface';
 import { Network } from '~types';
 
 export type LoggingTags = {
@@ -13,7 +13,7 @@ export type TokenDependencySelectorKey = {
   tokenId?: number;
 };
 
-export type TokenDependency = AppTokenPosition | BaseTokenPrice;
+export type TokenDependency = BaseToken | AppTokenPosition;
 
 export type GetOne = (opts: TokenDependencySelectorKey) => Promise<TokenDependency | null>;
 export type GetMany = (opts: TokenDependencySelectorKey[]) => Promise<(TokenDependency | null)[]>;


### PR DESCRIPTION
## Description

Token dependency selector should be returning a `BaseToken` or `AppTokenPosition`, not a `BaseTokenPrice` which has unnecessary fields for token dependencies.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
