### PR TITLE
feat(aura): Aura pools upgrade

### DIFF
--- a/src/apps/aura/ethereum/aura.aura-bal-staking.contract-position-fetcher.ts
+++ b/src/apps/aura/ethereum/aura.aura-bal-staking.contract-position-fetcher.ts
@@ -1,12 +1,25 @@
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
+import { GetDisplayPropsParams } from '~position/template/contract-position.template.types';
+import { SingleStakingFarmDataProps } from '~position/template/single-staking.template.contract-position-fetcher';
 
 import { AuraFarmContractPositionFetcher } from '../common/aura.farm.contract-position-fetcher';
+import { AuraBaseRewardPool } from '../contracts';
 
 @PositionTemplate()
 export class EthereumAuraAuraBalStakingContractPositionFetcher extends AuraFarmContractPositionFetcher {
   groupLabel = 'auraBAL Staking';
 
+  AURA_BAL_STAKING_V1 = '0x5e5ea2048475854a5702f5b8468a51ba1296efcc';
+  AURA_BAL_STAKING_V2 = '0x00a7ba8ae7bca0b10a32ea1f8e2a1da980c6cad2';
+
   getFarmAddresses() {
-    return ['0x5e5ea2048475854a5702f5b8468a51ba1296efcc'];
+    return [this.AURA_BAL_STAKING_V1, this.AURA_BAL_STAKING_V2];
+  }
+
+  async getTertiaryLabel(params: GetDisplayPropsParams<AuraBaseRewardPool, SingleStakingFarmDataProps>) {
+    if (params.definition.address === this.AURA_BAL_STAKING_V1) {
+      return `Needs migration`;
+    }
+    return super.getTertiaryLabel(params);
   }
 }

--- a/src/apps/aura/ethereum/aura.deposit.token-fetcher.ts
+++ b/src/apps/aura/ethereum/aura.deposit.token-fetcher.ts
@@ -19,6 +19,7 @@ import { AuraContractFactory, AuraDepositToken } from '../contracts';
 type AuraDepositTokenDefinition = {
   address: string;
   poolIndex: number;
+  booster: string;
 };
 
 @PositionTemplate()
