### PR TITLE
fix(sentiment): fix balances and deposit in borrow market

### DIFF
--- a/src/apps/sentiment/common/sentiment.accounts-resolver.ts
+++ b/src/apps/sentiment/common/sentiment.accounts-resolver.ts
@@ -2,9 +2,8 @@ import { Inject, Injectable } from '@nestjs/common';
 import { gql } from 'graphql-request';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
-import { gqlFetch, gqlFetchAll } from '~app-toolkit/helpers/the-graph.helper';
+import { gqlFetchAll } from '~app-toolkit/helpers/the-graph.helper';
 import { Cache } from '~cache/cache.decorator';
-import { Network } from '~types/network.interface';
 
 type GetAccountsResponse = {
   accounts: {
@@ -47,7 +46,7 @@ export class SentimentAccountsResolver {
     return data.accounts;
   }
 
-  async getAccountOfOwner(address: string) {
+  async getAccountsOfOwner(address: string) {
     const accountsData = await this.getAllAccountsData();
 
     const accountOfOwner = accountsData.filter(x => x.owner.id == address).map(x => x.id);

--- a/src/apps/sentiment/sentiment.module.ts
+++ b/src/apps/sentiment/sentiment.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
 
 import { AbstractApp } from '~app/app.dynamic-module';
-import { ArbitrumSentimentBorrowContractPositionFetcher } from './arbitrum/sentiment.borrow.contract-position-fetcher';
 
+import { ArbitrumSentimentBorrowContractPositionFetcher } from './arbitrum/sentiment.borrow.contract-position-fetcher';
 import { ArbitrumSentimentSupplyTokenFetcher } from './arbitrum/sentiment.supply.token-fetcher';
 import { SentimentAccountsResolver } from './common/sentiment.accounts-resolver';
 import { SentimentContractFactory } from './contracts';


### PR DESCRIPTION
## Description

Balances weren't marked as borrowed for the user accounts. 
When a user borrows, assets are held in his account and can be fetched with `asset.balanceOf(account)`, those assets can then be re-invested if the user wishes, but doesn't have to be as it can be swapped. 

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
