### PR TITLE
fix(lyra-avalon): Fix option decimals on Arbitrum

### DIFF
--- a/src/apps/lyra-avalon/arbitrum/lyra-avalon.options.contract-position-fetcher.ts
+++ b/src/apps/lyra-avalon/arbitrum/lyra-avalon.options.contract-position-fetcher.ts
@@ -237,9 +237,9 @@ export class ArbitrumLyraAvalonOptionsContractPositionFetcher extends ContractPo
     if (!userPosition) return [];
 
     // Find amount of position
-    const quoteToken = contractPosition.tokens[0];
-    const price = OPTION_TYPES[optionType].includes('Call') ? callPrice : putPrice;
-    const amountRaw = ((Number(price) * Number(userPosition.amount)) / 10 ** quoteToken.decimals).toString();
+    const priceRaw = OPTION_TYPES[optionType].includes('Call') ? callPrice : putPrice;
+    const price = priceRaw / 10 ** 18;
+    const amountRaw = ((Number(price) * Number(userPosition.amount)) / 10 ** 12).toString();
 
     if (optionType === 0 || optionType === 1) return [amountRaw];
     return [amountRaw, userPosition.collateral];


### PR DESCRIPTION
## Description

- Fix decimals for options on Arbitrum

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

`0xed5f239fc64c084afdd3fa2000e6e577638f4bd0`
