### PR TITLE
fix(abracadabra): Wrap bentobox calls in multicall to mitigate reverts

### DIFF
--- a/src/apps/abracadabra/common/abracadabra.cauldron.contract-position-fetcher.ts
+++ b/src/apps/abracadabra/common/abracadabra.cauldron.contract-position-fetcher.ts
@@ -99,6 +99,7 @@ export abstract class AbracadabraCauldronContractPositionFetcher extends Contrac
     address,
     contractPosition,
     contract,
+    multicall,
   }: GetTokenBalancesParams<AbracadabraCauldron>) {
     const [borrowPartRaw, totalBorrowRaw, collateralShareRaw, bentoBoxAddressRaw] = await Promise.all([
       contract.userBorrowPart(address),
@@ -107,10 +108,12 @@ export abstract class AbracadabraCauldronContractPositionFetcher extends Contrac
       contract.bentoBox(),
     ]);
 
-    const bentoBoxTokenContract = this.contractFactory.abracadabraBentoBoxTokenContract({
-      address: bentoBoxAddressRaw,
-      network: this.network,
-    });
+    const bentoBoxTokenContract = multicall.wrap(
+      this.contractFactory.abracadabraBentoBoxTokenContract({
+        address: bentoBoxAddressRaw,
+        network: this.network,
+      }),
+    );
 
     const suppliedToken = contractPosition.tokens.find(isSupplied)!;
     const suppliedBalanceRaw = await bentoBoxTokenContract.toAmount(suppliedToken.address, collateralShareRaw, false);


### PR DESCRIPTION
## Description

Was getting reverts on my local setup, and found that the bentobox call wasn't wrapped in a multicall. Doing that seems to have helped.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

http://localhost:5001/apps/abracadabra/balances?network=ethereum&addresses%5B%5D=0xDF2C270f610Dc35d8fFDA5B453E74db5471E126B

Prior to the changes I get:
```json
{
  "statusCode": 500,
  "message": "Internal server error"
}
```
After:
```json
{
  "0xdf2c270f610dc35d8ffda5b453e74db5471e126b": {
    "products": [],
    "meta": [
      {
        "label": "Total",
        "value": 0,
        "type": "dollar"
      },
      {
        "label": "Assets",
        "value": 0,
        "type": "dollar"
      },
      {
        "label": "Debt",
        "value": 0,
        "type": "dollar"
      }
    ]
  }
}
```
