### PR TITLE
fix(vela): Make PPS and APY zero for beta VLP

### DIFF
--- a/src/apps/vela/arbitrum/vela.beta-vlp.token-fetcher.ts
+++ b/src/apps/vela/arbitrum/vela.beta-vlp.token-fetcher.ts
@@ -7,4 +7,12 @@ export class ArbitrumVelaVlpTokenFetcher extends VelaVlpTokenFetcher {
   vlpAddress = '0x4e0d4a5a5b4faf5c2ecc1c63c8d19bb0804a96f1';
   usdcAddress = '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8';
   velaVaultAddress = '0x5957582f020301a2f732ad17a69ab2d8b2741241';
+
+  async getApy(): Promise<number> {
+    return 0;
+  }
+
+  async getPricePerShare(): Promise<number[]> {
+    return [0];
+  }
 }

--- a/src/apps/vela/vela.module.ts
+++ b/src/apps/vela/vela.module.ts
@@ -2,9 +2,9 @@ import { Module } from '@nestjs/common';
 
 import { AbstractApp } from '~app/app.dynamic-module';
 
+import { ArbitrumVelaVlpTokenFetcher } from './arbitrum/vela.beta-vlp.token-fetcher';
 import { ArbitrumVelaEsVelaTokenFetcher } from './arbitrum/vela.es-vela.token-fetcher';
 import { ArbitrumVelaVlpFarmContractPositionFetcher } from './arbitrum/vela.token-farm.contract-position-fetcher';
-import { ArbitrumVelaVlpTokenFetcher } from './arbitrum/vela.vlp.token-fetcher';
 import { VelaContractFactory } from './contracts';
 
 @Module({


### PR DESCRIPTION
## Description

Make PPS and APY zero for the beta VLP to avoid displaying a wrong amount of USDC. It was considered to remove the beta VLP completely, however, then unclaimed esVELA in the VLP would not be displayed. So a compromise was to just make it's PPS and APY zero.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: 0xmDreamy.eth
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

Address with VLP staked:
http://localhost:5001/apps/vela/balances?network=arbitrum&addresses[]=0x128e50f8a4f1d9a53a7a0201243fcb72e6161bce
