### PR TITLE
feat(studio): Remove step to publish to NPM

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
       changelog: ${{ steps.set_outputs.outputs.changelog }}
 
     steps:
-      - uses: google-github-actions/release-please-action@v3.7.8
+      - uses: google-github-actions/release-please-action@v3
         id: release
         with:
           release-type: node
@@ -56,13 +56,6 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
         run: pnpm build
-        if: ${{ steps.release.outputs.release_created }}
-
-      - name: Publish to NPM
-        working-directory: dist
-        run: pnpm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}
 
       - name: Publish to Github Packages


### PR DESCRIPTION
## Description

No need to publish to NPM anymore, and pinning the version did not help.

Remove the failing publish to NPM step:
![image](https://github.com/Zapper-fi/studio/assets/22452366/392dffc3-7334-4a8f-a5d9-7471fbfd4cc2)

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
