### PR TITLE
fix(lido): Wrapped staked ETH should not count towards TIV

### DIFF
--- a/src/apps/lido/ethereum/lido.wsteth.token-fetcher.ts
+++ b/src/apps/lido/ethereum/lido.wsteth.token-fetcher.ts
@@ -11,6 +11,8 @@ import { LidoContractFactory, LidoWsteth } from '../contracts';
 export class EthereumLidoWstethTokenFetcher extends AppTokenTemplatePositionFetcher<LidoWsteth> {
   groupLabel = 'wstETH';
 
+  isExcludedFromTvl = true;
+
   constructor(
     @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
     @Inject(LidoContractFactory) protected readonly contractFactory: LidoContractFactory,


### PR DESCRIPTION
## Description

Wrapped staked ETH shouldn't count towards TIV because it's double counting

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
