### PR TITLE
feat(abracadabra): Add support for the CRV V2 cauldron

### DIFF
--- a/src/apps/abracadabra/ethereum/abracadabra.cauldron.contract-position-fetcher.ts
+++ b/src/apps/abracadabra/ethereum/abracadabra.cauldron.contract-position-fetcher.ts
@@ -42,6 +42,7 @@ export class EthereumAbracadabraCauldronContractPositionFetcher extends Abracada
     '0x1062eb452f8c7a94276437ec1f4aaca9b1495b72', // Stargate USDT (POF)
     '0x692887e8877c6dd31593cda44c382db5b289b684', // magicAPE
     '0xedcf198bc94ddcabb21dbeb38ad9f9793208f12a', // Protocol Owned Debt
+    '0x7d8df3e4d06b0e19960c19ee673c0823beb90815', // CRV V2
   ];
 
   convexCauldrons = [


### PR DESCRIPTION
## Description

Add support for the CRV V2 cauldron.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: 0xmDreamy.eth
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

Unfortunately it is not possible to really test yet as there not positions yet. However, the change is fairly trivial, so should work :eyes: :eyes: .
It is possible to verify that it is a cauldron and that it was deployed by Abracadabra on Etherscan: https://etherscan.io/address/0x7d8dF3E4D06B0e19960c19Ee673c0823BEB90815.
