### PR TITLE
feat(gains-network): add arbitrum support

### DIFF
--- a/src/apps/gains-network/arbitrum/gains-network.g-token.token-fetcher.ts
+++ b/src/apps/gains-network/arbitrum/gains-network.g-token.token-fetcher.ts
@@ -1,0 +1,41 @@
+import { Inject } from '@nestjs/common';
+import { ethers } from 'ethers';
+
+import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
+import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
+import { AppTokenTemplatePositionFetcher } from '~position/template/app-token.template.position-fetcher';
+import { GetPricePerShareParams, GetUnderlyingTokensParams } from '~position/template/app-token.template.types';
+
+import { GainsNetworkContractFactory, GainsNetworkGToken } from '../contracts';
+
+@PositionTemplate()
+export class ArbitrumGainsNetworkGTokenTokenFetcher extends AppTokenTemplatePositionFetcher<GainsNetworkGToken> {
+  groupLabel = 'gTokens';
+
+  constructor(
+    @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
+    @Inject(GainsNetworkContractFactory) protected readonly contractFactory: GainsNetworkContractFactory,
+  ) {
+    super(appToolkit);
+  }
+
+  getContract(address: string): GainsNetworkGToken {
+    return this.contractFactory.gainsNetworkGToken({ network: this.network, address });
+  }
+
+  async getAddresses() {
+    return ['0xd85e038593d7a098614721eae955ec2022b9b91b'];
+  }
+
+  async getUnderlyingTokenDefinitions({ contract }: GetUnderlyingTokensParams<GainsNetworkGToken>) {
+    return [{ address: await contract.asset(), network: this.network }];
+  }
+
+  async getPricePerShare({ contract, appToken }: GetPricePerShareParams<GainsNetworkGToken>) {
+    const oneUnit = ethers.BigNumber.from(10).pow(18);
+    const pricePerShareWar = await contract.convertToShares(oneUnit);
+    const pricePerShare = Number(pricePerShareWar) / 10 ** appToken.decimals;
+
+    return [pricePerShare];
+  }
+}

--- a/src/apps/gains-network/arbitrum/gains-network.staking.contract-position-fetcher.ts
+++ b/src/apps/gains-network/arbitrum/gains-network.staking.contract-position-fetcher.ts
@@ -1,0 +1,63 @@
+import { Inject } from '@nestjs/common';
+
+import { APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
+import { AppToolkit } from '~app-toolkit/app-toolkit.service';
+import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
+import { GetDataPropsParams, GetTokenBalancesParams } from '~position/template/contract-position.template.types';
+import {
+  SingleStakingFarmDataProps,
+  SingleStakingFarmDefinition,
+  SingleStakingFarmTemplateContractPositionFetcher,
+} from '~position/template/single-staking.template.contract-position-fetcher';
+
+import { GainsNetworkContractFactory, GainsNetworkStaking } from '../contracts';
+
+const FARMS = [
+  {
+    address: '0x6b8d3c08072a020ac065c467ce922e3a36d3f9d6',
+    stakedTokenAddress: '0x18c11fd286c5ec11c3b683caa813b77f5163a122',
+    rewardTokenAddresses: ['0xda10009cbd5d07dd0cecc66161fc93d7c9000da1'],
+  },
+];
+
+@PositionTemplate()
+export class ArbitrumGainsNetworkStakingContractPositionFetcher extends SingleStakingFarmTemplateContractPositionFetcher<GainsNetworkStaking> {
+  groupLabel = 'Staking';
+
+  constructor(
+    @Inject(APP_TOOLKIT) protected readonly appToolkit: AppToolkit,
+    @Inject(GainsNetworkContractFactory) protected readonly contractFactory: GainsNetworkContractFactory,
+  ) {
+    super(appToolkit);
+  }
+
+  getContract(address: string): GainsNetworkStaking {
+    return this.contractFactory.gainsNetworkStaking({ address, network: this.network });
+  }
+
+  async getFarmDefinitions(): Promise<SingleStakingFarmDefinition[]> {
+    return FARMS;
+  }
+
+  getRewardRates({ contract }: GetDataPropsParams<GainsNetworkStaking, SingleStakingFarmDataProps>) {
+    return contract.accDaiPerToken();
+  }
+
+  async getStakedTokenBalance({
+    address,
+    contract,
+  }: GetTokenBalancesParams<GainsNetworkStaking, SingleStakingFarmDataProps>) {
+    return (await contract.users(address)).stakedTokens;
+  }
+
+  async getRewardTokenBalances({
+    address,
+    contract,
+  }: GetTokenBalancesParams<GainsNetworkStaking, SingleStakingFarmDataProps>) {
+    const [userPosition, rate] = await Promise.all([contract.users(address), contract.accDaiPerToken()]);
+    const rewardBalance =
+      ((Number(userPosition.stakedTokens) + Number(userPosition.totalBoostTokens)) * Number(rate)) / 1e18 -
+      Number(userPosition.debtDai);
+    return rewardBalance;
+  }
+}

--- a/src/apps/gains-network/gains-network.module.ts
+++ b/src/apps/gains-network/gains-network.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 
 import { AbstractApp } from '~app/app.dynamic-module';
 
+import { ArbitrumGainsNetworkGTokenTokenFetcher } from './arbitrum/gains-network.g-token.token-fetcher';
+import { ArbitrumGainsNetworkStakingContractPositionFetcher } from './arbitrum/gains-network.staking.contract-position-fetcher';
 import { GainsNetworkContractFactory } from './contracts';
 import { PolygonGainsNetworkGTokenTokenFetcher } from './polygon/gains-network.g-token.token-fetcher';
 import { PolygonGainsNetworkLockedContractPositionFetcher } from './polygon/gains-network.locked.contract-position-fetcher';
@@ -13,6 +15,8 @@ import { PolygonGainsNetworkStakingContractPositionFetcher } from './polygon/gai
     PolygonGainsNetworkStakingContractPositionFetcher,
     PolygonGainsNetworkGTokenTokenFetcher,
     PolygonGainsNetworkLockedContractPositionFetcher,
+    ArbitrumGainsNetworkGTokenTokenFetcher,
+    ArbitrumGainsNetworkStakingContractPositionFetcher,
   ],
 })
 export class GainsNetworkAppModule extends AbstractApp() {}


### PR DESCRIPTION
## Description

Adds Arbitrum support for Gains Network staking and gDAI vault.

Implementation matches 1:1 with the Polygon one

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: clonescody.eth
- [X] (optional) As a contributor, my Twitter handle is: [Clonescody](https://twitter.com/Clonescody)

## How to test?

AppId `gains-network`

GNS staking : http://localhost:5001/apps/gains-network/balances?addresses[]=0xadae0cdb5b7fdbcdb6094b80af96869abf8ad394&network=arbitrum

gDAI vault : http://localhost:5001/apps/gains-network/balances?addresses[]=0xddd0898ccb492e78c714ea1baeb593100746510e&network=arbitrum
