### PR TITLE
feat(balances): Improve performance by doing O(1) lookups

### DIFF
--- a/src/position/template/app-token.template.position-fetcher.ts
+++ b/src/position/template/app-token.template.position-fetcher.ts
@@ -354,9 +354,14 @@ export abstract class AppTokenTemplatePositionFetcher<
   async drillRawBalances(balances: RawAppTokenBalance[]): Promise<AppTokenPositionBalance<V>[]> {
     const appTokens = await this.getPositionsForBalances();
 
+    const balancesByKey = _(balances)
+      .groupBy(b => b.key)
+      .mapValues(v => v[0])
+      .value();
+
     const appTokenBalances = appTokens.map(token => {
       const key = this.appToolkit.getPositionKey(token);
-      const tokenBalance = balances.find(b => b.key === key);
+      const tokenBalance = balancesByKey[key];
       if (!tokenBalance) return null;
 
       const result = drillBalance<typeof token, V>(token, tokenBalance.balance, { isDebt: this.isDebt });


### PR DESCRIPTION
## Description

This should have quite a significant improvement for apps that have a lot of positions since it would avoid doing O(N^2) lookups.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
