### PR TITLE
fix(raft): Early return if there's no balances

### DIFF
--- a/src/apps/raft/ethereum/raft.position-presenter.ts
+++ b/src/apps/raft/ethereum/raft.position-presenter.ts
@@ -29,6 +29,8 @@ export class EthereumRaftPositionPresenter extends PositionPresenterTemplate {
     const minCRatio = balance?.dataProps?.minCRatio;
     if (!minCRatio) return [];
 
+    if (!balances.some(balance => balance.balanceUSD < 0)) return [];
+
     const collateral = balance?.tokens[0];
     const collateralUSD = collateral?.balanceUSD ?? 0;
     const debt = Math.abs(balance?.tokens[1]?.balanceUSD ?? 0);


### PR DESCRIPTION
## Description

- Early return if there's no balance will prevent throwing on 
`const liquidationPrice = (minCRatio * debt) / collateral.balance;`

If there's no balances
**collateral is undefined**


## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
