### PR TITLE
fix(concentrator): Calculate claimable using vesting state

### DIFF
--- a/src/apps/concentrator/ethereum/concentrator.vesting.contract-position-fetcher.ts
+++ b/src/apps/concentrator/ethereum/concentrator.vesting.contract-position-fetcher.ts
@@ -1,5 +1,5 @@
 import { Inject } from '@nestjs/common';
-import { BigNumberish } from 'ethers';
+import { BigNumber, BigNumberish } from 'ethers';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
@@ -55,6 +55,7 @@ export class EthereumConcentratorVestingContractPositionFetcher extends Contract
     address,
     contract,
   }: GetTokenBalancesParams<AladdinConcentratorVest, DefaultDataProps>): Promise<BigNumberish[]> {
-    return Promise.all([contract.locked(address), contract.vested(address)]);
+    const claimable = (await contract.getUserVest(address)).reduce((claimable: BigNumber, current) => claimable.add(current[0].sub(current[1])), BigNumber.from(0));
+    return Promise.all([contract.locked(address), claimable]);
   }
 }


### PR DESCRIPTION
## Description
The purpose of this PR is to calculate the claimable from vesting from Concentrator correctly. As mentioned in #2285

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: 0xcfb3b99e0a7ad8008a5bd5d3255e338f493f8c15
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

The address 0xcfb3b99e0a7ad8008a5bd5d3255e338f493f8c15 has no vesting claimable anymore. Before this PR Zapper says that there stil is, after this PR not.


