### PR TITLE
fix(subgraph): Bump cached data ttl to an hour

### DIFF
--- a/src/apps/arrakis/common/arrakis.pool-definition-resolver.ts
+++ b/src/apps/arrakis/common/arrakis.pool-definition-resolver.ts
@@ -44,7 +44,7 @@ export class ArrakisPoolDefinitionsResolver {
 
   @Cache({
     key: network => `studio:arrakis:${network}:pool-data`,
-    ttl: 5 * 60, // 5 minutes
+    ttl: 60 * 60, // 5 minutes
   })
   private async getPoolDefinitionsData(network: Network) {
     const data = await gqlFetch<ArrakisPoolFetcherResponse>({

--- a/src/apps/aura/common/aura.balancer-pool.resolver.ts
+++ b/src/apps/aura/common/aura.balancer-pool.resolver.ts
@@ -92,7 +92,7 @@ export class AuraBalancerPoolResolver {
 
   @Cache({
     key: (poolId: string) => `studio:aura:balancer-pools-${poolId}`,
-    ttl: 15 * 60,
+    ttl: 60 * 60,
   })
   private async getBalancerPoolData(poolId: string) {
     const endpoint = `https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2`;

--- a/src/apps/ren/common/ren.api.client.ts
+++ b/src/apps/ren/common/ren.api.client.ts
@@ -13,7 +13,7 @@ export class RenApiClient {
   @Cache({
     instance: 'business',
     key: () => `studio:ren:darknode:assets`,
-    ttl: 5 * 60, // 5 minutes
+    ttl: 60 * 60, // 5 minutes
   })
   async getDarknodeAssets() {
     const data = await gqlFetch<GetAssetsResponse>({
@@ -27,7 +27,7 @@ export class RenApiClient {
   @Cache({
     instance: 'user',
     key: (address: string) => `studio:ren:darknode:${address}:darknodes`,
-    ttl: 5 * 60, // 5 minutes
+    ttl: 60 * 60, // 5 minutes
   })
   async getDarknodeBalance(address: string) {
     const data = await gqlFetch<GetDarknodesResponse>({

--- a/src/apps/rubicon/common/rubicon.bath.token-definition-resolver.ts
+++ b/src/apps/rubicon/common/rubicon.bath.token-definition-resolver.ts
@@ -27,7 +27,7 @@ export class RubiconBathTokenDefinitionResolver {
 
   @Cache({
     key: `studio:rubicon:optimism:pool-data`,
-    ttl: 5 * 60, // 5 minutes
+    ttl: 60 * 60, // 5 minutes
   })
   private async getPoolDefinitionsData() {
     const data = await gqlFetch<RubiconPoolFetcherResponse>({

--- a/src/apps/sentiment/common/sentiment.accounts-resolver.ts
+++ b/src/apps/sentiment/common/sentiment.accounts-resolver.ts
@@ -33,7 +33,7 @@ export class SentimentAccountsResolver {
 
   @Cache({
     key: network => `studio:sentiment:${network}:accounts`,
-    ttl: 5 * 60, // 5 minutes
+    ttl: 60 * 60, // 5 minutes
   })
   private async getAllAccountsData() {
     const data = await gqlFetchAll<GetAccountsResponse>({

--- a/src/apps/silo-finance/common/silo-finance.definition-resolver.ts
+++ b/src/apps/silo-finance/common/silo-finance.definition-resolver.ts
@@ -54,7 +54,7 @@ const SUBGRAPH_URL = {
 export class SiloFinanceDefinitionResolver {
   @Cache({
     key: network => `studio:silo-finance:${network}:silo-data`,
-    ttl: moment.duration('15', 'minutes').asSeconds(),
+    ttl: moment.duration('60', 'minutes').asSeconds(),
   })
   private async getSiloDefinitionData(network: Network) {
     return gqlFetch<SiloFinanceMarketsResponse>({ endpoint: SUBGRAPH_URL[network], query: MARKETS_QUERY });

--- a/src/apps/solid-lizard/common/solid-lizard.definitions-resolver.ts
+++ b/src/apps/solid-lizard/common/solid-lizard.definitions-resolver.ts
@@ -92,7 +92,7 @@ const poolsQuery = gql`
 export class SolidLizardDefinitionsResolver {
   @Cache({
     key: `studio:solid-lizard:pool-token-data`,
-    ttl: 5 * 60, // 60 minutes
+    ttl: 60 * 60, // 60 minutes
   })
   private async getPoolDefinitionsData() {
     const response = await gqlFetch<SolidLizardApiPairData>({

--- a/src/apps/sushiswap-bentobox/common/sushiswap-bentobox.vault-tokens-resolver.ts
+++ b/src/apps/sushiswap-bentobox/common/sushiswap-bentobox.vault-tokens-resolver.ts
@@ -38,7 +38,7 @@ export class SushiswapBentoboxVaultTokensResolver {
 
   @Cache({
     key: (_, network) => `studio:sushiswap-bentobox:${network}:vault-data`,
-    ttl: 5 * 60, // 5 minutes
+    ttl: 60 * 60, // 5 minutes
   })
   private async getVaultTokensData(subgraphUrl: string, _network: Network) {
     const data = await gqlFetch<TokensResponse>({

--- a/src/apps/synthetix/common/synthetix.mintr.snx-holders.cache.ts
+++ b/src/apps/synthetix/common/synthetix.mintr.snx-holders.cache.ts
@@ -47,7 +47,7 @@ export class SynthetixMintrSnxHoldersCache {
   @Cache({
     instance: 'business',
     key: (network: Network) => `studio:synthetix:${network}:all-snx-holders`,
-    ttl: moment.duration('15', 'minutes').asSeconds(),
+    ttl: moment.duration('60', 'minutes').asSeconds(),
   })
   async getSynthetixHolders(network: Network) {
     const endpoint = this.graphs[network];

--- a/src/apps/tenderize/common/tenderize.token-definition-resolver.ts
+++ b/src/apps/tenderize/common/tenderize.token-definition-resolver.ts
@@ -54,7 +54,7 @@ export class TenderizeTokenDefinitionsResolver {
 
   @Cache({
     key: network => `studio:tenderize:${network}:token-data`,
-    ttl: 5 * 60, // 5 minutes
+    ttl: 60 * 60, // 5 minutes
   })
   private async getVaultDefinitionsData(network: Network) {
     const data = await gqlFetch<TenderTokenFetcherResponse>({
@@ -83,7 +83,7 @@ export class TenderizeTokenDefinitionsResolver {
 
   @Cache({
     key: `studio:tenderize:token-apy-data`,
-    ttl: 5 * 60, // 5 minutes
+    ttl: 60 * 60, // 5 minutes
   })
   private async getTokenApyData() {
     const { data } = await Axios.get<TokenApyResponse>('https://www.tenderize.me/api/apy');
@@ -101,7 +101,7 @@ export class TenderizeTokenDefinitionsResolver {
 
   @Cache({
     key: (network, tenderFarm) => `studio:tenderize:${network}:${tenderFarm}-reward-data`,
-    ttl: 5 * 60, // 5 minutes
+    ttl: 60 * 60, // 5 minutes
   })
   private async getRewardRateData(network: Network, tenderFarm: string) {
     return gqlFetch<RewardRateFetcherResponse>({


### PR DESCRIPTION
## Description

- Bumped cached data TTL to an hour. This is temporary mesure preventing 'false' errors all over the place. This will be reverted as soon as maintenance is done

_theGraph hosted services subgraph will be under database maintenance on May 22, 2023 at 5am UTC_

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
