### PR TITLE
feat(app-token): Support string token ID

### DIFF
--- a/src/position/template/app-token.template.position-fetcher.ts
+++ b/src/position/template/app-token.template.position-fetcher.ts
@@ -1,6 +1,6 @@
 import { Inject } from '@nestjs/common';
 import { BigNumberish, Contract } from 'ethers/lib/ethers';
-import _, { isEqual, isNumber, uniqWith } from 'lodash';
+import _, { isEqual, isUndefined, uniqWith } from 'lodash';
 import { compact, intersection, isArray, partition, sortBy, sum } from 'lodash';
 
 import { drillBalance } from '~app-toolkit';
@@ -208,7 +208,7 @@ export abstract class AppTokenTemplatePositionFetcher<
               const isAddressMatch = token.address === definition.address;
               const isNetworkMatch = token.network === definition.network;
               const isMaybeTokenIdMatch =
-                !isNumber(definition.tokenId) ||
+                isUndefined(definition.tokenId) ||
                 (token.type === ContractType.APP_TOKEN && token.dataProps.tokenId === definition.tokenId) ||
                 (token.type === ContractType.NON_FUNGIBLE_TOKEN &&
                   Number(token.assets?.[0].tokenId) === definition.tokenId);


### PR DESCRIPTION
## Description

Support token ID as a string because Shell V2 has very large numeric token IDs.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
