### PR TITLE
feat(pendle-v2): Use API response to populate all token groups

### DIFF
--- a/src/apps/pendle-v2/ethereum/pendle-v2.pool.token-fetcher.ts
+++ b/src/apps/pendle-v2/ethereum/pendle-v2.pool.token-fetcher.ts
@@ -1,5 +1,4 @@
 import { Inject } from '@nestjs/common';
-import request from 'graphql-request';
 import moment from 'moment';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
@@ -21,7 +20,7 @@ import { NETWORK_IDS } from '~types/network.interface';
 
 import { PendleMarket, PendleV2ContractFactory } from '../contracts';
 import { BACKEND_QUERIES, PENDLE_V2_GRAPHQL_ENDPOINT } from '../pendle-v2.constant';
-import { MarketResponse, MarketsQueryResponse, TokenResponse } from '../pendle-v2.types';
+import { MarketsQueryResponse, TokenResponse } from '../pendle-v2.types';
 
 type Token = {
   name: string;
@@ -73,14 +72,14 @@ export class EthereumPendleV2PoolTokenFetcher extends AppTokenTemplatePositionFe
   }
 
   async getDefinitions(): Promise<PendleV2MarketTokenDefinition[]> {
-    const resp: MarketsQueryResponse = await request(PENDLE_V2_GRAPHQL_ENDPOINT, BACKEND_QUERIES.getMarkets, {
-      chainId: NETWORK_IDS[this.network],
+    const marketsResponse = await this.appToolkit.helpers.theGraphHelper.request<MarketsQueryResponse>({
+      endpoint: PENDLE_V2_GRAPHQL_ENDPOINT,
+      query: BACKEND_QUERIES.getMarkets,
+      variables: { chainId: NETWORK_IDS[this.network] },
     });
 
-    const markets: MarketResponse[] = resp.markets.results;
-
     const definitions = await Promise.all(
-      markets.map(async market => {
+      marketsResponse.markets.results.map(async market => {
         return {
           address: market.address,
           aggregatedApy: market.aggregatedApy,

--- a/src/apps/pendle-v2/ethereum/pendle-v2.principal.token-fetcher.ts
+++ b/src/apps/pendle-v2/ethereum/pendle-v2.principal.token-fetcher.ts
@@ -50,7 +50,7 @@ export class EthereumPendleV2PrincipalTokenFetcher extends AppTokenTemplatePosit
     const marketsResponse = await this.appToolkit.helpers.theGraphHelper.request<MarketsQueryResponse>({
       endpoint: PENDLE_V2_GRAPHQL_ENDPOINT,
       query: BACKEND_QUERIES.getMarkets,
-      variables: { chainIds: NETWORK_IDS[this.network] },
+      variables: { chainId: NETWORK_IDS[this.network] },
     });
 
     const definitions = await Promise.all(

--- a/src/apps/pendle-v2/ethereum/pendle-v2.standardized-yield.token-fetcher.ts
+++ b/src/apps/pendle-v2/ethereum/pendle-v2.standardized-yield.token-fetcher.ts
@@ -51,7 +51,7 @@ export class EthereumPendleV2StandardizedYieldTokenFetcher extends AppTokenTempl
     const marketsResponse = await this.appToolkit.helpers.theGraphHelper.request<MarketsQueryResponse>({
       endpoint: PENDLE_V2_GRAPHQL_ENDPOINT,
       query: BACKEND_QUERIES.getMarkets,
-      variables: { chainIds: NETWORK_IDS[this.network] },
+      variables: { chainId: NETWORK_IDS[this.network] },
     });
 
     const definitions = await Promise.all(

--- a/src/apps/pendle-v2/ethereum/pendle-v2.standardized-yield.token-fetcher.ts
+++ b/src/apps/pendle-v2/ethereum/pendle-v2.standardized-yield.token-fetcher.ts
@@ -11,11 +11,11 @@ import {
   GetDisplayPropsParams,
   GetPriceParams,
 } from '~position/template/app-token.template.types';
+import { NETWORK_IDS } from '~types';
 
 import { PendleV2ContractFactory, StandardizedYield } from '../contracts';
-import { PENDLE_V_2_DEFINITION } from '../pendle-v2.definition';
-
-import { PendleV2MarketDataProps } from './pendle-v2.pool.token-fetcher';
+import { BACKEND_QUERIES, PENDLE_V2_GRAPHQL_ENDPOINT } from '../pendle-v2.constant';
+import { MarketsQueryResponse } from '../pendle-v2.types';
 
 export type PendleV2StandardizedYieldTokenDefinition = {
   address: string;
@@ -29,7 +29,7 @@ export type PendleV2StandardizedYieldTokenDataProps = DefaultAppTokenDataProps &
   PendleV2StandardizedYieldTokenDefinition;
 
 @PositionTemplate()
-export class EthereumPendleV2StandardizedYieldTokenTokenFetcher extends AppTokenTemplatePositionFetcher<
+export class EthereumPendleV2StandardizedYieldTokenFetcher extends AppTokenTemplatePositionFetcher<
   StandardizedYield,
   PendleV2StandardizedYieldTokenDataProps,
   PendleV2StandardizedYieldTokenDefinition
@@ -43,27 +43,30 @@ export class EthereumPendleV2StandardizedYieldTokenTokenFetcher extends AppToken
     super(appToolkit);
   }
 
-  async getDefinitions(_params: GetDefinitionsParams): Promise<PendleV2StandardizedYieldTokenDefinition[]> {
-    const markets = await this.appToolkit.getAppTokenPositions<PendleV2MarketDataProps>({
-      appId: 'pendle-v2',
-      groupIds: [PENDLE_V_2_DEFINITION.groups.pool.id],
-      network: this.network,
-    });
-    const definitions = markets.map(market => {
-      return {
-        address: market.dataProps.sy.address,
-        icon: market.dataProps.sy.icon,
-        name: market.dataProps.sy.name,
-        price: market.dataProps.sy.price,
-        underlyingApy: market.dataProps.underlyingApy,
-      };
-    });
-
-    return definitions;
-  }
-
   getContract(address: string) {
     return this.pendleV2ContractFactory.standardizedYield({ address, network: this.network });
+  }
+
+  async getDefinitions(_params: GetDefinitionsParams): Promise<PendleV2StandardizedYieldTokenDefinition[]> {
+    const marketsResponse = await this.appToolkit.helpers.theGraphHelper.request<MarketsQueryResponse>({
+      endpoint: PENDLE_V2_GRAPHQL_ENDPOINT,
+      query: BACKEND_QUERIES.getMarkets,
+      variables: { chainIds: NETWORK_IDS[this.network] },
+    });
+
+    const definitions = await Promise.all(
+      marketsResponse.markets.results.map(async market => {
+        return {
+          address: market.sy.address,
+          icon: market.sy.proIcon,
+          name: market.sy.proName,
+          price: market.sy.price.usd,
+          underlyingApy: market.underlyingApy,
+        };
+      }),
+    );
+
+    return definitions;
   }
 
   async getAddresses({ definitions }: GetAddressesParams): Promise<string[]> {

--- a/src/apps/pendle-v2/ethereum/pendle-v2.yield.token-fetcher.ts
+++ b/src/apps/pendle-v2/ethereum/pendle-v2.yield.token-fetcher.ts
@@ -52,7 +52,7 @@ export class EthereumPendleV2YieldTokenFetcher extends AppTokenTemplatePositionF
     const marketsResponse = await this.appToolkit.helpers.theGraphHelper.request<MarketsQueryResponse>({
       endpoint: PENDLE_V2_GRAPHQL_ENDPOINT,
       query: BACKEND_QUERIES.getMarkets,
-      variables: { chainIds: NETWORK_IDS[this.network] },
+      variables: { chainId: NETWORK_IDS[this.network] },
     });
 
     const definitions = await Promise.all(

--- a/src/apps/pendle-v2/index.ts
+++ b/src/apps/pendle-v2/index.ts
@@ -1,3 +1,0 @@
-export { PENDLE_V_2_DEFINITION, PendleV2AppDefinition } from './pendle-v2.definition';
-export { PendleV2AppModule } from './pendle-v2.module';
-export { PendleV2ContractFactory } from './contracts';

--- a/src/apps/pendle-v2/pendle-v2.module.ts
+++ b/src/apps/pendle-v2/pendle-v2.module.ts
@@ -3,18 +3,18 @@ import { AbstractApp } from '~app/app.dynamic-module';
 
 import { PendleV2ContractFactory } from './contracts';
 import { EthereumPendleV2PoolTokenFetcher } from './ethereum/pendle-v2.pool.token-fetcher';
-import { EthereumPendleV2PrincipalTokenTokenFetcher } from './ethereum/pendle-v2.principal-token.token-fetcher';
-import { EthereumPendleV2StandardizedYieldTokenTokenFetcher } from './ethereum/pendle-v2.standardized-yield-token.token-fetcher';
-import { EthereumPendleV2YieldTokenTokenFetcher } from './ethereum/pendle-v2.yield-token.token-fetcher';
+import { EthereumPendleV2PrincipalTokenFetcher } from './ethereum/pendle-v2.principal.token-fetcher';
+import { EthereumPendleV2StandardizedYieldTokenFetcher } from './ethereum/pendle-v2.standardized-yield.token-fetcher';
+import { EthereumPendleV2YieldTokenFetcher } from './ethereum/pendle-v2.yield.token-fetcher';
 import { PendleV2AppDefinition, PENDLE_V_2_DEFINITION } from './pendle-v2.definition';
 
 @Register.AppModule({
   appId: PENDLE_V_2_DEFINITION.id,
   providers: [
     EthereumPendleV2PoolTokenFetcher,
-    EthereumPendleV2PrincipalTokenTokenFetcher,
-    EthereumPendleV2StandardizedYieldTokenTokenFetcher,
-    EthereumPendleV2YieldTokenTokenFetcher,
+    EthereumPendleV2PrincipalTokenFetcher,
+    EthereumPendleV2StandardizedYieldTokenFetcher,
+    EthereumPendleV2YieldTokenFetcher,
     PendleV2AppDefinition,
     PendleV2ContractFactory,
   ],


### PR DESCRIPTION
## Description

Prevent circular dependency between pool group and SY/Y/P token groups.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
