### PR TITLE
fix(abracadabra): Fix division by zero error when cauldrons have no borrows

### DIFF
--- a/src/apps/abracadabra/common/abracadabra.cauldron.contract-position-fetcher.ts
+++ b/src/apps/abracadabra/common/abracadabra.cauldron.contract-position-fetcher.ts
@@ -117,7 +117,10 @@ export abstract class AbracadabraCauldronContractPositionFetcher extends Contrac
 
     const suppliedToken = contractPosition.tokens.find(isSupplied)!;
     const suppliedBalanceRaw = await bentoBoxTokenContract.toAmount(suppliedToken.address, collateralShareRaw, false);
-    const borrowedBalanceRaw = borrowPartRaw.mul(totalBorrowRaw.elastic).div(totalBorrowRaw.base);
+    let borrowedBalanceRaw = totalBorrowRaw.base;
+    if (!borrowedBalanceRaw.eq(0)) {
+      borrowedBalanceRaw = borrowPartRaw.mul(totalBorrowRaw.elastic).div(totalBorrowRaw.base);
+    }
 
     return [suppliedBalanceRaw, borrowedBalanceRaw];
   }


### PR DESCRIPTION
## Description

Fix division by zero error when cauldrons have no borrows.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: 0xmDreamy
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

Currently there's no borrows in the Stargate USDT POF cauldron. So no address should throw an exception. Here's e.g. the Abracadabra Treasury address.
http://localhost:5001/apps/abracadabra/balances?network=ethereum&addresses%5B%5D=0xdf2c270f610dc35d8ffda5b453e74db5471e126b
