### PR TITLE
fix(llama-airforce): Add new uCRV pounder and distributor

### DIFF
--- a/src/apps/llama-airforce/ethereum/llama-airforce.airdrop.contract-position-fetcher.ts
+++ b/src/apps/llama-airforce/ethereum/llama-airforce.airdrop.contract-position-fetcher.ts
@@ -43,8 +43,8 @@ export class EthereumLlamaAirforceAirdropContractPositionFetcher extends Contrac
   async getDefinitions(): Promise<LlamaAirforceAirdropDefinition[]> {
     return [
       {
-        address: '0x0ed7d0497194fc029ae02223fec6d4d567696f17',
-        rewardTokenAddress: '0x4ebad8dbd4edbd74db0278714fbd67ebc76b89b7', // uCRV
+        address: '0x2c5e808fca6d8299ce194e12ed728f0fdbbf06c8',
+        rewardTokenAddress: '0xde2bef0a01845257b4aef2a2eaa48f6eaeafa8b7', // uCRV
       },
       {
         address: '0x5682a28919389b528ae74dd627e0d632ca7e398c',

--- a/src/apps/llama-airforce/ethereum/llama-airforce.merkle-cache.ts
+++ b/src/apps/llama-airforce/ethereum/llama-airforce.merkle-cache.ts
@@ -35,7 +35,7 @@ export class EthereumLlamaAirforceMerkleCache extends MerkleCache<LlamaAirforceM
       ),
     ]);
 
-    const uCrvTokenAddress = '0x4ebad8dbd4edbd74db0278714fbd67ebc76b89b7';
+    const uCrvTokenAddress = '0xde2bef0a01845257b4aef2a2eaa48f6eaeafa8b7';
     const uFxsTokenAddress = '0x3a886455e5b33300a31c5e77bac01e76c0c7b29c';
     const uCvxTokenAddress = '0x8659fc767cad6005de79af65dafe4249c57927af';
 

--- a/src/apps/llama-airforce/ethereum/llama-airforce.vault.token-fetcher.ts
+++ b/src/apps/llama-airforce/ethereum/llama-airforce.vault.token-fetcher.ts
@@ -31,6 +31,7 @@ export class EthereumLlamaAirforceVaultTokenFetcher extends AppTokenTemplatePosi
     return [
       '0x83507cc8c8b67ed48badd1f59f684d5d02884c81', // uCRV
       '0x4ebad8dbd4edbd74db0278714fbd67ebc76b89b7', // uCRV V2
+      '0xde2bef0a01845257b4aef2a2eaa48f6eaeafa8b7', // uCRV V3
       '0xf964b0e3ffdea659c44a5a52bc0b82a24b89ce0e', // uFXS
       '0x3a886455e5b33300a31c5e77bac01e76c0c7b29c', // uFXS V2
       '0x8659fc767cad6005de79af65dafe4249c57927af', // uCVX


### PR DESCRIPTION
## Description

1. Adds a new uCRV pounder and distributor. People are advised to migrate from the old one to the new one.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: [0xaef6ea60f6443bad046e825c1d2b0c0b5ebc1f16](https://gnosis-safe.io/app/eth:0xaef6ea60f6443bad046e825c1d2b0c0b5ebc1f16)
- [x] (optional) As a contributor, my Twitter handle is: @0xAlunara

## How to test?

I've built the app, went to [http://localhost:5001/apps/llama-airforce/balances?addresses[]=[redacted]&network=ethereum](http://localhost:5001/apps/llama-airforce/balances?addresses%5B%5D=[redacted]&network=ethereum) and saw that the JSON contained the correct balance and underlying cvxCRV balance for the new uCRV pounder and merkle airdrop for my personal account.