@@ -29,7 +30,8 @@ export class EthereumAuraDepositTokenFetcher extends AppTokenTemplatePositionFet
 > {
   groupLabel = 'Deposits';
 
-  BOOSTER_ADDRESS = '0x7818a1da7bd1e64c199029e86ba244a9798eee10';
+  BOOSTER_V1_ADDRESS = '0x7818a1da7bd1e64c199029e86ba244a9798eee10';
+  BOOSTER_V2_ADDRESS = '0xa57b8d98dae62b26ec3bcc4a365338157060b234';
 
   constructor(
     @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
@@ -43,17 +45,28 @@ export class EthereumAuraDepositTokenFetcher extends AppTokenTemplatePositionFet
   }
 
   async getDefinitions({ multicall }: GetDefinitionsParams): Promise<AuraDepositTokenDefinition[]> {
-    const boosterContract = this.contractFactory.auraBooster({ address: this.BOOSTER_ADDRESS, network: this.network });
-    const numOfPools = await boosterContract.poolLength();
-
     const definitions = await Promise.all(
-      range(0, Number(numOfPools)).flatMap(async poolIndex => {
-        const poolInfo = await multicall.wrap(boosterContract).poolInfo(poolIndex);
-        return { address: poolInfo.token.toLowerCase(), poolIndex };
+      [this.BOOSTER_V1_ADDRESS, this.BOOSTER_V2_ADDRESS].map(async booster => {
+        const boosterContract = this.contractFactory.auraBooster({
+          address: booster,
+          network: this.network,
+        });
+        const numOfPools = await boosterContract.poolLength();
+
+        return Promise.all(
+          range(0, Number(numOfPools)).flatMap(async poolIndex => {
+            const poolInfo = await multicall.wrap(boosterContract).poolInfo(poolIndex);
+            return {
+              address: poolInfo.token.toLowerCase(),
+              poolIndex,
+              booster,
+            };
+          }),
+        );
       }),
     );
 
-    return definitions;
+    return definitions.flat();
   }
 
   async getAddresses({ definitions }: GetAddressesParams) {
@@ -63,7 +76,7 @@ export class EthereumAuraDepositTokenFetcher extends AppTokenTemplatePositionFet
   async getUnderlyingTokenAddresses({
     definition,
   }: GetUnderlyingTokensParams<AuraDepositToken, AuraDepositTokenDefinition>) {
-    const boosterContract = this.contractFactory.auraBooster({ address: this.BOOSTER_ADDRESS, network: this.network });
+    const boosterContract = this.contractFactory.auraBooster({ address: definition.booster, network: this.network });
     const poolInfo = await boosterContract.poolInfo(definition.poolIndex);
     return poolInfo.lptoken;
   }
@@ -82,5 +95,14 @@ export class EthereumAuraDepositTokenFetcher extends AppTokenTemplatePositionFet
 
   async getLabel({ appToken }: GetDisplayPropsParams<AuraDepositToken, DefaultAppTokenDataProps>) {
     return getLabelFromToken(appToken.tokens[0]!);
+  }
+
+  async getTertiaryLabel(
+    params: GetDisplayPropsParams<AuraDepositToken, DefaultAppTokenDataProps, AuraDepositTokenDefinition>,
+  ) {
+    if (params.definition.booster === this.BOOSTER_V1_ADDRESS) {
+      return `Needs migration`;
+    }
+    return super.getTertiaryLabel(params);
   }
 }

--- a/src/apps/aura/ethereum/aura.lp-farm.contract-position-fetcher.ts
+++ b/src/apps/aura/ethereum/aura.lp-farm.contract-position-fetcher.ts
@@ -8,10 +8,21 @@ import { AuraFarmContractPositionFetcher } from '../common/aura.farm.contract-po
 export class EthereumAuraLpFarmContractPositionFetcher extends AuraFarmContractPositionFetcher {
   groupLabel = 'Liquidity Pool Staking';
 
+  BOOSTER_V1_ADDRESS = '0x7818a1da7bd1e64c199029e86ba244a9798eee10';
+  BOOSTER_V2_ADDRESS = '0xa57b8d98dae62b26ec3bcc4a365338157060b234';
+
   async getFarmAddresses() {
-    const address = '0x7818a1da7bd1e64c199029e86ba244a9798eee10';
-    const contract = this.contractFactory.auraBooster({ address, network: this.network });
-    const numPools = await contract.poolLength().then(Number);
-    return Promise.all(range(0, numPools).map(v => contract.poolInfo(v).then(p => p.crvRewards)));
+    const boosters = [this.BOOSTER_V1_ADDRESS, this.BOOSTER_V2_ADDRESS].map(booster =>
+      this.contractFactory.auraBooster({ address: booster, network: this.network }),
+    );
+
+    const addresses = await Promise.all(
+      boosters.map(async contract => {
+        const numPools = await contract.poolLength().then(Number);
+        return Promise.all(range(0, numPools).map(v => contract.poolInfo(v).then(p => p.crvRewards)));
+      }),
+    );
+
+    return addresses.flat();
   }
 }


### PR DESCRIPTION
## Description

Aura has just started an [LP migration](https://twitter.com/AuraFinance/status/1601065333925650432) for all users to opt in to. 

This PR makes several changes to support this migration, by showing the balances of the new pools, and showing a 'Needs migration' label for pools that will not be receiving further rewards.

The subgraph endpoint has also changed: 

```typescript
export class AuraSubgraphHelper {
  static V1 = 'https://graph.aura.finance/subgraphs/name/aura/aura-mainnet-v1';
  static V2 = 'https://graph.aura.finance/subgraphs/name/aura/aura-mainnet-v2';
```

The schema is the same; v1 contains the deprecated pools/accounts, and v2 contains the current pools/accounts, and also the locker.


## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: brianbutterfield.eth
- [x] (optional) As a contributor, my Twitter handle is: https://twitter.com/0xbutterfield

## How to test?

You can test with `0x51D63958A63A31eB4028917F049Ce477c8DD07Bb` and optionally compare this with the UI at https://app.aura.finance (I suggest using https://impersonator.xyz ).

For the diff with the current `aura` app on Zapper prod, you should see new WETH/AURA and auraBAL positions.

To test auraBAL staking, you can see a position that needs migration for `0x019edcb493bd91e2b25b70f26d5d9041fd7ef946` and a migrated position for `0x0e6c5c610739ddf254147a38f811ea935f91e10f`.