### PR TITLE
feat(presenter): Add presenter dataProps

### DIFF
--- a/src/app-toolkit/decorators/index.ts
+++ b/src/app-toolkit/decorators/index.ts
@@ -4,7 +4,6 @@ import { PositionBalanceFetcher } from '~position/position-balance-fetcher.decor
 import { PositionFetcher } from '~position/position-fetcher.decorator';
 
 import { BalanceFetcher } from './balance-fetcher.decorator';
-import { BalanceProductMeta } from './balance-product-meta.decorator';
 import { PositionTemplate } from './position-template.decorator';
 import { PresenterTemplate } from './presenter-template.decorator';
 
@@ -12,7 +11,6 @@ export const Register = {
   AppDefinition,
   AppModule,
   BalanceFetcher,
-  BalanceProductMeta,
   ContractPositionBalanceFetcher: PositionBalanceFetcher(ContractType.POSITION),
   ContractPositionFetcher: PositionFetcher(ContractType.POSITION),
   PositionTemplate,

--- a/src/apps/bastion-protocol/aurora/bastion-protocol.position-presenter.ts
+++ b/src/apps/bastion-protocol/aurora/bastion-protocol.position-presenter.ts
@@ -1,9 +1,9 @@
 import { sumBy } from 'lodash';
 
-import { Register } from '~app-toolkit/decorators';
 import { PresenterTemplate } from '~app-toolkit/decorators/presenter-template.decorator';
 import { PresentationConfig } from '~app/app.interface';
 import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
+import { DefaultDataProps } from '~position/display.interface';
 import { PositionPresenterTemplate, ReadonlyBalances } from '~position/template/position-presenter.template';
 
 @PresenterTemplate()
@@ -82,51 +82,37 @@ export class AuroraBastionProtocolPositionPresenter extends PositionPresenterTem
     ],
   };
 
-  async getLendingMeta(address: string, balances: ReadonlyBalances) {
-    const collaterals = balances.filter(balance => balance.balanceUSD > 0);
-    const debt = balances.filter(balance => balance.balanceUSD < 0);
-    const totalCollateralUSD = sumBy(collaterals, a => a.balanceUSD);
-    const totalDebtUSD = sumBy(debt, a => a.balanceUSD);
-    const utilRatio = (Math.abs(totalDebtUSD) / totalCollateralUSD) * 100;
+  override metadataItemsForBalanceGroup(
+    groupLabel: string,
+    balances: ReadonlyBalances,
+    _dataProps?: DefaultDataProps,
+  ): MetadataItemWithLabel[] {
+    if (['Staked NEAR Realm', 'Multichain Realm', 'Main Hub Realm', 'Aurora Ecosystem Realm'].includes(groupLabel)) {
+      const collaterals = balances.filter(balance => balance.balanceUSD > 0);
+      const debt = balances.filter(balance => balance.balanceUSD < 0);
+      const totalCollateralUSD = sumBy(collaterals, a => a.balanceUSD);
+      const totalDebtUSD = sumBy(debt, a => a.balanceUSD);
+      const utilRatio = (Math.abs(totalDebtUSD) / totalCollateralUSD) * 100;
 
-    const meta: MetadataItemWithLabel[] = [
-      {
-        label: 'Collateral',
-        value: totalCollateralUSD,
-        type: 'dollar',
-      },
-      {
-        label: 'Debt',
-        value: totalDebtUSD,
-        type: 'dollar',
-      },
-      {
-        label: 'Utilization Rate',
-        value: utilRatio,
-        type: 'pct',
-      },
-    ];
+      return [
+        {
+          label: 'Collateral',
+          value: totalCollateralUSD,
+          type: 'dollar',
+        },
+        {
+          label: 'Debt',
+          value: totalDebtUSD,
+          type: 'dollar',
+        },
+        {
+          label: 'Utilization Rate',
+          value: utilRatio,
+          type: 'pct',
+        },
+      ];
+    }
 
-    return meta;
-  }
-
-  @Register.BalanceProductMeta('Aurora Ecosystem Realm')
-  async getAuroraEcosystemMeta(address: string, balances: ReadonlyBalances) {
-    return this.getLendingMeta(address, balances);
-  }
-
-  @Register.BalanceProductMeta('Main Hub Realm')
-  async getMainHubMeta(address: string, balances: ReadonlyBalances) {
-    return this.getLendingMeta(address, balances);
-  }
-
-  @Register.BalanceProductMeta('Multichain Realm')
-  async getMultichainMeta(address: string, balances: ReadonlyBalances) {
-    return this.getLendingMeta(address, balances);
-  }
-
-  @Register.BalanceProductMeta('Staked NEAR Realm')
-  async getStakedNearMeta(address: string, balances: ReadonlyBalances) {
-    return this.getLendingMeta(address, balances);
+    return [];
   }
 }

