### PR TITLE
feat(velodrome): Fix raw balances

### DIFF
--- a/src/apps/velodrome/common/velodrome.voting-rewards.contract-position-fetcher.ts
+++ b/src/apps/velodrome/common/velodrome.voting-rewards.contract-position-fetcher.ts
@@ -1,20 +1,21 @@
 import { Inject, NotImplementedException } from '@nestjs/common';
+import { BigNumber, Contract } from 'ethers/lib/ethers';
 import _, { range, sumBy } from 'lodash';
-import { Contract } from 'ethers/lib/ethers';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { drillBalance } from '~app-toolkit/helpers/drill-balance.helper';
 import { DefaultDataProps } from '~position/display.interface';
-import { ContractPositionBalance } from '~position/position-balance.interface';
+import { ContractPositionBalance, RawContractPositionBalance } from '~position/position-balance.interface';
 import { MetaType } from '~position/position.interface';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import { GetTokenDefinitionsParams } from '~position/template/contract-position.template.types';
 
 import { VelodromeDefinitionsResolver } from '../common/velodrome.definitions-resolver';
-import { VelodromeContractFactory } from '../contracts';
+import { VelodromeBribe, VelodromeContractFactory } from '../contracts';
 
-
-export abstract class VotingRewardsContractPositionFetcher<T extends Contract> extends ContractPositionTemplatePositionFetcher<T> {
+export abstract class VotingRewardsContractPositionFetcher<
+  T extends Contract,
+> extends ContractPositionTemplatePositionFetcher<T> {
   veTokenAddress = '0x9c7305eb78a432ced5c4d14cac27e8ed569a2e26';
 
   constructor(
@@ -48,20 +49,13 @@ export abstract class VotingRewardsContractPositionFetcher<T extends Contract> e
 
   async getBalances(address: string): Promise<ContractPositionBalance<DefaultDataProps>[]> {
     const multicall = this.appToolkit.getMulticall(this.network);
-    const escrow = multicall.wrap(
-      this.contractFactory.velodromeVe({ address: this.veTokenAddress, network: this.network }),
-    );
-    const veCount = Number(await escrow.balanceOf(address));
-    if (veCount === 0) {
-      return [];
-    }
 
-    const veTokenIds = await Promise.all(
-      range(veCount).map(async i => {
-        const tokenId = await escrow.tokenOfOwnerByIndex(address, i);
-        return tokenId;
-      }),
-    );
+    // Get ve token IDs
+    const escrow = this.contractFactory.velodromeVe({ address: this.veTokenAddress, network: this.network });
+    const mcEscrow = multicall.wrap(escrow);
+    const veCount = Number(await mcEscrow.balanceOf(address));
+    const veTokenIds = await Promise.all(range(veCount).map(async i => mcEscrow.tokenOfOwnerByIndex(address, i)));
+    if (veTokenIds.length === 0) return [];
 
     const contractPositions = await this.appToolkit.getAppContractPositions({
       appId: this.appId,
@@ -71,38 +65,62 @@ export abstract class VotingRewardsContractPositionFetcher<T extends Contract> e
 
     const balances = await Promise.all(
       contractPositions.map(async contractPosition => {
-        const bribeTokens = contractPosition.tokens;
-        const bribeContract = multicall.wrap(this.getContract(contractPosition.address));
+        const bribeContract = multicall.wrap(this.getContract(contractPosition.address) as unknown as VelodromeBribe);
 
-        const tokenBalancesRaw = await Promise.all(
-          bribeTokens.map(async bribeToken => {
-            const tokenBalancePerBribe = await Promise.all(
-              veTokenIds.map(async veTokenId => {
-                const balance = await multicall.wrap(bribeContract).earned(bribeToken.address, veTokenId);
-                return Number(balance);
-              }),
-            );
-            return tokenBalancePerBribe;
+        const tokens = await Promise.all(
+          contractPosition.tokens.map(async bribeToken => {
+            const balancesPerBribePromises = veTokenIds.map(async id => bribeContract.earned(bribeToken.address, id));
+            const balancesPerBribe = await Promise.all(balancesPerBribePromises);
+            const balancesPerBribeSum = balancesPerBribe.reduce((acc, v) => acc.add(v), BigNumber.from(0));
+            return drillBalance(bribeToken, balancesPerBribeSum.toString());
           }),
         );
 
-        const allTokensRaw = contractPosition.tokens.map((cp, idx) => {
-          return veTokenIds.map((_id, index) => {
-            return drillBalance(cp, tokenBalancesRaw[idx][index]?.toString() ?? '0');
-          });
-        });
-
-        const allTokens = allTokensRaw.flat();
-
-        const tokens = allTokens.filter(v => Math.abs(v.balanceUSD) > 0.01);
         const balanceUSD = sumBy(tokens, t => t.balanceUSD);
-
         const balance: ContractPositionBalance = { ...contractPosition, tokens, balanceUSD };
+        return balance;
+      }),
+    );
+
+    return balances;
+  }
+
+  async getRawBalances(address: string): Promise<RawContractPositionBalance[]> {
+    const multicall = this.appToolkit.getMulticall(this.network);
+
+    // Get ve token IDs
+    const escrow = this.contractFactory.velodromeVe({ address: this.veTokenAddress, network: this.network });
+    const mcEscrow = multicall.wrap(escrow);
+    const veCount = Number(await mcEscrow.balanceOf(address));
+    const veTokenIds = await Promise.all(range(veCount).map(async i => mcEscrow.tokenOfOwnerByIndex(address, i)));
+    if (veTokenIds.length === 0) return [];
+
+    const contractPositions = await this.appToolkit.getAppContractPositions({
+      appId: this.appId,
+      network: this.network,
+      groupIds: [this.groupId],
+    });
+
+    const balances = await Promise.all(
+      contractPositions.map(async contractPosition => {
+        const bribeContract = multicall.wrap(this.getContract(contractPosition.address) as unknown as VelodromeBribe);
+
+        const balance: RawContractPositionBalance = {
+          key: this.appToolkit.getPositionKey(contractPosition),
+          tokens: await Promise.all(
+            contractPosition.tokens.map(async bribeToken => {
+              const balancesPerBribePromises = veTokenIds.map(async id => bribeContract.earned(bribeToken.address, id));
+              const balancesPerBribe = await Promise.all(balancesPerBribePromises);
+              const balancesPerBribeSum = balancesPerBribe.reduce((acc, v) => acc.add(v), BigNumber.from(0));
+              return { key: this.appToolkit.getPositionKey(bribeToken), balance: balancesPerBribeSum.toString() };
+            }),
+          ),
+        };
 
         return balance;
       }),
     );
 
-    return _.compact(balances);
+    return balances;
   }
 }

--- a/src/apps/velodrome/optimism/velodrome.bribe.contract-position-fetcher.ts
+++ b/src/apps/velodrome/optimism/velodrome.bribe.contract-position-fetcher.ts
@@ -4,8 +4,9 @@ import { PositionTemplate } from '~app-toolkit/decorators/position-template.deco
 import { DefaultDataProps } from '~position/display.interface';
 import { MetaType } from '~position/position.interface';
 import { GetDisplayPropsParams, GetTokenDefinitionsParams } from '~position/template/contract-position.template.types';
-import { VelodromeBribe } from '../contracts';
+
 import { VotingRewardsContractPositionFetcher } from '../common/velodrome.voting-rewards.contract-position-fetcher';
+import { VelodromeBribe } from '../contracts';
 
 export type VelodromeBribeDefinition = {
   address: string;
@@ -46,5 +47,4 @@ export class OptimismVelodromeBribeContractPositionFetcher extends VotingRewards
   }: GetDisplayPropsParams<VelodromeBribe, DefaultDataProps, VelodromeBribeDefinition>): Promise<string> {
     return `${definition.name} Bribe`;
   }
-
 }

--- a/src/apps/velodrome/optimism/velodrome.fees.contract-position-fetcher.ts
+++ b/src/apps/velodrome/optimism/velodrome.fees.contract-position-fetcher.ts
@@ -2,8 +2,9 @@ import { PositionTemplate } from '~app-toolkit/decorators/position-template.deco
 import { DefaultDataProps } from '~position/display.interface';
 import { MetaType } from '~position/position.interface';
 import { GetDisplayPropsParams, GetTokenDefinitionsParams } from '~position/template/contract-position.template.types';
-import { VelodromeFees } from '../contracts';
+
 import { VotingRewardsContractPositionFetcher } from '../common/velodrome.voting-rewards.contract-position-fetcher';
+import { VelodromeFees } from '../contracts';
 
 export type VelodromeFeesDefinition = {
   address: string;
@@ -23,9 +24,12 @@ export class OptimismVelodromeFeesContractPositionFetcher extends VotingRewardsC
     return this.definitionsResolver.getFeesDefinitions();
   }
 
-  async getTokenDefinitions({ definition, multicall }: GetTokenDefinitionsParams<VelodromeFees, VelodromeFeesDefinition>) {
+  async getTokenDefinitions({
+    definition,
+    multicall,
+  }: GetTokenDefinitionsParams<VelodromeFees, VelodromeFeesDefinition>) {
     const poolContract = multicall.wrap(
-      this.contractFactory.velodromePool({ address: definition.poolAddress, network: this.network })
+      this.contractFactory.velodromePool({ address: definition.poolAddress, network: this.network }),
     );
 
     return [
@@ -39,5 +43,4 @@ export class OptimismVelodromeFeesContractPositionFetcher extends VotingRewardsC
   }: GetDisplayPropsParams<VelodromeFees, DefaultDataProps, VelodromeFeesDefinition>): Promise<string> {
     return `${definition.name} Fees`;
   }
-
 }


### PR DESCRIPTION
## Description

Since `getTokenBalancesPerPosition` is overridden to throw, we need to implement _both_ `getBalances` and `getRawBalances`. Our goal is to eventually remove `getBalances` entirely in favour of `getRawBalances`, but for now, both functions need to be present in our integrations (and usually, the default implementations in the template are good enough).

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
