### PR TITLE
feat(amp): Add getTokenBalancesPerPosition, update label & update group label.

### DIFF
--- a/src/apps/amp/ethereum/amp.farm.contract-position-fetcher.ts
+++ b/src/apps/amp/ethereum/amp.farm.contract-position-fetcher.ts
@@ -61,7 +61,7 @@ export class EthereumAmpFarmContractPositionFetcher extends ContractPositionTemp
   @Cache({
     instance: 'business',
     key: (address: string) => `apps-v3:balance:ethereum:amp:api-data:${address}`,
-    ttl: 5 * 60, // 5 minutes
+    ttl: 15 * 60, // 15 minutes
   })
   async getAddressBalances(address: string) {
     const axiosInstance = axios.create({
@@ -87,7 +87,7 @@ export class EthereumAmpFarmContractPositionFetcher extends ContractPositionTemp
   @Cache({
     instance: 'business',
     key: () => `apps-v3:balance:ethereum:amp:api-data`,
-    ttl: 5 * 60, // 5 minutes
+    ttl: 15 * 60, // 15 minutes
   })
   async getPoolApys() {
     const capacityResponse = axios.create({

--- a/src/apps/amp/ethereum/amp.farm.contract-position-fetcher.ts
+++ b/src/apps/amp/ethereum/amp.farm.contract-position-fetcher.ts
@@ -33,11 +33,6 @@ export class EthereumAmpFarmContractPositionFetcher extends ContractPositionTemp
     super(appToolkit);
   }
 
-  @Cache({
-    instance: 'business',
-    key: (address: string) => `apps-v3:balance:ethereum:amp:api-data:${address}`,
-    ttl: 5 * 60, // 5 minutes
-  })
   async getDefinitions(): Promise<DefaultContractPositionDefinition[]> {
     return [{ address: '0x706d7f8b3445d8dfc790c524e3990ef014e7c578' }];
   }
@@ -50,9 +45,9 @@ export class EthereumAmpFarmContractPositionFetcher extends ContractPositionTemp
         network: this.network,
       },
       //add second position to represent earned rewards that are not claimable and auto compounded
-      //we do not want claimable label on front end
+      //we do not want claimable label on front end, using LOCKED for now
       {
-        metaType: MetaType.SUPPLIED,
+        metaType: MetaType.LOCKED,
         address: '0xff20817765cb7f73d4bde2e66e067e58d11095c2',
         network: this.network,
         symbol: 'AMP Rewards',
@@ -63,7 +58,11 @@ export class EthereumAmpFarmContractPositionFetcher extends ContractPositionTemp
   getContract(address: string): AmpStaking {
     return this.contractFactory.ampStaking({ address, network: this.network });
   }
-
+  @Cache({
+    instance: 'business',
+    key: (address: string) => `apps-v3:balance:ethereum:amp:api-data:${address}`,
+    ttl: 5 * 60, // 5 minutes
+  })
   async getAddressBalances(address: string) {
     const axiosInstance = axios.create({
       baseURL: 'https://api.capacity.production.flexa.network',
@@ -85,7 +84,11 @@ export class EthereumAmpFarmContractPositionFetcher extends ContractPositionTemp
     const { supplyTotal, rewardTotal } = await this.getAddressBalances(address);
     return rewardTotal > supplyTotal ? [] : [supplyTotal, rewardTotal];
   }
-
+  @Cache({
+    instance: 'business',
+    key: () => `apps-v3:balance:ethereum:amp:api-data`,
+    ttl: 5 * 60, // 5 minutes
+  })
   async getPoolApys() {
     const capacityResponse = axios.create({
       baseURL: 'https://api.capacity.production.flexa.network',


### PR DESCRIPTION
## Description

We updated the contract-position-fetcher from single-staking.template.contract-position-fetcher to contract-position.template.position-fetcher, which enables us to use getTokenBalancesPerPosition. This change allows for multiple positions to be represented as rows on the front end. The previous implementation had a misleading "claimable" green tag on the front end, as rewards are auto-compounding, not claimable. With getTokenBalancesPerPosition, we now return both the supplied total and reward total with metaType supplied. Additionally, we updated the label to display the range of pool APYs and the group label.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: bubby.eth
- [x] (optional) As a contributor, my Twitter handle is: @bubbY_io

## How to test?

/apps/amp/balances?addresses[]=0x376F49Cf37632913E0F09f51D16bBcAc0f12263C&network=ethereum
