### PR TITLE
fix(presenter): ignore empty balance set

### DIFF
--- a/src/balance/balance-presentation.service.ts
+++ b/src/balance/balance-presentation.service.ts
@@ -104,6 +104,8 @@ export class BalancePresentationService {
 
         return Promise.all(
           Object.entries(groupBalances).map(async ([computedGroupLabel, balances]) => {
+            if (!groupBalances.length) return;
+
             const groupMetaResolver = balanceMetaResolvers?.get(group.label);
 
             return {
@@ -112,7 +114,7 @@ export class BalancePresentationService {
               ...(groupMetaResolver && { meta: await groupMetaResolver(address, balances) }),
             };
           }),
-        );
+        ).then(v => _.compact(v));
       }),
     );
 


### PR DESCRIPTION
## Description

Since we are presenter the balances by using the groups, we may end up with an empty set of balances. For now let's ignore the fact that we may have empty balances.

Ideally, we should group the balances by groupId, then map the groupId => label, then regroup by label. This way we would never end up with an empty set of balances.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
