### PR TITLE
feat(uniswap-v3): Show min/max ranges and fix sig figs on range

### DIFF
--- a/src/apps/uniswap-v3/common/uniswap-v3.liquidity.contract-position-builder.ts
+++ b/src/apps/uniswap-v3/common/uniswap-v3.liquidity.contract-position-builder.ts
@@ -1,5 +1,6 @@
 import { Inject } from '@nestjs/common';
-import BigNumber from 'bignumber.js';
+import { TickMath } from '@uniswap/v3-sdk';
+import { BigNumber } from 'bignumber.js';
 import { BigNumberish } from 'ethers';
 import { sumBy } from 'lodash';
 
@@ -74,9 +75,10 @@ export class UniswapV3LiquidityContractPositionBuilder {
     const token0Contract = this.contractFactory.erc20(token0);
     const token1Contract = this.contractFactory.erc20(token1);
 
-    const [slot, liquidity, feeGrowth0, feeGrowth1, ticksLower, ticksUpper, reserveRaw0, reserveRaw1] =
+    const [slot, tickSpacing, liquidity, feeGrowth0, feeGrowth1, ticksLower, ticksUpper, reserveRaw0, reserveRaw1] =
       await Promise.all([
         multicall.wrap(poolContract).slot0(),
+        multicall.wrap(poolContract).tickSpacing(),
         multicall.wrap(poolContract).liquidity(),
         multicall.wrap(poolContract).feeGrowthGlobal0X128(),
         multicall.wrap(poolContract).feeGrowthGlobal1X128(),
@@ -89,6 +91,8 @@ export class UniswapV3LiquidityContractPositionBuilder {
     // Retrieve underlying reserves, both supplied and claimable
     const range = getRange({ position, slot, token0, token1, network, liquidity });
     const suppliedBalances = getSupplied({ position, slot, token0, token1, network, liquidity });
+    const isMin = Math.floor(-position.tickLower / tickSpacing) === Math.floor(-TickMath.MIN_TICK / tickSpacing);
+    const isMax = Math.floor(position.tickUpper / tickSpacing) === Math.floor(TickMath.MAX_TICK / tickSpacing);
 
     const suppliedTokens = [token0, token1].map(v => supplied(v));
     const suppliedTokenBalances = suppliedTokens.map((t, i) => drillBalance(t, suppliedBalances[i]));
@@ -123,7 +127,7 @@ export class UniswapV3LiquidityContractPositionBuilder {
     };
 
     const displayProps = {
-      label: `${token0.symbol} / ${token1.symbol} (${range[0]} to ${range[1]})`,
+      label: `${token0.symbol} / ${token1.symbol} (${isMin ? 'MIN' : range[0]} - ${isMax ? 'MAX' : range[1]})`,
       images: [...getImagesFromToken(token0), ...getImagesFromToken(token1)],
       statsItems: [{ label: 'Liquidity', value: buildDollarDisplayItem(Number(liquidity)) }],
     };

--- a/src/apps/uniswap-v3/common/uniswap-v3.liquidity.utils.ts
+++ b/src/apps/uniswap-v3/common/uniswap-v3.liquidity.utils.ts
@@ -143,7 +143,7 @@ export const getRange = ({
   const pool = new Pool(t0Wrapper, t1Wrapper, feeBips, sqrtPriceX96.toString(), liquidity.toString(), tickCurrent);
   const positionZ = new Position({ pool, liquidity: position.liquidity.toString(), tickLower, tickUpper });
 
-  const positionLowerBound = Number(positionZ.token0PriceLower.toFixed(4));
-  const positionUpperBound = Number(positionZ.token0PriceUpper.toFixed(4));
+  const positionLowerBound = Number(positionZ.token0PriceLower.toSignificant(4));
+  const positionUpperBound = Number(positionZ.token0PriceUpper.toSignificant(4));
   return [positionLowerBound, positionUpperBound];
 };


### PR DESCRIPTION
## Description

This is ugly
<img width="632" alt="image" src="https://user-images.githubusercontent.com/22452366/230422493-262fa01d-1d5c-41fa-984f-a7bc18429966.png">

This is better
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/22452366/230422518-45ce49c9-c3d0-423a-ad2d-49ec0b6125eb.png">

Also, provide 4 significant digits for the range.

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
