### PR TITLE
fix(vela): Update VLP APY endpoint

### DIFF
--- a/src/apps/vela/common/vela.vlp.token-fetcher.ts
+++ b/src/apps/vela/common/vela.vlp.token-fetcher.ts
@@ -52,23 +52,16 @@ export abstract class VelaVlpTokenFetcher extends AppTokenTemplatePositionFetche
   }
 
   async getApy(): Promise<number> {
-    const {
-      data: { VLP_APR },
-    } = await axios.request<VelaGetVlpAprResponse>({
-      method: 'post',
-      url: 'https://app.vela.exchange/api/public',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      data: JSON.stringify({
-        route: 'market',
-        action: 'GET_VLP_APR',
-        payload: {
-          chainId: NETWORK_IDS[this.network],
-        },
-      }),
-    });
-    return VLP_APR;
+    try {
+      const {
+        data: { VLP_APR },
+      } = await axios.get<VelaGetVlpAprResponse>(
+        `https://vela-public-server-prod-qxq2l.ondigitalocean.app/market/vlp-apr/${NETWORK_IDS[this.network]}`,
+      );
+      return VLP_APR;
+    } catch {
+      return 0;
+    }
   }
 
   async getPricePerShare({


### PR DESCRIPTION
## Description

Updated the VLP APY endpoint. Also added a try catch s.t. it does not break the token fetcher if the APR endpoint is unavailable.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: 0xmDreamy.eth
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

Address with a non-zero amount of VLP staked:
http://localhost:5001/apps/vela/balances?network=arbitrum&addresses%5B%5D=0x33774483bd9e61a5568a22fa90d32195e5ae0824