### PR TITLE
feat(mean-finance): add Mean Finance bnb deployment and fix hub addresses

### DIFF
--- a/src/apps/mean-finance/binance-smart-chain/mean-finance.dca-position.contract-position-fetcher.ts
+++ b/src/apps/mean-finance/binance-smart-chain/mean-finance.dca-position.contract-position-fetcher.ts
@@ -3,7 +3,7 @@ import { PositionTemplate } from '~app-toolkit/decorators/position-template.deco
 import { MeanFinanceDcaPositionContractPositionFetcher } from '../common/mean-finance.dca-position.contract-position-fetcher';
 
 @PositionTemplate()
-export class ArbitrumMeanFinanceDcaPositionContractPositionFetcher extends MeanFinanceDcaPositionContractPositionFetcher {
+export class BinanceSmartChainMeanFinanceDcaPositionContractPositionFetcher extends MeanFinanceDcaPositionContractPositionFetcher {
   groupLabel = 'DCA Positions';
   hubs = [
     {
@@ -11,7 +11,7 @@ export class ArbitrumMeanFinanceDcaPositionContractPositionFetcher extends MeanF
       hubAddress: '0xA5AdC5484f9997fBF7D405b9AA62A7d88883C345',
       tokenAddress: '0x20bdAE1413659f47416f769a4B27044946bc9923',
       transformerAddress: '0xc0136591df365611b1452b5f8823def69ff3a685',
-      subgraphUrl: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-yf-arbitrum',
+      subgraphUrl: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-yf-bnb',
     },
   ];
 }

--- a/src/apps/mean-finance/ethereum/mean-finance.dca-position.contract-position-fetcher.ts
+++ b/src/apps/mean-finance/ethereum/mean-finance.dca-position.contract-position-fetcher.ts
@@ -8,8 +8,8 @@ export class EthereumMeanFinanceDcaPositionContractPositionFetcher extends MeanF
   hubs = [
     {
       // Version 4 Hub - YIELD
-      hubAddress: '0xa43cc0b95ec985bf45fc03262150c20cae180952',
-      tokenAddress: '0x516cb11697bf1ba2dbb5c081c23f169791c4bd01',
+      hubAddress: '0xA5AdC5484f9997fBF7D405b9AA62A7d88883C345',
+      tokenAddress: '0x20bdAE1413659f47416f769a4B27044946bc9923',
       transformerAddress: '0xc0136591df365611b1452b5f8823def69ff3a685',
       subgraphUrl: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-yf-ethereum',
     },

--- a/src/apps/mean-finance/mean-finance.module.ts
+++ b/src/apps/mean-finance/mean-finance.module.ts
@@ -7,6 +7,7 @@ import { MeanFinanceContractFactory } from './contracts';
 import { EthereumMeanFinanceDcaPositionContractPositionFetcher } from './ethereum/mean-finance.dca-position.contract-position-fetcher';
 import { OptimismMeanFinanceDcaPositionContractPositionFetcher } from './optimism/mean-finance.dca-position.contract-position-fetcher';
 import { PolygonMeanFinanceDcaPositionContractPositionFetcher } from './polygon/mean-finance.dca-position.contract-position-fetcher';
+import { BinanceSmartChainMeanFinanceDcaPositionContractPositionFetcher } from './binance-smart-chain/mean-finance.dca-position.contract-position-fetcher';
 
 @Module({
   providers: [
@@ -15,6 +16,7 @@ import { PolygonMeanFinanceDcaPositionContractPositionFetcher } from './polygon/
     PolygonMeanFinanceDcaPositionContractPositionFetcher,
     ArbitrumMeanFinanceDcaPositionContractPositionFetcher,
     EthereumMeanFinanceDcaPositionContractPositionFetcher,
+    BinanceSmartChainMeanFinanceDcaPositionContractPositionFetcher,
   ],
 })
-export class MeanFinanceAppModule extends AbstractApp() {}
+export class MeanFinanceAppModule extends AbstractApp() { }

--- a/src/apps/mean-finance/optimism/mean-finance.dca-position.contract-position-fetcher.ts
+++ b/src/apps/mean-finance/optimism/mean-finance.dca-position.contract-position-fetcher.ts
@@ -20,8 +20,8 @@ export class OptimismMeanFinanceDcaPositionContractPositionFetcher extends MeanF
     },
     {
       // Version 4 Hub - YIELD
-      hubAddress: '0xa43cc0b95ec985bf45fc03262150c20cae180952',
-      tokenAddress: '0x516cb11697bf1ba2dbb5c081c23f169791c4bd01',
+      hubAddress: '0xA5AdC5484f9997fBF7D405b9AA62A7d88883C345',
+      tokenAddress: '0x20bdAE1413659f47416f769a4B27044946bc9923',
       transformerAddress: '0xc0136591df365611b1452b5f8823def69ff3a685',
       subgraphUrl: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-yf-optimism',
     },

--- a/src/apps/mean-finance/polygon/mean-finance.dca-position.contract-position-fetcher.ts
+++ b/src/apps/mean-finance/polygon/mean-finance.dca-position.contract-position-fetcher.ts
@@ -20,8 +20,8 @@ export class PolygonMeanFinanceDcaPositionContractPositionFetcher extends MeanFi
     },
     {
       // Version 4 Hub - YIELD
-      hubAddress: '0xa43cc0b95ec985bf45fc03262150c20cae180952',
-      tokenAddress: '0x516cb11697bf1ba2dbb5c081c23f169791c4bd01',
+      hubAddress: '0xA5AdC5484f9997fBF7D405b9AA62A7d88883C345',
+      tokenAddress: '0x20bdAE1413659f47416f769a4B27044946bc9923',
       transformerAddress: '0xc0136591df365611b1452b5f8823def69ff3a685',
       subgraphUrl: 'https://api.thegraph.com/subgraphs/name/mean-finance/dca-v2-yf-polygon',
     },


### PR DESCRIPTION
…sses

## Description

Adds the Mean deployment of Binance Smart Chain and updates old yield v4 hub addresses

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: fiboape.eth
- [X] (optional) As a contributor, my Twitter handle is: @fiboape

## How to test?

Address: 0x1cb6020db373a3e1cfcda9489570933fd0f79d0d for binance smart chain can retrieve balances
