### PR TITLE
fix(raft): fix cratio percentage

### DIFF
--- a/src/apps/raft/ethereum/raft.position-presenter.ts
+++ b/src/apps/raft/ethereum/raft.position-presenter.ts
@@ -39,7 +39,7 @@ export class EthereumRaftPositionPresenter extends PositionPresenterTemplate {
     const liquidationPrice = minCRatio * debt / collateral.balance
 
     return [
-      { label: 'C-Ratio', ...buildPercentageDisplayItem(cRatio) },
+      { label: 'C-Ratio', ...buildPercentageDisplayItem(cRatio * 100) },
       { label: 'Liquidation Price', ...buildDollarDisplayItem(liquidationPrice) },
     ];
   }


### PR DESCRIPTION
sorry about pr spam for this app

Vukašin | Raft — Today at 5:40 PM
One small issue regarding C-ratio formatting. It should be 153.9%, not 1.539% Image

## Description

<!-- Provide a description of your changeset -->

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: tonygao.eth

## How to test?

https://zapper.xyz/account/0x6bddefb9f04b01c326b43b218059ee6938ea1ca8/protocols/ethereum/raft
