### PR TITLE
feat(positions): Split getPositions to enable batching

### DIFF
--- a/src/position/template/app-token.template.position-fetcher.ts
+++ b/src/position/template/app-token.template.position-fetcher.ts
@@ -161,15 +161,12 @@ export abstract class AppTokenTemplatePositionFetcher<
     return statsItems;
   }
 
-  // Default (adapted) Template Runner
-  // Note: This will be removed in favour of an orchestrator at a higher level once all groups are migrated
-  async getPositions(): Promise<AppTokenPosition<V>[]> {
+  async getPositionsForBatch(definitions: R[]) {
     const multicall = this.appToolkit.getMulticall(this.network);
     const tokenLoader = this.appToolkit.getTokenDependencySelector({
       tags: { network: this.network, context: `${this.appId}__template` },
     });
 
-    const definitions = await this.getDefinitions({ multicall, tokenLoader });
     const maybeSkeletons = await Promise.all(
       definitions.map(async definition => {
         const address = definition.address.toLowerCase();
@@ -279,6 +276,18 @@ export abstract class AppTokenTemplatePositionFetcher<
       if (typeof t.dataProps.liquidity === 'number') return -t.dataProps.liquidity;
       return 1;
     });
+  }
+
+  // Default (adapted) Template Runner
+  // Note: This will be removed in favour of an orchestrator at a higher level once all groups are migrated
+  async getPositions(): Promise<AppTokenPosition<V>[]> {
+    const multicall = this.appToolkit.getMulticall(this.network);
+    const tokenLoader = this.appToolkit.getTokenDependencySelector({
+      tags: { network: this.network, context: `${this.appId}__template` },
+    });
+
+    const definitions = await this.getDefinitions({ multicall, tokenLoader });
+    return this.getPositionsForBatch(definitions);
   }
 
   async getAccountAddress(address: string) {


### PR DESCRIPTION
## Description

Time to start pulling more Uniswap V2 pools! Split the `getPositions` method so that we can batch in Zapper API by calling the batch method with a subset of the definitions.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
