### PR TITLE
feat(synthetix): display perp position side

### DIFF
--- a/src/apps/kwenta/optimism/kwenta.perp-v1-cross-margin.contract-position-fetcher.ts
+++ b/src/apps/kwenta/optimism/kwenta.perp-v1-cross-margin.contract-position-fetcher.ts
@@ -22,7 +22,7 @@ const getCrossMarginAccountsQuery = gql`
 @PositionTemplate()
 export class OptimismKwentaPerpV1CrossMarginContractPositionFetcher extends OptimismSynthetixPerpV1ContractPositionFetcher {
   groupLabel = 'PerpV1 cross-margin';
-  extraLabel = ' (v1 cross-margin)'
+  extraLabel = '(v1 cross-margin)'
 
   async getAccountAddress(address: string): Promise<string> {
     const crossMarginAccountsFromSubgraph = await gqlFetch<GetCrossMarginAccounts>({

--- a/src/apps/kwenta/optimism/kwenta.perp-v2-smart-margin.contract-position-fetcher.ts
+++ b/src/apps/kwenta/optimism/kwenta.perp-v2-smart-margin.contract-position-fetcher.ts
@@ -9,7 +9,7 @@ import { KwentaContractFactory } from '../contracts';
 @PositionTemplate()
 export class OptimismKwentaPerpV2SmartMarginContractPositionFetcher extends OptimismSynthetixPerpV2ContractPositionFetcher {
   groupLabel = 'PerpV2 smart-margin';
-  extraLabel = ' (v2 smart-margin)'
+  extraLabel = '(v2 smart-margin)'
   kwentaAccountResolverAddress = '0x8234f990b149ae59416dc260305e565e5dafeb54';
 
   constructor(

--- a/src/apps/synthetix/optimism/synthetix.perp-v1.contract-position-fetcher.ts
+++ b/src/apps/synthetix/optimism/synthetix.perp-v1.contract-position-fetcher.ts
@@ -4,7 +4,7 @@ import { OptimismSynthetixPerpContractPositionFetcher } from './synthetix.perp.c
 @PositionTemplate()
 export class OptimismSynthetixPerpV1ContractPositionFetcher extends OptimismSynthetixPerpContractPositionFetcher {
   groupLabel = 'PerpV1';
-  extraLabel = ' (v1)'
+  extraLabel = '(v1)'
 
   marketFilter(market) {
     return !this.isV2Market(market);

--- a/src/apps/synthetix/optimism/synthetix.perp.contract-position-fetcher.ts
+++ b/src/apps/synthetix/optimism/synthetix.perp.contract-position-fetcher.ts
@@ -7,8 +7,8 @@ import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { getAppAssetImage } from '~app-toolkit/helpers/presentation/image.present';
 import { MetaType } from '~position/position.interface';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
+import { DefaultDataProps } from '~position/display.interface';
 import {
-  DefaultContractPositionDefinition,
   GetDisplayPropsParams,
   GetTokenBalancesParams,
 } from '~position/template/contract-position.template.types';
@@ -31,6 +31,11 @@ export const getContractsQuery = gql`
   }
 `;
 
+export type PerpPositionDefinition = {
+  address: string;
+  side: string;
+};
+
 export abstract class OptimismSynthetixPerpContractPositionFetcher extends ContractPositionTemplatePositionFetcher<SynthetixPerp> {
   extraLabel = '';
   constructor(
@@ -52,15 +57,24 @@ export abstract class OptimismSynthetixPerpContractPositionFetcher extends Contr
     return marketKeyString.includes('PERP');
   }
 
-  async getDefinitions(): Promise<DefaultContractPositionDefinition[]> {
+  async getDefinitions(): Promise<PerpPositionDefinition[]> {
     const contractsFromSubgraph = await gqlFetch<GetContracts>({
       endpoint: 'https://api.thegraph.com/subgraphs/name/kwenta/optimism-perps',
       query: getContractsQuery,
     });
 
-    return contractsFromSubgraph.futuresMarkets
-      .filter(market => this.marketFilter(market))
-      .map(futuresMarket => ({ address: futuresMarket.id }));
+    const markets = contractsFromSubgraph.futuresMarkets
+      .filter(market => this.marketFilter(market));
+
+    const longMarkets = this.getMarketsDefinitions(markets, 'LONG');
+    const shortMarkets = this.getMarketsDefinitions(markets, 'SHORT');
+    const neutralMarkets = this.getMarketsDefinitions(markets, 'NEUTRAL');
+
+    return longMarkets.concat(shortMarkets, neutralMarkets);
+  }
+
+  getMarketsDefinitions(markets, side: string) {
+    return markets.map(futuresMarket => ({ address: futuresMarket.id, side: side }));
   }
 
   async getTokenDefinitions() {
@@ -85,9 +99,13 @@ export abstract class OptimismSynthetixPerpContractPositionFetcher extends Contr
     return baseAsset;
   }
 
-  async getLabel({ contractPosition }: GetDisplayPropsParams<SynthetixPerp>): Promise<string> {
+  async getLabel({ contractPosition, definition }: GetDisplayPropsParams<SynthetixPerp, DefaultDataProps, PerpPositionDefinition>): Promise<string> {
     const baseAsset = await this.getBaseAsset({ contractPosition });
-    return `${baseAsset}-PERP${this.extraLabel}`;
+    return `${baseAsset}-PERP ${definition.side} ${this.extraLabel}`;
+  }
+
+  async getDataProps({ definition }) {
+    return { side: definition.side };
   }
 
   async getImages({ contractPosition }: GetDisplayPropsParams<SynthetixPerp>) {
@@ -95,8 +113,18 @@ export abstract class OptimismSynthetixPerpContractPositionFetcher extends Contr
     return [getAppAssetImage('synthetix', `s${baseAsset}`)];
   }
 
-  async getTokenBalancesPerPosition({ address, contract }: GetTokenBalancesParams<SynthetixPerp>) {
+  async getTokenBalancesPerPosition({ address, contract, contractPosition }: GetTokenBalancesParams<SynthetixPerp>) {
     const remainingMargin = await contract.remainingMargin(address);
-    return [remainingMargin.marginRemaining];
+    const marginRemaining = remainingMargin.marginRemaining;
+    if (Number(marginRemaining) === 0) {
+      return [];
+    }
+    const position = await contract.positions(address);
+    const side = contractPosition.dataProps.side;
+    const isLong = Number(position.size) > 0;
+    const isShort = Number(position.size) < 0;
+    const isNeutral = !isLong && !isShort;
+    const matchesSide = (isLong && side === 'LONG') || (isShort && side === 'SHORT') || (isNeutral && side === 'NEUTRAL');
+    return matchesSide ? [marginRemaining] : [];
   }
 }


### PR DESCRIPTION
## Description

Create 3 contract position per market in order to show perp position side: long, short or neutral (no position open, only margin deposited).
This applies to synthetix perp v1 (including Kwenta cross margin implementation) and v2 (including Polynomial Perp and Kwenta Smart Margin).

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: gaulois.eth
- [X] (optional) As a contributor, my Twitter handle is: @pseudo__alakon

## How to test?

BTC long: 0x1960feccc7f649d66457f81c270540a3b1785872
BTC/ETH/SOL shorts: 0x1960feccc7f649d66457f81c270540a3b1785872
ETH neutral: 0x15217ccc4d81d9ab3254ebb4414b30d24f08c71f (or 0xacbe85b298d2c1b791ece44ec2c17021b011db03 through polynomial app)

Can use https://watcher.synthetix.io/ to find other wallets