### PR TITLE
fix(synthetix): custom perp market logos

### DIFF
--- a/src/apps/synthetix/optimism/synthetix.perp.contract-position-fetcher.ts
+++ b/src/apps/synthetix/optimism/synthetix.perp.contract-position-fetcher.ts
@@ -42,6 +42,8 @@ export abstract class OptimismSynthetixPerpContractPositionFetcher extends Contr
   DefaultDataProps,
   SynthetixPerpPositionDefinition
 > {
+  useCustomMarketLogos = false;
+
   constructor(
     @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
     @Inject(SynthetixContractFactory) protected readonly contractFactory: SynthetixContractFactory,
@@ -97,7 +99,7 @@ export abstract class OptimismSynthetixPerpContractPositionFetcher extends Contr
   async getImages({
     definition,
   }: GetDisplayPropsParams<SynthetixPerp, DefaultDataProps, SynthetixPerpPositionDefinition>) {
-    return [getAppAssetImage('synthetix', `s${definition.asset}`)];
+    return [getAppAssetImage(this.useCustomMarketLogos ? this.appId : 'synthetix', `s${definition.asset}`)];
   }
 
   async getTokenBalancesPerPosition({ address, contract }: GetTokenBalancesParams<SynthetixPerp>) {


### PR DESCRIPTION
## Description

Let perps built on top of synthetix use different market logos (currently kwenta)

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: gaulois.eth
- [X] (optional) As a contributor, my Twitter handle is: @pseudo__alakon

## How to test?

0xd8e80c06f9f3a41c85cad28117e01ebd50fd535e currently has kwenta perp position opened
