### PR TITLE
fix(llama-airforce): Add new uCRV pounder

### DIFF
--- a/src/apps/llama-airforce/ethereum/llama-airforce.vault.token-fetcher.ts
+++ b/src/apps/llama-airforce/ethereum/llama-airforce.vault.token-fetcher.ts
@@ -31,6 +31,7 @@ export class EthereumLlamaAirforceVaultTokenFetcher extends AppTokenTemplatePosi
   getAddresses() {
     return [
       '0x83507cc8c8b67ed48badd1f59f684d5d02884c81', // uCRV
+      '0x4ebad8dbd4edbd74db0278714fbd67ebc76b89b7', // uCRV V2
       '0xf964b0e3ffdea659c44a5a52bc0b82a24b89ce0e', // uFXS
       '0x8659fc767cad6005de79af65dafe4249c57927af', // uCVX
       '0xd6fc1ecd9965ba9cac895654979564a291c74c29', // uauraBAL


### PR DESCRIPTION
## Description

1. Adds a new uCRV pounder. People are advised to migrate from the old one to the new one.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: [0xaef6ea60f6443bad046e825c1d2b0c0b5ebc1f16](https://gnosis-safe.io/app/eth:0xaef6ea60f6443bad046e825c1d2b0c0b5ebc1f16)
- [x] (optional) As a contributor, my Twitter handle is: @0xAlunara

## How to test?

I've build the app, went to http://localhost:5001/apps/llama-airforce/balances?addresses[]=0x71df067D1d2dF5291278b7C660Fd37d9b6272b4C&network=ethereum and saw that the JSON contained the correct balance for the new uCRV pounder: 9.896040787579413.