### PR TITLE
fix(studio): KyberSwap elastic failing on Polygon

### DIFF
--- a/src/apps/kyberswap-elastic/common/kyberswap-elastic.farm.contract-position-fetcher.ts
+++ b/src/apps/kyberswap-elastic/common/kyberswap-elastic.farm.contract-position-fetcher.ts
@@ -1,6 +1,5 @@
 import { Inject, NotImplementedException } from '@nestjs/common';
-import _ from 'lodash';
-import { compact, range } from 'lodash';
+import _, { compact, range } from 'lodash';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
@@ -71,6 +70,16 @@ export abstract class KyberswapElasticFarmContractPositionFetcher extends Custom
       range(0, poolLengthRaw.toNumber()).map(async index => {
         const poolInfos = await multicall.wrap(kyberswapElasticLmContract).getPoolInfo(index);
         const poolContract = this.contractFactory.pool({ address: poolInfos.poolAddress, network: this.network });
+        // filtering out pool '0xf2057f0231bedcecf32436e3cd6b0b93c6675e0a' on Polygon, this
+        // seems to not exist on Polygon and is actually on Arbitrum. KyberSwap is even filtering it out
+        // from some of their own GQL queries.
+        // (see https://github.com/KyberNetwork/kyberswap-interface/blob/23dfea561ea5ad4eb13778518a94209fff1846b7/src/state/farms/elastic/updaters/v1.tsx#L79 for details)
+        if (
+          poolContract.address.toLowerCase() === '0xf2057f0231bedcecf32436e3cd6b0b93c6675e0a' &&
+          this.network === 'polygon'
+        ) {
+          return;
+        }
         const [token0Raw, token1Raw, feeTier] = await Promise.all([
           multicall.wrap(poolContract).token0(),
           multicall.wrap(poolContract).token1(),


### PR DESCRIPTION
## Description

A single pool is mis-configured on Polygon and causes a lot of errors on production. This PR is filtering out the pool and keeps the other operating as normal, and should thus kill the errors.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

- set the `kyberswap-elastic` for `ENABLED_APPS` in your `.env` and `pnpm dev`
- there shouldn't be any error thrown anymore

Previous error:
```
ERROR [CacheOnIntervalService] @CacheOnInterval error init for PolygonKyberswapElasticFarmContractPositionFetcher#getPositions: Multicall call failed for 0xF2057f0231bedCEcf32436E3cD6b0b93C6675E0a:token0(): call revert exception [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ] (method="token0()", data="0x", errorArgs=null, errorName=null, errorSignature=null, reason=null, code=CALL_EXCEPTION, version=abi/5.7.0) (decode)
```