### PR TITLE
fix(polynomial): fix triple count smart wallet tvl

### DIFF
--- a/src/apps/polynomial/optimism/polynomial.smart-wallet.contract-position-fetcher.ts
+++ b/src/apps/polynomial/optimism/polynomial.smart-wallet.contract-position-fetcher.ts
@@ -66,7 +66,10 @@ export class OptimismPolynomialSmartWalletContractPositionFetcher extends Contra
     return [await contract.balanceOf(address)];
   }
 
-  async getDataProps(): Promise<PolynomialSmartWalletDataProp> {
+  async getDataProps({ contract }): Promise<PolynomialSmartWalletDataProp> {
+    if (await contract.symbol() != 'sUSD') {
+      return { liquidity: 0 };
+    }
     const { data } = await Axios.get<{ tvl: number }>('https://perps-api-experimental.polynomial.fi/snx-perps/tvl');
     return {
       liquidity: data.tvl,


### PR DESCRIPTION
## Description

TVL fetched from API was applied for each token hence triple counting, to display accurate data we'll assume all tvl is sUSD.
USDC deposited is converted to sUSD to trade, OP amounts are low (trading rewards).

## Checklist

- [X] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [X] (optional) As a contributor, my Ethereum address/ENS is: gaulois.eth
- [X] (optional) As a contributor, my Twitter handle is: @pseudo__alakon

## How to test?

address with sUSD: 0x22EEb166310EE35695dD856dF8b4F7AE489df933
with OP: 0x79926C541D1f28f9a0ABc9C84592E31743Cd1997
