### PR TITLE
fix(studio): Revamping KyberSwap classic pools+farms

### DIFF
--- a/src/apps/kyberswap-classic/kyberswap-classic.module.ts
+++ b/src/apps/kyberswap-classic/kyberswap-classic.module.ts
@@ -13,9 +13,10 @@ import { EthereumKyberSwapClassicFarmContractPositionFetcher } from './ethereum/
 import { EthereumKyberSwapClassicPoolTokenFetcher } from './ethereum/kyberswap-classic.pool.token-fetcher';
 import { FantomKyberSwapClassicPoolTokenFetcher } from './fantom/kyberswap-classic.pool.token-fetcher';
 import { OptimismKyberSwapClassicPoolTokenFetcher } from './optimism/kyberswap-classic.pool.token-fetcher';
+import { PolygonKyberSwapDmmClassicPoolTokenFetcher } from './polygon/kyberswap-classic.dmm-pool.token-fetcher';
 import { PolygonKyberSwapClassicFarmContractPositionFetcher } from './polygon/kyberswap-classic.farm.contract-position-fetcher';
+import { PolygonKyberSwapKsClassicPoolTokenFetcher } from './polygon/kyberswap-classic.ks-pool.token-fetcher';
 import { PolygonKyberSwapClassicLegacyFarmContractPositionFetcher } from './polygon/kyberswap-classic.legacy-farm.contract-position-fetcher';
-import { PolygonKyberSwapClassicPoolTokenFetcher } from './polygon/kyberswap-classic.pool.token-fetcher';
 
 @Module({
   providers: [
@@ -23,7 +24,8 @@ import { PolygonKyberSwapClassicPoolTokenFetcher } from './polygon/kyberswap-cla
     UniswapV2ContractFactory,
     EthereumKyberSwapClassicPoolTokenFetcher,
     EthereumKyberSwapClassicFarmContractPositionFetcher,
-    PolygonKyberSwapClassicPoolTokenFetcher,
+    PolygonKyberSwapDmmClassicPoolTokenFetcher,
+    PolygonKyberSwapKsClassicPoolTokenFetcher,
     PolygonKyberSwapClassicFarmContractPositionFetcher,
     PolygonKyberSwapClassicLegacyFarmContractPositionFetcher,
     AvalancheKyberSwapClassicPoolTokenFetcher,

--- a/src/apps/kyberswap-classic/polygon/kyberswap-classic.dmm-pool.token-fetcher.ts
+++ b/src/apps/kyberswap-classic/polygon/kyberswap-classic.dmm-pool.token-fetcher.ts
@@ -1,0 +1,9 @@
+import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
+
+import { KyberSwapClassicPoolTokenFetcher } from '../common/kyberswap-classic.pool.token-fetcher';
+
+@PositionTemplate()
+export class PolygonKyberSwapDmmClassicPoolTokenFetcher extends KyberSwapClassicPoolTokenFetcher {
+  groupLabel = 'Pools';
+  factoryAddress = '0x5f1fe642060b5b9658c15721ea22e982643c095c';
+}

--- a/src/apps/kyberswap-classic/polygon/kyberswap-classic.ks-pool.token-fetcher.ts
+++ b/src/apps/kyberswap-classic/polygon/kyberswap-classic.ks-pool.token-fetcher.ts
@@ -3,7 +3,7 @@ import { PositionTemplate } from '~app-toolkit/decorators/position-template.deco
 import { KyberSwapClassicPoolTokenFetcher } from '../common/kyberswap-classic.pool.token-fetcher';
 
 @PositionTemplate()
-export class PolygonKyberSwapClassicPoolTokenFetcher extends KyberSwapClassicPoolTokenFetcher {
+export class PolygonKyberSwapKsClassicPoolTokenFetcher extends KyberSwapClassicPoolTokenFetcher {
   groupLabel = 'Pools';
-  factoryAddress = '0x5f1fe642060b5b9658c15721ea22e982643c095c';
+  factoryAddress = '0x1c758af0688502e49140230f6b0ebd376d429be5';
 }


### PR DESCRIPTION
## Description

KyberSwap classic is only listing pools with dynamic fees (DMM) and farms that have launched for the first 2 FairLaunch. This PR is adding KS static fee pools (KS) as well as a way to fetch all farms for all fairlaunches dynamically.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
