### PR TITLE
feat(beefy): Fix price per share and decimals

### DIFF
--- a/src/apps/beefy/common/beefy.vault.token-fetcher.ts
+++ b/src/apps/beefy/common/beefy.vault.token-fetcher.ts
@@ -8,6 +8,7 @@ import {
   GetAddressesParams,
   GetDisplayPropsParams,
   GetPricePerShareParams,
+  GetTokenPropsParams,
   GetUnderlyingTokensParams,
 } from '~position/template/app-token.template.types';
 
@@ -41,6 +42,10 @@ export abstract class BeefyVaultTokenFetcher extends AppTokenTemplatePositionFet
     return this.contractFactory.beefyVaultToken({ network: this.network, address });
   }
 
+  async getDecimals({ appToken }: GetTokenPropsParams<BeefyVaultToken>): Promise<number> {
+    return appToken.tokens[0].decimals;
+  }
+
   async getDefinitions(): Promise<BeefyVaultTokenDefinition[]> {
     return this.tokenDefinitionsResolver.getVaultDefinitions(this.network);
   }
@@ -55,9 +60,9 @@ export abstract class BeefyVaultTokenFetcher extends AppTokenTemplatePositionFet
     return [{ address: definition.underlyingAddress, network: this.network }];
   }
 
-  async getPricePerShare({ contract, appToken, multicall }: GetPricePerShareParams<BeefyVaultToken>) {
+  async getPricePerShare({ contract, multicall }: GetPricePerShareParams<BeefyVaultToken>) {
     const ratioRaw = await multicall.wrap(contract).getPricePerFullShare();
-    const ratio = Number(ratioRaw) / 10 ** appToken.decimals;
+    const ratio = Number(ratioRaw) / 10 ** 18;
     return [ratio];
   }
 


### PR DESCRIPTION
## Description

Beefy was not working for vaulted token with less than 18 decimals. Adjust the logic since `balanceOf` and `supply` are always rendered in the precision of the underlying token, and `getPricePerFullShare` is always rendered in 18 decimals.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
