### PR TITLE
fix(uniswap-v3): Pin uniswap/sdk-core version to 3.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@nestjs/schedule": "^2.1.0",
     "@pendle/sdk": "^2.5.8",
     "@types/moment-duration-format": "^2.2.3",
-    "@uniswap/sdk-core": "^3.0.1",
+    "@uniswap/sdk-core": "3.2.2",
     "@uniswap/v3-sdk": "^3.9.0",
     "bitcoin-address-validation": "^2.2.1",
     "dayjs": "^1.11.5",


### PR DESCRIPTION
## Description

- There's a bug in Uniswap/sdk-core version 3.2.4, so until the issue is fixed, the version of the package will be pinned to 3.2.2

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
