### PR TITLE
fix(gearbox): Exclude phantom app tokens from balances

### DIFF
--- a/src/apps/gearbox/ethereum/gearbox.phantom.token-fetcher.ts
+++ b/src/apps/gearbox/ethereum/gearbox.phantom.token-fetcher.ts
@@ -11,6 +11,7 @@ import { GearboxContractFactory, PhantomToken } from '../contracts';
 export class EthereumGearboxPhantomTokenFetcher extends AppTokenTemplatePositionFetcher<PhantomToken> {
   groupLabel = 'Phantom Tokens';
   isExcludedFromExplore = true;
+  isExcludedFromBalances = true;
   isExcludedFromTvl = true;
 
   constructor(


### PR DESCRIPTION
## Description

- Exclude phantom tokens from balances
Phantom tokens are a wrapper on top of a mint token you get back when you stake into convex

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
