### PR TITLE
feat(olympus): Update bond template to support async definitions and custom data props

### DIFF
--- a/src/apps/jpegd/ethereum/jpegd.bond.contract-position-fetcher.ts
+++ b/src/apps/jpegd/ethereum/jpegd.bond.contract-position-fetcher.ts
@@ -33,6 +33,10 @@ export class EthereumJpegdBondContractPositionFetcher extends OlympusBondContrac
     return this.contractFactory.jpegdBondDepository({ address, network: this.network });
   }
 
+  async resolveBondDefinitions() {
+    return this.bondDefinitions;
+  }
+
   async resolveVestingBalance({
     address,
     contract,

--- a/src/apps/klima/polygon/klima.bond.contract-position-fetcher.ts
+++ b/src/apps/klima/polygon/klima.bond.contract-position-fetcher.ts
@@ -58,6 +58,10 @@ export class PolygonKlimaBondContractPositionFetcher extends OlympusBondContract
     return this.contractFactory.klimaBondDepository({ address, network: this.network });
   }
 
+  async resolveBondDefinitions() {
+    return this.bondDefinitions;
+  }
+
   async resolveVestingBalance({
     address,
     contract,

--- a/src/apps/olympus/common/olympus.bond.contract-position-fetcher.ts
+++ b/src/apps/olympus/common/olympus.bond.contract-position-fetcher.ts
@@ -11,6 +11,7 @@ import {
   GetTokenDefinitionsParams,
   GetDisplayPropsParams,
   GetTokenBalancesParams,
+  GetDefinitionsParams,
 } from '~position/template/contract-position.template.types';
 
 export type OlympusBondContractPositionDefinition = {
@@ -33,9 +34,9 @@ export type ResolveVestingBalanceParams<T extends Contract> = {
 
 export abstract class OlympusBondContractPositionFetcher<
   T extends Contract,
-> extends ContractPositionTemplatePositionFetcher<T, DefaultDataProps, OlympusBondContractPositionDefinition> {
-  abstract bondDefinitions: OlympusBondContractPositionDefinition[];
-
+  V extends DefaultDataProps = DefaultDataProps,
+> extends ContractPositionTemplatePositionFetcher<T, V, OlympusBondContractPositionDefinition> {
+  abstract resolveBondDefinitions(params: GetDefinitionsParams): Promise<OlympusBondContractPositionDefinition[]>;
   abstract resolveVestingBalance(params: ResolveVestingBalanceParams<T>): Promise<BigNumberish>;
   abstract resolveClaimableBalance(params: ResolveClaimableBalanceParams<T>): Promise<BigNumberish>;
 
@@ -43,8 +44,8 @@ export abstract class OlympusBondContractPositionFetcher<
     super(appToolkit);
   }
 
-  async getDefinitions(): Promise<OlympusBondContractPositionDefinition[]> {
-    return this.bondDefinitions;
+  async getDefinitions(params: GetDefinitionsParams): Promise<OlympusBondContractPositionDefinition[]> {
+    return this.resolveBondDefinitions(params);
   }
 
   async getTokenDefinitions({ definition }: GetTokenDefinitionsParams<T, OlympusBondContractPositionDefinition>) {
@@ -63,7 +64,7 @@ export abstract class OlympusBondContractPositionFetcher<
     address,
     contract,
     multicall,
-  }: GetTokenBalancesParams<T, DefaultDataProps>): Promise<BigNumberish[]> {
+  }: GetTokenBalancesParams<T, V>): Promise<BigNumberish[]> {
     const vestingAmountRaw = await this.resolveVestingBalance({ address, contract, multicall });
     const claimableAmountRaw = await this.resolveClaimableBalance({ address, contract, multicall });
     return [vestingAmountRaw, claimableAmountRaw, 0];

--- a/src/apps/olympus/ethereum/olympus.bond.contract-position-fetcher.ts
+++ b/src/apps/olympus/ethereum/olympus.bond.contract-position-fetcher.ts
@@ -33,6 +33,10 @@ export class EthereumOlympusBondContractPositionFetcher extends OlympusBondContr
     return this.contractFactory.olympusV2BondDepository({ address, network: this.network });
   }
 
+  async resolveBondDefinitions() {
+    return this.bondDefinitions;
+  }
+
   async resolveVestingBalance({ address, contract, multicall }: ResolveVestingBalanceParams<OlympusV2BondDepository>) {
     const indexes = await multicall.wrap(contract).indexesFor(address);
     const pendingBonds = await Promise.all(indexes.map(index => multicall.wrap(contract).pendingFor(address, index)));


### PR DESCRIPTION
## Description

A few integrations require this in Zapper API.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
