### PR TITLE
feat(olympus): Make position available for balance methods

### DIFF
--- a/src/apps/jpegd/ethereum/jpegd.bond.contract-position-fetcher.ts
+++ b/src/apps/jpegd/ethereum/jpegd.bond.contract-position-fetcher.ts
@@ -1,13 +1,9 @@
 import { Inject } from '@nestjs/common';
-import { BigNumberish } from 'ethers';
 
 import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
-import {
-  OlympusBondContractPositionFetcher,
-  ResolveClaimableBalanceParams,
-  ResolveVestingBalanceParams,
-} from '~apps/olympus/common/olympus.bond.contract-position-fetcher';
+import { OlympusBondContractPositionFetcher } from '~apps/olympus/common/olympus.bond.contract-position-fetcher';
+import { GetTokenBalancesParams } from '~position/template/contract-position.template.types';
 
 import { JpegdBondDepository, JpegdContractFactory } from '../contracts';
 
@@ -37,10 +33,7 @@ export class EthereumJpegdBondContractPositionFetcher extends OlympusBondContrac
     return this.bondDefinitions;
   }
 
-  async resolveVestingBalance({
-    address,
-    contract,
-  }: ResolveVestingBalanceParams<JpegdBondDepository>): Promise<BigNumberish> {
+  async resolveVestingBalance({ address, contract }: GetTokenBalancesParams<JpegdBondDepository>) {
     const [bondInfo, pendingPayout] = await Promise.all([
       contract.bondInfo(address),
       contract.pendingPayoutFor(address),
@@ -50,10 +43,7 @@ export class EthereumJpegdBondContractPositionFetcher extends OlympusBondContrac
     return vestingBalanceRaw;
   }
 
-  resolveClaimableBalance({
-    address,
-    contract,
-  }: ResolveClaimableBalanceParams<JpegdBondDepository>): Promise<BigNumberish> {
+  resolveClaimableBalance({ address, contract }: GetTokenBalancesParams<JpegdBondDepository>) {
     return contract.pendingPayoutFor(address);
   }
 }

--- a/src/apps/klima/polygon/klima.bond.contract-position-fetcher.ts
+++ b/src/apps/klima/polygon/klima.bond.contract-position-fetcher.ts
@@ -3,11 +3,8 @@ import { BigNumberish } from 'ethers';
 
 import { IAppToolkit, APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
-import {
-  OlympusBondContractPositionFetcher,
-  ResolveClaimableBalanceParams,
-  ResolveVestingBalanceParams,
-} from '~apps/olympus/common/olympus.bond.contract-position-fetcher';
+import { OlympusBondContractPositionFetcher } from '~apps/olympus/common/olympus.bond.contract-position-fetcher';
+import { GetTokenBalancesParams } from '~position/template/contract-position.template.types';
 
 import { KlimaBondDepository, KlimaContractFactory } from '../contracts';
 
@@ -65,7 +62,7 @@ export class PolygonKlimaBondContractPositionFetcher extends OlympusBondContract
   async resolveVestingBalance({
     address,
     contract,
-  }: ResolveVestingBalanceParams<KlimaBondDepository>): Promise<BigNumberish> {
+  }: GetTokenBalancesParams<KlimaBondDepository>): Promise<BigNumberish> {
     const [bondInfo, pendingPayout] = await Promise.all([
       contract.bondInfo(address),
       contract.pendingPayoutFor(address),
@@ -78,7 +75,7 @@ export class PolygonKlimaBondContractPositionFetcher extends OlympusBondContract
   async resolveClaimableBalance({
     address,
     contract,
-  }: ResolveClaimableBalanceParams<KlimaBondDepository>): Promise<BigNumberish> {
+  }: GetTokenBalancesParams<KlimaBondDepository>): Promise<BigNumberish> {
     return contract.pendingPayoutFor(address);
   }
 }

--- a/src/apps/olympus/ethereum/olympus.bond.contract-position-fetcher.ts
+++ b/src/apps/olympus/ethereum/olympus.bond.contract-position-fetcher.ts
@@ -3,12 +3,9 @@ import { BigNumber } from 'ethers';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
+import { GetTokenBalancesParams } from '~position/template/contract-position.template.types';
 
-import {
-  OlympusBondContractPositionFetcher,
-  ResolveClaimableBalanceParams,
-  ResolveVestingBalanceParams,
-} from '../common/olympus.bond.contract-position-fetcher';
+import { OlympusBondContractPositionFetcher } from '../common/olympus.bond.contract-position-fetcher';
 import { OlympusContractFactory, OlympusV2BondDepository } from '../contracts';
 
 @PositionTemplate()
@@ -37,7 +34,7 @@ export class EthereumOlympusBondContractPositionFetcher extends OlympusBondContr
     return this.bondDefinitions;
   }
 
-  async resolveVestingBalance({ address, contract, multicall }: ResolveVestingBalanceParams<OlympusV2BondDepository>) {
+  async resolveVestingBalance({ address, contract, multicall }: GetTokenBalancesParams<OlympusV2BondDepository>) {
     const indexes = await multicall.wrap(contract).indexesFor(address);
     const pendingBonds = await Promise.all(indexes.map(index => multicall.wrap(contract).pendingFor(address, index)));
     const vestingBonds = pendingBonds.filter(p => !p.matured_);
@@ -45,11 +42,7 @@ export class EthereumOlympusBondContractPositionFetcher extends OlympusBondContr
     return vestingAmount;
   }
 
-  async resolveClaimableBalance({
-    address,
-    contract,
-    multicall,
-  }: ResolveClaimableBalanceParams<OlympusV2BondDepository>) {
+  async resolveClaimableBalance({ address, contract, multicall }: GetTokenBalancesParams<OlympusV2BondDepository>) {
     const indexes = await multicall.wrap(contract).indexesFor(address);
     const pendingBonds = await Promise.all(indexes.map(index => multicall.wrap(contract).pendingFor(address, index)));
     const claimableBonds = pendingBonds.filter(p => p.matured_);


### PR DESCRIPTION
## Description

Need the position for data props in some forks in Zapper API.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
