### PR TITLE
fix(raft): fix for position presenter

### DIFF
--- a/src/apps/raft/ethereum/raft.position-presenter.ts
+++ b/src/apps/raft/ethereum/raft.position-presenter.ts
@@ -30,12 +30,11 @@ export class EthereumRaftPositionPresenter extends PositionPresenterTemplate<Raf
     balances: ReadonlyBalances,
     dataProps?: RaftPositionPresenterDataProps,
   ): MetadataItemWithLabel[] {
-
     const collateral = (balances[0] as ContractPositionBalance)?.tokens[0]
     const collateralUSD = collateral?.balanceUSD ?? 0;
-    const debt = (balances[0] as ContractPositionBalance)?.tokens[1]?.balanceUSD ?? 0;
-    const cRatio = Math.abs(debt) > 0 ? Math.abs(collateralUSD / debt) : 0;
-    const liquidationPrice = dataProps?.minCRatio ? (dataProps.minCRatio * debt) / collateral.balance : 0
+    const debt = Math.abs(((balances[0] as ContractPositionBalance)?.tokens[1]?.balanceUSD ?? 0));
+    const cRatio = debt > 0 ? Math.abs(collateralUSD / debt) : 0;
+    const liquidationPrice = dataProps?.minCRatio ? ((dataProps.minCRatio * debt) / collateral.balance) : 0
 
     return [
       { label: 'C-Ratio', ...buildPercentageDisplayItem(cRatio) },

--- a/src/apps/raft/raft.module.ts
+++ b/src/apps/raft/raft.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { AbstractApp } from '~app/app.dynamic-module';
 
 import { RaftContractFactory } from './contracts';
+import { EthereumRaftPositionPresenter } from './ethereum/raft.position-presenter';
 import { EthereumRaftWstethCollateralTokenFetcher } from './ethereum/raft.wsteth-collateral.token-fetcher';
 import { EthereumRaftWstethDebtTokenFetcher } from './ethereum/raft.wsteth-debt.token-fetcher';
 import { EthereumRaftWstethContractPositionFetcher } from './ethereum/raft.wsteth.contract-position-fetcher';
@@ -13,6 +14,7 @@ import { EthereumRaftWstethContractPositionFetcher } from './ethereum/raft.wstet
     EthereumRaftWstethDebtTokenFetcher,
     EthereumRaftWstethContractPositionFetcher,
     RaftContractFactory,
+    EthereumRaftPositionPresenter,
   ],
 })
 export class RaftAppModule extends AbstractApp() {}


### PR DESCRIPTION
## Description

see https://github.com/Zapper-fi/studio/pull/2728

solution for https://discord.com/channels/647279669388771329/964569348243075082/1116498228406394941. just not imported. still not testable. if this doesnt work I have an alternate approach, which is to override getBalances in the raft.position.contract-position-fetcher as follows
```

  // Hack: should be position presenter
  async getBalances(_address: string) {
    const rawBalances = await super.getBalances(_address);
    const balances = rawBalances.map(balance => {
      const collateral = balance.tokens[0];
      const collateralUSD = collateral?.balanceUSD ?? 0;
      const debt = -(balance.tokens[1]?.balanceUSD ?? 0);
      const cRatio = Math.abs(debt) > 0 ? Math.abs(collateralUSD / debt) : 0;
      const liquidationPrice = (Number(balance.dataProps.minCRatio) * debt) / collateral.balance
      balance.displayProps['statsItems'] = [
        { label: 'C-Ratio', value: buildPercentageDisplayItem(cRatio) },
        { label: 'Liquidation Price', value: buildDollarDisplayItem(liquidationPrice) },
      ]
      return balance
    })
    return balances;
  }
```

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
