### PR TITLE
fix(gmx): Refactor perpetuals definitions reflecting available position

### DIFF
--- a/src/apps/gmx/common/gmx.perp.contract-position-fetcher.ts
+++ b/src/apps/gmx/common/gmx.perp.contract-position-fetcher.ts
@@ -57,16 +57,19 @@ export abstract class GmxPerpContractPositionFetcher extends ContractPositionTem
       tokensRange.map(async tokenIndex => multicall.wrap(vaultContract).allWhitelistedTokens(tokenIndex)),
     );
 
-    const definitions = whitelistedTokens.flatMap(v =>
-      whitelistedTokens.flatMap(t => {
-        if (v === t) return null;
-        const long = { address: this.vaultAddress, indexTokenAddress: v, collateralTokenAddress: t, isLong: true };
-        const short = { address: this.vaultAddress, indexTokenAddress: v, collateralTokenAddress: t, isLong: false };
-        return [long, short];
+    const definitions = await Promise.all(
+      whitelistedTokens.flatMap(async v => {
+        const isShortable = await multicall.wrap(vaultContract).shortableTokens(v.toLowerCase());
+        if (!isShortable) return null;
+        return whitelistedTokens.flatMap(t => {
+          const long = { address: this.vaultAddress, indexTokenAddress: v, collateralTokenAddress: t, isLong: true };
+          const short = { address: this.vaultAddress, indexTokenAddress: v, collateralTokenAddress: t, isLong: false };
+          return [long, short];
+        });
       }),
     );
 
-    return compact(definitions);
+    return compact(definitions.flat());
   }
 
   async getTokenDefinitions({ definition }: GetTokenDefinitionsParams<GmxVault, GmxOptionContractPositionDefinition>) {


### PR DESCRIPTION
## Description

Fix missing balances on GMX

**Why?**
`if (v === t) return null;`
On Gmx, you can long ETH and use ETH as collateral
 
Refactor definitions removing positions that doesnt' exist (e.g collateral: ETH, long: USDT)
Arbitrum went from 144 => 72 (9 tokens can be used as collateral * 4 tokens you can long/short * 2 available position (short + long) 
Same applies for Avalanche, 84 => 56

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