--- a/src/apps/compound/common/compound.position-presenter.ts
+++ b/src/apps/compound/common/compound.position-presenter.ts
@@ -1,7 +1,8 @@
 import { sumBy } from 'lodash';
 
-import { Register } from '~app-toolkit/decorators';
 import { PresentationConfig } from '~app/app.interface';
+import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
+import { DefaultDataProps } from '~position/display.interface';
 import { PositionPresenterTemplate, ReadonlyBalances } from '~position/template/position-presenter.template';
 
 export abstract class CompoundPositionPresenter extends PositionPresenterTemplate {
@@ -26,30 +27,37 @@ export abstract class CompoundPositionPresenter extends PositionPresenterTemplat
     ],
   };
 
-  @Register.BalanceProductMeta('Lending')
-  async getLendingMeta(_address: string, balances: ReadonlyBalances) {
-    const collaterals = balances.filter(balance => balance.balanceUSD > 0);
-    const debt = balances.filter(balance => balance.balanceUSD < 0);
-    const totalCollateralUSD = sumBy(collaterals, a => a.balanceUSD);
-    const totalDebtUSD = sumBy(debt, a => a.balanceUSD);
-    const utilRatio = (Math.abs(totalDebtUSD) / totalCollateralUSD) * 100;
+  override metadataItemsForBalanceGroup(
+    groupLabel: string,
+    balances: ReadonlyBalances,
+    _dataProps?: DefaultDataProps,
+  ): MetadataItemWithLabel[] {
+    if (groupLabel === 'Lending') {
+      const collaterals = balances.filter(balance => balance.balanceUSD > 0);
+      const debt = balances.filter(balance => balance.balanceUSD < 0);
+      const totalCollateralUSD = sumBy(collaterals, a => a.balanceUSD);
+      const totalDebtUSD = sumBy(debt, a => a.balanceUSD);
+      const utilRatio = (Math.abs(totalDebtUSD) / totalCollateralUSD) * 100;
 
-    return [
-      {
-        label: 'Collateral',
-        value: totalCollateralUSD,
-        type: 'dollar',
-      },
-      {
-        label: 'Debt',
-        value: totalDebtUSD,
-        type: 'dollar',
-      },
-      {
-        label: 'Utilization Rate',
-        value: utilRatio,
-        type: 'pct',
-      },
-    ];
+      return [
+        {
+          label: 'Collateral',
+          value: totalCollateralUSD,
+          type: 'dollar',
+        },
+        {
+          label: 'Debt',
+          value: totalDebtUSD,
+          type: 'dollar',
+        },
+        {
+          label: 'Utilization Rate',
+          value: utilRatio,
+          type: 'pct',
+        },
+      ];
+    }
+
+    return [];
   }
 }

--- a/src/apps/morpho/ethereum/morpho.position-presenter.ts
+++ b/src/apps/morpho/ethereum/morpho.position-presenter.ts
@@ -1,19 +1,17 @@
 import { Inject } from '@nestjs/common';
 import { formatUnits } from 'ethers/lib/utils';
-import { uniq } from 'lodash';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
-import { Register } from '~app-toolkit/decorators';
 import { PresenterTemplate } from '~app-toolkit/decorators/presenter-template.decorator';
-import { MorphoContractPositionDataProps } from '~apps/morpho/common/morpho.supply.contract-position-fetcher';
+import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
 import { isMulticallUnderlyingError } from '~multicall/multicall.ethers';
