### PR TITLE
fix(beefy): 🐛 map `sGLP` to `GLP`

### DIFF
--- a/src/apps/beefy/common/beefy.vault.token-definition-resolver.ts
+++ b/src/apps/beefy/common/beefy.vault.token-definition-resolver.ts
@@ -54,9 +54,20 @@ export class BeefyVaultTokenDefinitionsResolver {
     const definitionsData = definitionsDataRaw.filter(x => x.tokenAddress);
 
     const vaultDefinitions = definitionsData.map(t => {
+      const tokenAddress = t.tokenAddress.toLowerCase();
       return {
         address: t.earnContractAddress.toLowerCase(),
-        underlyingAddress: t.tokenAddress.toLowerCase(),
+        underlyingAddress:
+          (
+            {
+              arbitrum: {
+                '0x5402b5f40310bded796c7d0f3ff6683f5c0cffdf': '0x4277f8f2c384827b5273592ff7cebd9f2c1ac258', // sGLP
+              },
+              avax: {
+                '0xae64d55a6f09e4263421737397d1fdfa71896a69': '0x01234181085565ed162a948b6a5e88758cd7c7b8', // sGLP
+              },
+            } as Record<string, Record<string, string>>
+          )[t.network]?.[tokenAddress] ?? tokenAddress,
         id: t.id,
         marketName: t.name,
         symbol: t.token,


### PR DESCRIPTION
## Description

beefy api returns `sGLP` as the underlying, because it's what should be used for transfers. for this reason, the `GLP` vaults are not being displayed on zapper.
more context here: https://github.com/beefyfinance/beefy-api/issues/1002

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: `cruzdanilo.eth`
- [x] (optional) As a contributor, my Twitter handle is: `cruzdanilo`

## How to test?

`0xdc9a909f3d09b0cd59d4a0206790dc881cb0b5ed`
