### PR TITLE
feat(studio): Attempt to pin version on release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
       changelog: ${{ steps.set_outputs.outputs.changelog }}
 
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v3.7.8
         id: release
         with:
           release-type: node


### PR DESCRIPTION
## Description

Attempt to pin the version on release-please-action.

Seems like suddenly the release please action isn't running, and there has been a release in the last hour. Attempt to pin to the earlier version to see if an improvement is made.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
