### PR TITLE
fix(uniswap-v2): Fix pool subgraph strategy APY

### DIFF
--- a/src/apps/uniswap-v2/common/uniswap-v2.pool.subgraph.template.token-fetcher.ts
+++ b/src/apps/uniswap-v2/common/uniswap-v2.pool.subgraph.template.token-fetcher.ts
@@ -94,7 +94,7 @@ export abstract class UniswapV2PoolSubgraphTemplateTokenFetcher<
     const volume = this.volumeDataLoader ? await this.volumeDataLoader.load(appToken.address) : 0;
     const yearlyFees = volume * (this.fee / 100) * 365;
     const apy = yearlyFees / liquidity;
-    return apy;
+    return apy * 100;
   }
 
   async getDataProps(params: GetDataPropsParams<T, UniswapV2TokenDataProps>) {


### PR DESCRIPTION
## Description

- Fix pool subgraph strategy APY (Uniswap-v2, sushiswap, etc APYs are off by 100)

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
