### PR TITLE
feat(studio): Remove string and number from stats items possible types

### DIFF
--- a/src/balance/balance-fetcher.interface.ts
+++ b/src/balance/balance-fetcher.interface.ts
@@ -1,4 +1,4 @@
-import { MetadataItem } from '~position/display.interface';
+import { AnyDisplayItem } from '~position/display.interface';
 import { AppTokenPositionBalance, ContractPositionBalance } from '~position/position-balance.interface';
 
 export type ProductItem = {
@@ -7,7 +7,7 @@ export type ProductItem = {
   meta: MetadataItemWithLabel[];
 };
 
-export type MetadataItemWithLabel = MetadataItem & { label: string };
+export type MetadataItemWithLabel = AnyDisplayItem & { label: string };
 
 export interface TokenBalanceResponse {
   products: ProductItem[];

--- a/src/position/display.interface.ts
+++ b/src/position/display.interface.ts
@@ -26,7 +26,7 @@ export type PercentageDisplayItem = {
   value: number;
 };
 
-export type MetadataItem =
+export type AnyDisplayItem =
   | StringDisplayItem
   | NumberDisplayItem
   | DollarDisplayItem
@@ -35,14 +35,7 @@ export type MetadataItem =
 
 export type StatsItem = {
   label: string | TranslationDisplayItem;
-  value:
-    | string // @TODO Remove
-    | number // @TODO Remove
-    | StringDisplayItem
-    | NumberDisplayItem
-    | TranslationDisplayItem
-    | DollarDisplayItem
-    | PercentageDisplayItem;
+  value: AnyDisplayItem;
 };
 
 export enum BalanceDisplayMode {


### PR DESCRIPTION
## Description

We have `StringDisplayItem` and `NumberDisplayItem`. Remove primitives from possible stats items types.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
