### PR TITLE
fix(app-token-template): Allow app tokens with a supply of 0 to exist

### DIFF
--- a/src/position/template/app-token.template.position-fetcher.ts
+++ b/src/position/template/app-token.template.position-fetcher.ts
@@ -265,12 +265,14 @@ export abstract class AppTokenTemplatePositionFetcher<
           ]);
 
           const supply = Number(totalSupplyRaw) / 10 ** decimals;
-          if (supply === 0) return null;
 
           // Resolve price per share stage
           const pricePerShareStageFragment = { ...baseFragment, symbol, decimals, supply };
           const pricePerShareContext = { ...baseContext, appToken: pricePerShareStageFragment };
-          const pricePerShare = await this.getPricePerShare(pricePerShareContext).then(v => (isArray(v) ? v : [v]));
+          const pricePerShare =
+            supply !== 0
+              ? await this.getPricePerShare(pricePerShareContext).then(v => (isArray(v) ? v : [v]))
+              : Array(baseFragment.tokens.length).fill(1);
 
           // Resolve Price Stage
           const priceStageFragment = { ...pricePerShareStageFragment, pricePerShare };


### PR DESCRIPTION
## Description

Early return when a app tokens have a supply of ZERO doesn't work because some of these app tokens are required to resolve some positions
  
Why ?  What if there's a position which one of the underlying is a wrapped app token  with a supply of 0... That's the case of a few Convex position.

One of the extra reward of this [pool](https://etherscan.io/address/0xA61b57C452dadAF252D2f101f5Ba20aA86152992#readContract) is a wrapper on top of a LIDO token (https://etherscan.io/address/0xad2074172e212dcf82ec94558209c88156764a93) and it has a total supply of ZERO 

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

`0x9026a229b535ecf0162dfe48fdeb3c75f7b2a7ae`
