### PR TITLE
feat(mean-finance): add Ethereum Mainnet for Mean Finance integration

### DIFF
--- a/src/apps/mean-finance/ethereum/mean-finance.dca-position.contract-position-fetcher.ts
+++ b/src/apps/mean-finance/ethereum/mean-finance.dca-position.contract-position-fetcher.ts
@@ -1,0 +1,19 @@
+import 'moment-duration-format';
+
+import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
+
+import { MeanFinanceDcaPositionContractPositionFetcher } from '../common/mean-finance.dca-position.contract-position-fetcher';
+
+@PositionTemplate()
+export class EthereumMeanFinanceDcaPositionContractPositionFetcher extends MeanFinanceDcaPositionContractPositionFetcher {
+  groupLabel = 'DCA Positions';
+  hubs = [
+    {
+      // Version 4 Hub - YIELD
+      hubAddress: '0xa43cc0b95ec985bf45fc03262150c20cae180952',
+      tokenAddress: '0x516cb11697bf1ba2dbb5c081c23f169791c4bd01',
+      transformerAddress: '0xc0136591df365611b1452b5f8823def69ff3a685',
+      subgraphUrl: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-yf-ethereum',
+    },
+  ];
+}

--- a/src/apps/mean-finance/mean-finance.definition.ts
+++ b/src/apps/mean-finance/mean-finance.definition.ts
@@ -30,6 +30,7 @@ export const MEAN_FINANCE_DEFINITION = appDefinition({
     [Network.POLYGON_MAINNET]: [AppAction.VIEW],
     [Network.OPTIMISM_MAINNET]: [AppAction.VIEW],
     [Network.ARBITRUM_MAINNET]: [AppAction.VIEW],
+    [Network.ETHEREUM_MAINNET]: [AppAction.VIEW],
   },
 
   primaryColor: '#3076F6',

--- a/src/apps/mean-finance/mean-finance.module.ts
+++ b/src/apps/mean-finance/mean-finance.module.ts
@@ -6,6 +6,7 @@ import { MeanFinanceContractFactory } from './contracts';
 import { MeanFinanceAppDefinition, MEAN_FINANCE_DEFINITION } from './mean-finance.definition';
 import { OptimismMeanFinanceDcaPositionContractPositionFetcher } from './optimism/mean-finance.dca-position.contract-position-fetcher';
 import { PolygonMeanFinanceDcaPositionContractPositionFetcher } from './polygon/mean-finance.dca-position.contract-position-fetcher';
+import { EthereumMeanFinanceDcaPositionContractPositionFetcher } from './ethereum/mean-finance.dca-position.contract-position-fetcher';
 
 @Register.AppModule({
   appId: MEAN_FINANCE_DEFINITION.id,
@@ -15,6 +16,7 @@ import { PolygonMeanFinanceDcaPositionContractPositionFetcher } from './polygon/
     OptimismMeanFinanceDcaPositionContractPositionFetcher,
     PolygonMeanFinanceDcaPositionContractPositionFetcher,
     ArbitrumMeanFinanceDcaPositionContractPositionFetcher,
+    EthereumMeanFinanceDcaPositionContractPositionFetcher,
   ],
 })
-export class MeanFinanceAppModule extends AbstractApp() {}
+export class MeanFinanceAppModule extends AbstractApp() { }


### PR DESCRIPTION
## Description

Adds Ethereum Mainnet integration for Mean Finance

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: fiboape.eth
- [X] (optional) As a contributor, my Twitter handle is: @fiboape

## How to test?
http://localhost:5001/apps/mean-finance/balances?addresses[]=0x2421134c8e8278ad199f6886ae70c5c373da3b48&network=ethereum