### PR TITLE
fix(gmx): Add size and leverage to perp's dataProps

### DIFF
--- a/src/apps/gmx/common/gmx.perp.contract-position-fetcher.ts
+++ b/src/apps/gmx/common/gmx.perp.contract-position-fetcher.ts
@@ -1,8 +1,12 @@
 import { Inject, Injectable } from '@nestjs/common';
-import _, { compact } from 'lodash';
+import { BigNumberish } from 'ethers';
+import _, { compact, sumBy } from 'lodash';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
+import { ZERO_ADDRESS } from '~app-toolkit/constants/address';
+import { drillBalance } from '~app-toolkit/helpers/drill-balance.helper';
 import { getImagesFromToken, getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
+import { ContractPositionBalance } from '~position/position-balance.interface';
 import { MetaType } from '~position/position.interface';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
 import {
@@ -10,7 +14,6 @@ import {
   GetTokenDefinitionsParams,
   GetDisplayPropsParams,
   GetDataPropsParams,
-  GetTokenBalancesParams,
   DefaultContractPositionDefinition,
 } from '~position/template/contract-position.template.types';
 
@@ -105,32 +108,73 @@ export abstract class GmxPerpContractPositionFetcher extends ContractPositionTem
     return [indexToken, collateralToken].flatMap(v => getImagesFromToken(v));
   }
 
-  async getTokenBalancesPerPosition({
-    address,
-    contractPosition,
-    contract,
-  }: GetTokenBalancesParams<GmxVault, GmxOptionContractPositionDataProps>) {
-    const [collateralToken, indexToken, usdcToken] = contractPosition.tokens;
-    const isLong = contractPosition.dataProps.isLong;
+  async getTokenBalancesPerPosition(): Promise<BigNumberish[]> {
+    throw new Error('Method not implemented.');
+  }
 
-    const position = await contract.getPosition(address, collateralToken.address, indexToken.address, isLong);
-    // non existing position returns size and collateral = 0
-    if (Number(position[0]) == 0 && Number(position[1]) == 0) return [0, 0, 0];
+  async getBalances(address: string): Promise<ContractPositionBalance<GmxOptionContractPositionDataProps>[]> {
+    const multicall = this.appToolkit.getMulticall(this.network);
+    const contractPositions = await this.getPositionsForBalances();
+    if (address === ZERO_ADDRESS) return [];
 
-    // const leverage = await contract.getPositionLeverage(address, collateralToken.address, indexToken.address, isLong);
-    const delta = await contract.getPositionDelta(address, collateralToken.address, indexToken.address, isLong);
+    const balances = await Promise.all(
+      contractPositions.map(async contractPosition => {
+        const contract = multicall.wrap(this.getContract(contractPosition.address));
 
-    const initialCollateralRaw = position[1];
-    const initialCollateral = Number(initialCollateralRaw) / 10 ** 30;
-    const deltaBalanceRaw = delta[1];
-    const deltaBalance = Number(deltaBalanceRaw) / 10 ** 30;
+        const [collateralToken, indexToken, usdcToken] = contractPosition.tokens;
+        const isLong = contractPosition.dataProps.isLong;
 
-    const hasProfit = delta[0];
-    const balanceUSD = hasProfit == true ? initialCollateral + deltaBalance : initialCollateral - deltaBalance;
+        const position = await contract.getPosition(address, collateralToken.address, indexToken.address, isLong);
+        // non existing position returns size and collateral = 0
+        if (Number(position[0]) == 0 && Number(position[1]) == 0) return null;
 
-    const profitToken = isLong ? indexToken : usdcToken;
-    const balanceInProfitToken = balanceUSD / profitToken.price;
-    const balanceInProfitTokenRaw = balanceInProfitToken * 10 ** profitToken.decimals;
-    return isLong ? [0, balanceInProfitTokenRaw, 0] : [0, 0, balanceInProfitTokenRaw];
+        const [leverageRaw, basisPointDivisor] = await Promise.all([
+          contract.getPositionLeverage(address, collateralToken.address, indexToken.address, isLong),
+          contract.BASIS_POINTS_DIVISOR(),
+        ]);
+        const leverage = (Number(leverageRaw) / Number(basisPointDivisor)).toFixed(2);
+        const size = Number(position[0]) / 10 ** 30;
+
+        const delta = await contract.getPositionDelta(address, collateralToken.address, indexToken.address, isLong);
+
+        const initialCollateralRaw = position[1];
+        const initialCollateral = Number(initialCollateralRaw) / 10 ** 30;
+        const deltaBalanceRaw = delta[1];
+        const deltaBalance = Number(deltaBalanceRaw) / 10 ** 30;
+
+        const hasProfit = delta[0];
+        const balanceUsdPosition =
+          hasProfit == true ? initialCollateral + deltaBalance : initialCollateral - deltaBalance;
+
+        const profitToken = isLong ? indexToken : usdcToken;
+        const balanceInProfitToken = balanceUsdPosition / profitToken.price;
+        const balanceInProfitTokenRaw = balanceInProfitToken * 10 ** profitToken.decimals;
+        const balancesRaw = isLong ? [0, balanceInProfitTokenRaw, 0] : [0, 0, balanceInProfitTokenRaw];
+
+        const dataProps = {
+          ...contractPosition.dataProps,
+          size,
+          leverage: Number(leverage),
+        };
+
+        contractPosition.dataProps = dataProps;
+
+        const allTokens = contractPosition.tokens.map((cp, idx) =>
+          drillBalance(cp, balancesRaw[idx]?.toString() ?? '0', { isDebt: cp.metaType === MetaType.BORROWED }),
+        );
+
+        const tokens = allTokens.filter(v => Math.abs(v.balanceUSD) > 0.01);
+        const balanceUSD = sumBy(tokens, t => t.balanceUSD);
+
+        const balance: ContractPositionBalance<GmxOptionContractPositionDataProps> = {
+          ...contractPosition,
+          tokens,
+          balanceUSD,
+        };
+        return balance;
+      }),
+    );
+
+    return _.compact(balances);
   }
 }


### PR DESCRIPTION
## Description

- Add leverage and size to GMX Perps's dataProps

Haven't added liquidation prices yet because it's way more tricky. The borrow fee % varies based on the amount of liquidity available in the pool

<img width="205" alt="Screenshot 2023-03-13 at 12 13 14 AM" src="https://user-images.githubusercontent.com/18474228/224606663-0bdb0247-4f9f-4b12-bdd9-3527f3d822a1.png">


## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
