### PR TITLE
feat(studio): Use address in getPositionsForBalances to filter down where necessary

### DIFF
--- a/src/position/template/contract-position.template.position-fetcher.ts
+++ b/src/position/template/contract-position.template.position-fetcher.ts
@@ -203,7 +203,7 @@ export abstract class ContractPositionTemplatePositionFetcher<
     return address;
   }
 
-  async getPositionsForBalances() {
+  async getPositionsForBalances(_address: string) {
     return this.appToolkit.getAppContractPositions<V>({
       appId: this.appId,
       network: this.network,
@@ -221,7 +221,7 @@ export abstract class ContractPositionTemplatePositionFetcher<
   async getBalances(_address: string): Promise<ContractPositionBalance<V>[]> {
     const multicall = this.appToolkit.getMulticall(this.network);
     const address = await this.getAccountAddress(_address);
-    const contractPositions = await this.getPositionsForBalances();
+    const contractPositions = await this.getPositionsForBalances(address);
     if (address === ZERO_ADDRESS) return [];
 
     const balances = await Promise.all(


### PR DESCRIPTION
## Description

By passing the address into `getPositionsForBalances`, we can filter the positions down according to any other strategy like relying on a subgraph.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
