### PR TITLE
feat(aura): Aura pools upgrade

### DIFF
--- a/src/apps/aura/aura.module.ts
+++ b/src/apps/aura/aura.module.ts
@@ -14,6 +14,7 @@ import { EthereumAuraPoolContractPositionFetcher } from './ethereum/aura.pool.co
 import { EthereumAuraStakingContractPositionFetcher } from './ethereum/aura.staking.contract-position-fetcher';
 import { AuraBalancerPoolsHelper } from './helpers/aura.balancer-pools-helper';
 import { AuraBaseRewardPoolHelper } from './helpers/aura.base-reward-pool-helper';
+import { AuraSubgraphHelper } from './helpers/aura.subgraph-helper';
 
 @Register.AppModule({
   appId: AURA_DEFINITION.id,
@@ -32,6 +33,7 @@ import { AuraBaseRewardPoolHelper } from './helpers/aura.base-reward-pool-helper
     // Helpers
     AuraBalancerPoolsHelper,
     AuraBaseRewardPoolHelper,
+    AuraSubgraphHelper,
   ],
 })
 export class AuraAppModule extends AbstractApp() {}

--- a/src/apps/aura/aura.types.ts
+++ b/src/apps/aura/aura.types.ts
@@ -1,6 +1,7 @@
 export type AuraBaseRewardPoolDataProps = {
   extraRewards: { address: string; rewardToken: string }[];
   rewardToken: string;
+  rewardPool: { address: string; deprecated: boolean };
 };
 
 export type BalancerPool = {

--- a/src/apps/aura/ethereum/aura.locker.contract-position-fetcher.ts
+++ b/src/apps/aura/ethereum/aura.locker.contract-position-fetcher.ts
@@ -10,6 +10,7 @@ import {
   buildPercentageDisplayItem,
 } from '~app-toolkit/helpers/presentation/display-item.present';
 import { getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
+import { AuraSubgraphHelper } from '~apps/aura/helpers/aura.subgraph-helper';
 import { SynthetixSingleStakingRoiStrategy } from '~apps/synthetix';
 import { ContractType } from '~position/contract.interface';
 import { PositionFetcher } from '~position/position-fetcher.interface';
@@ -52,6 +53,7 @@ const AURA_LOCKER_QUERY = gql`
 export class EthereumAuraLockerContractPositionFetcher implements PositionFetcher<ContractPosition> {
   constructor(
     @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
+    @Inject(AuraSubgraphHelper) private readonly subgraphHelper: AuraSubgraphHelper,
     @Inject(AuraContractFactory) private readonly auraContractFactory: AuraContractFactory,
     @Inject(SynthetixSingleStakingRoiStrategy) private readonly roiStrategy: SynthetixSingleStakingRoiStrategy,
   ) {}
@@ -130,10 +132,7 @@ export class EthereumAuraLockerContractPositionFetcher implements PositionFetche
   private async getAuraLockerData() {
     const {
       auraLocker: { rewardData, totalSupply },
-    } = await this.appToolkit.helpers.theGraphHelper.request<AuraLockerQuery>({
-      endpoint: 'https://api.thegraph.com/subgraphs/name/aurafinance/aura',
-      query: AURA_LOCKER_QUERY,
-    });
+    } = await this.subgraphHelper.request<AuraLockerQuery>(AURA_LOCKER_QUERY);
     return {
       totalSupply: BigNumber.from(totalSupply),
       rewardData: rewardData.map(({ token: { id }, rewardRate }) => ({ address: id.toLowerCase(), rewardRate })),

--- a/src/apps/aura/ethereum/aura.staking.contract-position-fetcher.ts
+++ b/src/apps/aura/ethereum/aura.staking.contract-position-fetcher.ts
@@ -26,7 +26,10 @@ export class EthereumAuraStakingContractPositionFetcher implements PositionFetch
         { appId: BALANCER_V2_DEFINITION.id, network, groupIds: [BALANCER_V2_DEFINITION.groups.pool.id] },
         { appId: AURA_DEFINITION.id, network, groupIds: [AURA_DEFINITION.groups.auraBal.id] },
       ],
-      rewardPools: ['0x5e5ea2048475854a5702f5b8468a51ba1296efcc'],
+      rewardPools: [
+        { address: '0x00a7ba8ae7bca0b10a32ea1f8e2a1da980c6cad2', deprecated: false },
+        { address: '0x5e5ea2048475854a5702f5b8468a51ba1296efcc', deprecated: true },
+      ],
     });
   }
 }

--- a/src/apps/aura/helpers/aura.subgraph-helper.ts
+++ b/src/apps/aura/helpers/aura.subgraph-helper.ts
@@ -1,0 +1,30 @@
+import { Inject, Injectable } from '@nestjs/common';
+
+import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
+import { AuraBaseRewardPoolHelper } from '~apps/aura/helpers/aura.base-reward-pool-helper';
+
+@Injectable()
+export class AuraSubgraphHelper {
+  static V1 = 'https://graph.aura.finance/subgraphs/name/aura/aura-mainnet-v1';
+  static V2 = 'https://graph.aura.finance/subgraphs/name/aura/aura-mainnet-v2';
+
+  constructor(
+    @Inject(APP_TOOLKIT) private readonly appToolkit: IAppToolkit,
+    @Inject(AuraBaseRewardPoolHelper) private readonly auraBaseRewardPoolHelper: AuraBaseRewardPoolHelper,
+  ) {}
+
+  async request<T>(query: string, endpoint = AuraSubgraphHelper.V2) {
+    return this.appToolkit.helpers.theGraphHelper.request<T>({ query, endpoint });
+  }
+
+  async requestAllVersions<T>(query: string) {
+    const [v1, v2] = await Promise.all(
+      [AuraSubgraphHelper.V1, AuraSubgraphHelper.V2].map(endpoint => this.request<T>(query, endpoint)),
+    );
+
+    return {
+      v1,
+      v2,
+    };
+  }
+}


### PR DESCRIPTION
## Description

Aura has just started an [LP migration](https://twitter.com/AuraFinance/status/1601065333925650432) for all users to opt in to. 

This PR makes several changes to support this migration, by showing the balances of the new pools, and showing a 'Needs migration' label for pools that will not be receiving further rewards.

The subgraph endpoint has also changed: 

```typescript
export class AuraSubgraphHelper {
  static V1 = 'https://graph.aura.finance/subgraphs/name/aura/aura-mainnet-v1';
  static V2 = 'https://graph.aura.finance/subgraphs/name/aura/aura-mainnet-v2';
```

The schema is the same; v1 contains the deprecated pools/accounts, and v2 contains the current pools/accounts, and also the locker.


## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: brianbutterfield.eth
- [x] (optional) As a contributor, my Twitter handle is: https://twitter.com/0xbutterfield

## How to test?

You can test with `0x51D63958A63A31eB4028917F049Ce477c8DD07Bb` and optionally compare this with the UI at https://app.aura.finance (I suggest using https://impersonator.xyz ).

For the diff with the current `aura` app on Zapper prod, you should see new WETH/AURA and auraBAL positions.