-import { ContractPositionBalance } from '~position/position-balance.interface';
 import { PositionPresenterTemplate, ReadonlyBalances } from '~position/template/position-presenter.template';
 
 import { MorphoContractFactory } from '../contracts';
 
+export type EthereumMorphoPositionPresenterDataProps = { healthFactor: number };
 @PresenterTemplate()
-export class EthereumMorphoPositionPresenter extends PositionPresenterTemplate {
+export class EthereumMorphoPositionPresenter extends PositionPresenterTemplate<EthereumMorphoPositionPresenterDataProps> {
   morphoCompoundLensAddress = '0x930f1b46e1d081ec1524efd95752be3ece51ef67';
   morphoAaveLensAddress = '0x507fa343d0a90786d86c7cd885f5c49263a91ff4';
 
@@ -24,8 +22,7 @@ export class EthereumMorphoPositionPresenter extends PositionPresenterTemplate {
     super();
   }
 
-  @Register.BalanceProductMeta('Morpho Aave')
-  async getMorphoAaveMeta(address: string) {
+  override async dataProps(address: string): Promise<EthereumMorphoPositionPresenterDataProps | undefined> {
     const multicall = this.appToolkit.getMulticall(this.network);
     const lens = this.contractFactory.morphoAaveV2Lens({
       address: this.morphoAaveLensAddress,
@@ -35,82 +32,32 @@ export class EthereumMorphoPositionPresenter extends PositionPresenterTemplate {
       .wrap(lens)
       .getUserHealthFactor(address)
       .catch(err => {
-        if (isMulticallUnderlyingError(err)) return null;
+        if (isMulticallUnderlyingError(err)) return;
         throw err;
       });
-    if (!healthFactor) return [];
-    return [
-      {
-        label: 'Health Factor',
-        value: +formatUnits(healthFactor),
-        type: 'number',
-      },
-    ];
+
+    if (!healthFactor) return;
+    return { healthFactor: +formatUnits(healthFactor) };
   }
 
-  @Register.BalanceProductMeta('Morpho Compound')
-  async getMorphoCompoundMeta(address: string, balances: ReadonlyBalances) {
-    const markets = (balances as ContractPositionBalance<MorphoContractPositionDataProps>[]).map(
-      v => v.dataProps.marketAddress,
-    );
+  override metadataItemsForBalanceGroup(
+    groupLabel: string,
+    _balances: ReadonlyBalances,
+    dataProps?: EthereumMorphoPositionPresenterDataProps,
+  ): MetadataItemWithLabel[] {
+    if (groupLabel === 'Morpho Aave') {
+      if (!dataProps) return [];
 
-    const multicall = this.appToolkit.getMulticall(this.network);
-    const lens = this.contractFactory.morphoCompoundLens({
-      address: this.morphoCompoundLensAddress,
-      network: this.network,
-    });
-    const balanceStates = await multicall
-      .wrap(lens)
-      .getUserBalanceStates(address, uniq(markets))
-      .catch(err => {
-        if (isMulticallUnderlyingError(err)) return null;
-        throw err;
-      });
-    if (!balanceStates) return [];
+      const { healthFactor } = dataProps;
 
-    const { collateralValue, debtValue, maxDebtValue } = balanceStates;
-
-    const maxDebt = +formatUnits(maxDebtValue);
-    return this._presentMeta({
-      collateral: +formatUnits(collateralValue),
-      debt: +formatUnits(debtValue),
-      maxDebt,
-      liquidationThreshold: maxDebt,
-    });
-  }
-
-  private _presentMeta({
-    collateral,
-    debt,
-    maxDebt,
-    liquidationThreshold,
-  }: {
-    collateral: number;
-    debt: number;
-    maxDebt: number;
-    liquidationThreshold: number;
-  }) {
-    return [
-      {
-        label: 'Collateral',
-        value: maxDebt,
-        type: 'dollar',
-      },
-      {
-        label: 'Total Supply',
-        value: collateral,
-        type: 'dollar',
-      },
-      {
-        label: 'Debt',
-        value: debt,
-        type: 'dollar',
-      },
-      {
-        label: 'Utilization Rate',
-        value: liquidationThreshold > 0 ? (debt / liquidationThreshold) * 100 : 0,
-        type: 'pct',
-      },
-    ];
+      return [
+        {
+          label: 'Health Factor',
+          value: healthFactor,
+          type: 'number',
+        },
+      ];
+    }
+    return [];
   }
 }

--- a/src/apps/rari-fuse/common/rari-fuse.position-presenter.ts
+++ b/src/apps/rari-fuse/common/rari-fuse.position-presenter.ts
@@ -1,36 +1,41 @@
 import { sumBy } from 'lodash';
 
-import { Register } from '~app-toolkit/decorators';
 import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
+import { DefaultDataProps } from '~position/display.interface';
 import { PositionPresenterTemplate, ReadonlyBalances } from '~position/template/position-presenter.template';
 
 export abstract class RariFusePositionPresenter extends PositionPresenterTemplate {
-  @Register.BalanceProductMeta('{{ dataProps.marketName }}')
-  async getLendingMeta(address: string, balances: ReadonlyBalances) {
-    const collaterals = balances.filter(balance => balance.balanceUSD > 0);
-    const debt = balances.filter(balance => balance.balanceUSD < 0);
-    const totalCollateralUSD = sumBy(collaterals, a => a.balanceUSD);
-    const totalDebtUSD = sumBy(debt, a => a.balanceUSD);
-    const utilRatio = (Math.abs(totalDebtUSD) / totalCollateralUSD) * 100;
+  override metadataItemsForBalanceGroup(
+    groupLabel: string,
+    balances: ReadonlyBalances,
+    _dataProps?: DefaultDataProps,
+  ): MetadataItemWithLabel[] {
+    if (groupLabel === (balances[0] as any).dataProps.marketName) {
+      const collaterals = balances.filter(balance => balance.balanceUSD > 0);
+      const debt = balances.filter(balance => balance.balanceUSD < 0);
+      const totalCollateralUSD = sumBy(collaterals, a => a.balanceUSD);
+      const totalDebtUSD = sumBy(debt, a => a.balanceUSD);
+      const utilRatio = (Math.abs(totalDebtUSD) / totalCollateralUSD) * 100;
 
-    const meta: MetadataItemWithLabel[] = [
-      {
-        label: 'Collateral',
-        value: totalCollateralUSD,
-        type: 'dollar',
-      },
-      {
-        label: 'Debt',
-        value: totalDebtUSD,
-        type: 'dollar',
-      },
-      {
-        label: 'Utilization Rate',
-        value: utilRatio,
-        type: 'pct',
-      },
-    ];
+      return [
+        {
+          label: 'Collateral',
+          value: totalCollateralUSD,
+          type: 'dollar',
+        },
+        {
+          label: 'Debt',
+          value: totalDebtUSD,
+          type: 'dollar',
+        },
+        {
+          label: 'Utilization Rate',
+          value: utilRatio,
+          type: 'pct',
+        },
+      ];
+    }
 
-    return meta;
+    return [];
   }
 }

--- a/src/apps/synthetix/common/synthetix.position-presenter.ts
+++ b/src/apps/synthetix/common/synthetix.position-presenter.ts
@@ -1,50 +1,50 @@
 import { Inject } from '@nestjs/common';
 import { formatBytes32String } from 'ethers/lib/utils';
-import _ from 'lodash';
 
-import { Register } from '~app-toolkit/decorators';
+import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import {
   buildDollarDisplayItem,
   buildPercentageDisplayItem,
   buildNumberDisplayItem,
 } from '~app-toolkit/helpers/presentation/display-item.present';
-import { ContractType } from '~position/contract.interface';
+import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
 import { PositionPresenterTemplate, ReadonlyBalances } from '~position/template/position-presenter.template';
 
 import { SynthetixContractFactory } from '../contracts';
 
-export abstract class SynthetixPositionPresenter extends PositionPresenterTemplate {
+export type SynthetixPositionPresenterDataProps = {
+  snxPrice: number;
+  susdPrice: number;
+  collateralBalance: number;
+  unlockedSnx: number;
+  debtBalance: number;
+};
+
+export abstract class SynthetixPositionPresenter extends PositionPresenterTemplate<SynthetixPositionPresenterDataProps> {
   abstract snxAddress: string;
 
-  constructor(@Inject(SynthetixContractFactory) protected readonly contractFactory: SynthetixContractFactory) {
+  constructor(
+    @Inject(SynthetixContractFactory) protected readonly contractFactory: SynthetixContractFactory,
+    @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
+  ) {
     super();
   }
 
-  @Register.BalanceProductMeta('Mintr')
-  async getMintrMeta(address: string, balances: ReadonlyBalances) {
-    let snxPrice: number | undefined;
-    let susdPrice: number | undefined;
+  override async dataProps(address: string): Promise<SynthetixPositionPresenterDataProps | undefined> {
+    const [snxToken, susdToken] = await Promise.all([
+      this.appToolkit.getBaseTokenPrice({
+        network: this.network,
+        address: '0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f',
+      }),
+      this.appToolkit.getBaseTokenPrice({
+        network: this.network,
+        address: '0x57ab1ec28d129707052df4df418d58a2d46d5f51',
+      }),
+    ]);
 
-    // Search for the first position with the SNX & SUSD token to get the price of the 2 tokens.
-    for (const b of balances) {
-      if (b.type !== ContractType.POSITION) continue;
-
-      const tokensBySymbols = _(b.tokens)
-        .groupBy(t => t.symbol)
-        .mapValues(v => v[0])
-        .value();
-
-      const snxToken = tokensBySymbols['SNX'];
-      const susdToken = tokensBySymbols['sUSD'];
-
-      if (snxToken && susdToken) {
-        snxPrice = snxToken.price;
-        susdPrice = susdToken.price;
-        break;
-      }
-    }
-
-    if (!snxPrice || !susdPrice) return [];
+    if (!snxToken || !susdToken) return;
+    const snxPrice = snxToken.price;
+    const susdPrice = susdToken.price;
 
     const synthetixContract = this.contractFactory.synthetixNetworkToken({
       address: this.snxAddress,
@@ -57,23 +57,38 @@ export abstract class SynthetixPositionPresenter extends PositionPresenterTempla
       synthetixContract.debtBalanceOf(address, formatBytes32String('sUSD')),
     ]);
 
-    // Collateral and debt computations
     const collateralBalance = Number(collateralRaw) / 10 ** 18;
     const unlockedSnx = Number(unlockedSnxRaw) / 10 ** 18;
     const debtBalance = Number(debtBalanceRaw) / 10 ** 18;
-    const collateralUSD = collateralBalance * snxPrice;
-    const debtBalanceUSD = -debtBalance * susdPrice;
-    const cRatio = debtBalance > 0 ? (collateralUSD / debtBalance) * 100 : 1;
-    const escrowed = collateralBalance - unlockedSnx;
-    const unescrowed = unlockedSnx;
 
-    return [
-      { label: 'Collateral', ...buildDollarDisplayItem(collateralUSD) },
-      { label: 'Debt', ...buildDollarDisplayItem(debtBalanceUSD) },
-      { label: 'C-Ratio', ...buildPercentageDisplayItem(cRatio) },
-      { label: 'Escrowed SNX', ...buildNumberDisplayItem(escrowed) },
-      { label: 'Unescrowed SNX', ...buildNumberDisplayItem(unescrowed) },
-      { label: 'SNX Price', ...buildDollarDisplayItem(snxPrice) },
-    ];
+    return { snxPrice, susdPrice, collateralBalance, unlockedSnx, debtBalance };
+  }
+
+  override metadataItemsForBalanceGroup(
+    groupLabel: string,
+    _balances: ReadonlyBalances,
+    dataProps?: SynthetixPositionPresenterDataProps,
+  ): MetadataItemWithLabel[] {
+    if (groupLabel === 'Mintr') {
+      if (!dataProps) return [];
+
+      const { snxPrice, susdPrice, collateralBalance, unlockedSnx, debtBalance } = dataProps;
+
+      const collateralUSD = collateralBalance * snxPrice;
+      const debtBalanceUSD = -debtBalance * susdPrice;
+      const cRatio = debtBalance > 0 ? (collateralUSD / debtBalance) * 100 : 1;
+      const escrowed = collateralBalance - unlockedSnx;
+      const unescrowed = unlockedSnx;
+
+      return [
+        { label: 'Collateral', ...buildDollarDisplayItem(collateralUSD) },
+        { label: 'Debt', ...buildDollarDisplayItem(debtBalanceUSD) },
+        { label: 'C-Ratio', ...buildPercentageDisplayItem(cRatio) },
+        { label: 'Escrowed SNX', ...buildNumberDisplayItem(escrowed) },
+        { label: 'Unescrowed SNX', ...buildNumberDisplayItem(unescrowed) },
+        { label: 'SNX Price', ...buildDollarDisplayItem(snxPrice) },
+      ];
+    }
+    return [];
   }
 }

--- a/src/balance/balance-presentation.service.ts
+++ b/src/balance/balance-presentation.service.ts
@@ -1,10 +1,10 @@
 import { Inject, Injectable } from '@nestjs/common';
-import _ from 'lodash';
-import { get, groupBy } from 'lodash';
+import _, { get, groupBy } from 'lodash';
 
 import { presentBalanceFetcherResponse } from '~app-toolkit/helpers/presentation/balance-fetcher-response.present';
 import { AppDefinition } from '~app/app.definition';
 import { AppService } from '~app/app.service';
+import { DefaultDataProps } from '~position/display.interface';
 import {
   AppTokenPositionBalance,
   ContractPositionBalance,
@@ -17,12 +17,7 @@ import { Network } from '~types';
 
 import { TokenBalanceResponse } from './balance-fetcher.interface';
 
-export type PresentParams = {
-  appId: string;
-  network: Network;
-  address: string;
-  balances: (AppTokenPositionBalance | ContractPositionBalance)[];
-};
+type Balances = (AppTokenPositionBalance | ContractPositionBalance)[];
 
 interface IAppService {
   getApp(appId: string): Promise<AppDefinition | undefined>;
@@ -55,11 +50,21 @@ export class BalancePresentationService {
     }
   }
 
-  async presentTemplates({ address, appId, network, balances }: PresentParams): Promise<TokenBalanceResponse> {
-    return this.presentBalances(address, appId, network, balances);
+  async presentTemplates({
+    appId,
+    network,
+    balances,
+    dataProps,
+  }: {
+    appId: string;
+    balances: Balances;
+    network: Network;
+    dataProps?: DefaultDataProps;
+  }): Promise<TokenBalanceResponse> {
+    return this.presentBalances(appId, network, balances, dataProps);
   }
 
-  async present({ appId, balances }: PresentParams): Promise<TokenBalanceResponse> {
+  async present({ appId, balances }: { appId: string; balances: Balances }): Promise<TokenBalanceResponse> {
     // Build labelled groups by the labels defined in the app definition
     const app = await this.appService.getApp(appId);
     const products = Object.values(app!.groups ?? {}).map(group => {
@@ -93,32 +98,53 @@ export class BalancePresentationService {
     }));
   }
 
-  private async presentBalances(address: string, appId: string, network: Network, balances: PositionBalance[]) {
-    const customPresenter = this.positionPresenterRegistry.get(appId, network);
-    const positionGroups = customPresenter?.positionGroups ?? this.getBalanceProductGroups(appId, network);
+  async balanceDataProps({ appId, network, address }: { appId: string; network: Network; address: string }) {
+    const presenter = this.positionPresenterRegistry.get(appId, network);
+    if (!presenter) return;
 
-    const balanceMetaResolvers = this.positionPresenterRegistry.getBalanceProductMetaResolvers(appId, network);
-    const products = await Promise.all(
-      positionGroups.map(async group => {
-        const groupBalances = this.groupBalancesByPositionGroup(balances, group);
+    const dataProps = await presenter.dataProps(address);
+    return dataProps;
+  }
 
-        return Promise.all(
-          Object.entries(groupBalances).map(async ([computedGroupLabel, balances]) => {
-            if (!balances.length) return;
+  private groupBalances(
+    appId: string,
+    network: Network,
+    balances: PositionBalance[],
+  ): { [groupLabel: string]: PositionBalance[] } {
+    const presenter = this.positionPresenterRegistry.get(appId, network);
+    const positionGroups = presenter?.positionGroups ?? this.getBalanceProductGroups(appId, network);
 
-            const groupMetaResolver = balanceMetaResolvers?.get(group.label);
-            const meta = groupMetaResolver && (await groupMetaResolver(address, balances).catch(_ => undefined));
+    return positionGroups
+      .map(group => this.groupBalancesByPositionGroup(balances, group))
+      .reduce((acc, v) => {
+        Object.entries(v).forEach(([groupLabel, balances]) => {
+          acc[groupLabel] = (acc[groupLabel] || []).concat(balances);
+        });
+        return acc;
+      }, {});
+  }
 
-            return {
-              label: computedGroupLabel,
-              assets: balances,
-              ...(meta && { meta }),
-            };
-          }),
-        ).then(v => _.compact(v));
-      }),
-    );
+  private presentBalances(appId: string, network: Network, balances: PositionBalance[], dataProps?: DefaultDataProps) {
+    const balancesByGroupLabel = this.groupBalances(appId, network, balances);
+    const presenter = this.positionPresenterRegistry.get(appId, network);
 
-    return presentBalanceFetcherResponse(products.flat());
+    const products = _(balancesByGroupLabel)
+      .mapValues((assets, label) => {
+        // Ignore groups with no assets/balances
+        if (!assets.length) return;
+
+        const meta = presenter && presenter.metadataItemsForBalanceGroup(label, assets, dataProps);
+
+        return {
+          label,
+          assets,
+          ...(meta && { meta }),
+        };
+      })
+      .values()
+      .compact()
+      .value();
+
+    return presentBalanceFetcherResponse(products);
   }
 }

--- a/src/balance/balance.service.ts
+++ b/src/balance/balance.service.ts
@@ -60,12 +60,21 @@ export class BalanceService {
 
     const addressBalancePairs = await Promise.all(
       addresses.map(async address => {
-        const balances = await Promise.all(balanceEnabledTemplates.map(template => template.getBalances(address)));
-        const presentedBalances = await this.balancePresentationService.presentTemplates({
+        const balances = await Promise.all(balanceEnabledTemplates.map(template => template.getBalances(address))).then(
+          v => v.flat(),
+        );
+
+        const dataProps = await this.balancePresentationService.balanceDataProps({
           appId,
           network,
           address,
-          balances: balances.flat(),
+        });
+
+        const presentedBalances = await this.balancePresentationService.presentTemplates({
+          appId,
+          network,
+          balances,
+          dataProps,
         });
         return [address, presentedBalances];
       }),
@@ -118,12 +127,10 @@ export class BalanceService {
           ),
         ]);
 
-        const preprocessed = [...tokenBalances.flat(), ...contractPositionBalances.flat()];
+        const balances = [...tokenBalances.flat(), ...contractPositionBalances.flat()];
         const presentedBalances = await this.balancePresentationService.present({
           appId,
-          network,
-          address,
-          balances: preprocessed,
+          balances,
         });
         return [address, presentedBalances];
       }),

--- a/src/position/position-presenter.registry.ts
+++ b/src/position/position-presenter.registry.ts
@@ -1,64 +1,25 @@
 import { Inject, Injectable, OnModuleInit } from '@nestjs/common';
-import { DiscoveryService, MetadataScanner, Reflector } from '@nestjs/core';
+import { DiscoveryService } from '@nestjs/core';
 
-import { BALANCE_PRODUCT_META_SELECTOR } from '~app-toolkit/decorators/balance-product-meta.decorator';
 import { Network } from '~types/network.interface';
 import { buildTemplateRegistry } from '~utils/build-template-registry';
 
-import { GroupMeta, PositionPresenterTemplate, ReadonlyBalances } from './template/position-presenter.template';
+import { PositionPresenterTemplate } from './template/position-presenter.template';
 
 @Injectable()
 export class PositionPresenterRegistry implements OnModuleInit {
-  private registry = new Map<Network, Map<string, PositionPresenterTemplate>>();
-  private balanceProductMetaResolverRegistry = new Map<
-    Network,
-    Map<string, Map<string, (address: string, balances: ReadonlyBalances) => Promise<GroupMeta>>>
-  >();
+  private registry: Map<string, PositionPresenterTemplate> = new Map();
 
-  constructor(
-    @Inject(DiscoveryService) private readonly discoveryService: DiscoveryService,
-    @Inject(MetadataScanner) private readonly metadataScanner: MetadataScanner,
-    @Inject(Reflector) private readonly reflector: Reflector,
-  ) {}
+  constructor(@Inject(DiscoveryService) private readonly discoveryService: DiscoveryService) {}
 
   onModuleInit() {
     this.registry = buildTemplateRegistry(this.discoveryService, {
       template: PositionPresenterTemplate,
-      keySelector: t => [t.network, t.appId] as const,
+      keySelector: t => [`${t.network}:${t.appId}`] as const,
     });
-
-    // Look for balance product metas on each position presenter
-    this.registry.forEach(r => {
-      r.forEach(presenter => {
-        this.metadataScanner.scanFromPrototype(presenter, Object.getPrototypeOf(presenter), (methodName: string) => {
-          this.registerBalanceProductMeta(presenter, methodName);
-        });
-      });
-    });
-  }
-
-  private registerBalanceProductMeta(instance: PositionPresenterTemplate, methodName: string) {
-    const { network, appId } = instance;
-    const methodRef = instance[methodName];
-    const groupSelector = this.reflector.get(BALANCE_PRODUCT_META_SELECTOR, methodRef);
-    if (!groupSelector) return;
-
-    if (!this.balanceProductMetaResolverRegistry.get(network))
-      this.balanceProductMetaResolverRegistry.set(network, new Map());
-    if (!this.balanceProductMetaResolverRegistry.get(network)?.get(appId))
-      this.balanceProductMetaResolverRegistry.get(network)?.set(appId, new Map());
-
-    this.balanceProductMetaResolverRegistry
-      .get(network)
-      ?.get(appId)
-      ?.set(groupSelector, (...args) => methodRef.apply(instance, args));
   }
 
   get(appId: string, network: Network) {
-    return this.registry.get(network)?.get(appId) ?? null;
-  }
-
-  getBalanceProductMetaResolvers(appId: string, network: Network) {
-    return this.balanceProductMetaResolverRegistry.get(network)?.get(appId) ?? null;
+    return this.registry.get(`${network}:${appId}`);
   }
 }

--- a/src/position/template/position-presenter.template.ts
+++ b/src/position/template/position-presenter.template.ts
@@ -1,18 +1,28 @@
 import { PresentationConfig } from '~app/app.interface';
 import { MetadataItemWithLabel } from '~balance/balance-fetcher.interface';
+import { DefaultDataProps } from '~position/display.interface';
 import { ContractPositionBalance, TokenBalance } from '~position/position-balance.interface';
 import { Network } from '~types';
 
-export interface PositionPresenter {
-  explorePresentationConfig?: PresentationConfig;
-}
-
-export abstract class PositionPresenterTemplate implements PositionPresenter {
+export abstract class PositionPresenterTemplate<T extends DefaultDataProps = DefaultDataProps> {
   network: Network;
   appId: string;
 
   positionGroups?: PositionGroup[];
   explorePresentationConfig?: PresentationConfig;
+
+  async dataProps(_address: string): Promise<T | undefined> {
+    return undefined;
+  }
+
+  // Note: This is not async on purpose. If anything needs to be async, it needs to be moved into dataProps.
+  metadataItemsForBalanceGroup(
+    _groupLabel: string,
+    _balances: ReadonlyBalances,
+    _dataProps?: T,
+  ): MetadataItemWithLabel[] {
+    return [];
+  }
 }
 
 export type PositionGroup = { label: string; groupIds: string[] };


### PR DESCRIPTION
## Description

I'm adding 2 new methods on presenters:

```
dataProps(address: string): Promise<T | undefined>
metadataItemsForBalanceGroup(groupLabel: string, balances: ReadonlyBalances, dataProps?: T): MetadataItemWithLabel[]
```

This will allow us to calculate the dataProps along with the balances, and massage the data after the fact. This will remove the remaining RPC calls that were being made when loading the balances for a given address.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
