### PR TITLE
feat(keeper): use official keep3r graph

### DIFF
--- a/src/apps/keeper/common/keeper.job.queries.ts
+++ b/src/apps/keeper/common/keeper.job.queries.ts
@@ -1,6 +1,6 @@
 import { gql } from 'graphql-request';
 
-export const SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/0xged/keep3r-v2-canary';
+export const SUBGRAPH_URL = 'https://api.thegraph.com/subgraphs/name/keep3r-network/keep3r-network';
 
 export type KeeperJob = {
   jobs: {


### PR DESCRIPTION
## Description

Just changes the keep3r subgraph url to the official one

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: fiboape.eth
- [X] (optional) As a contributor, my Twitter handle is: @fiboape

## How to test?
http://localhost:5001/apps/keeper/positions?groupIds[]=job&network=ethereum