### PR TITLE
fix(gains-network): fix pricePerShare call

### DIFF
--- a/src/apps/gains-network/arbitrum/gains-network.g-token.token-fetcher.ts
+++ b/src/apps/gains-network/arbitrum/gains-network.g-token.token-fetcher.ts
@@ -1,5 +1,4 @@
 import { Inject } from '@nestjs/common';
-import { ethers } from 'ethers';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
@@ -32,9 +31,8 @@ export class ArbitrumGainsNetworkGTokenTokenFetcher extends AppTokenTemplatePosi
   }
 
   async getPricePerShare({ contract, appToken }: GetPricePerShareParams<GainsNetworkGToken>) {
-    const oneUnit = ethers.BigNumber.from(10).pow(18);
-    const pricePerShareWar = await contract.convertToShares(oneUnit);
-    const pricePerShare = Number(pricePerShareWar) / 10 ** appToken.decimals;
+    const pricePerShareRaw = await contract.shareToAssetsPrice();
+    const pricePerShare = Number(pricePerShareRaw) / 10 ** appToken.decimals;
 
     return [pricePerShare];
   }

--- a/src/apps/gains-network/polygon/gains-network.g-token.token-fetcher.ts
+++ b/src/apps/gains-network/polygon/gains-network.g-token.token-fetcher.ts
@@ -1,5 +1,4 @@
 import { Inject } from '@nestjs/common';
-import { ethers } from 'ethers';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
@@ -32,9 +31,8 @@ export class PolygonGainsNetworkGTokenTokenFetcher extends AppTokenTemplatePosit
   }
 
   async getPricePerShare({ contract, appToken }: GetPricePerShareParams<GainsNetworkGToken>) {
-    const oneUnit = ethers.BigNumber.from(10).pow(18);
-    const pricePerShareWar = await contract.convertToShares(oneUnit);
-    const pricePerShare = Number(pricePerShareWar) / 10 ** appToken.decimals;
+    const pricePerShareRaw = await contract.shareToAssetsPrice();
+    const pricePerShare = Number(pricePerShareRaw) / 10 ** appToken.decimals;
 
     return [pricePerShare];
   }


### PR DESCRIPTION
## Description

The pricePerShare was wrongly reported for Gains Vaults ( gDAI ).
Fixed for Arbitrum and Polygon using the `shareToAssetsPrice` function.

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: clonescody.eth
- [X] (optional) As a contributor, my Twitter handle is: [Clonescody](https://twitter.com/Clonescody)

## How to test?

AppId `gains-network`

Arbitrum : http://localhost:5001/apps/gains-network/balances?addresses%5B%5D=0xddd0898ccb492e78c714ea1baeb593100746510e&network=arbitrum

Polygon : http://localhost:5001/apps/gains-network/balances?addresses%5B%5D=0xdec01942f6c39554ebd652b15fe6c5a08551105a&network=polygon