### PR TITLE
feat(studio): Add load to Multicall wrapper interface

### DIFF
--- a/src/multicall/multicall.contract.ts
+++ b/src/multicall/multicall.contract.ts
@@ -1,6 +1,6 @@
 import { Fragment, FunctionFragment, JsonFragment } from '@ethersproject/abi';
 
-import { ContractCall } from './multicall.ethers';
+import { ContractCall } from './multicall.interface';
 
 export class MulticallContract {
   private _address: string;

--- a/src/multicall/multicall.ethers.ts
+++ b/src/multicall/multicall.ethers.ts
@@ -5,16 +5,7 @@ import { FunctionFragment, Interface } from 'ethers/lib/utils';
 import { Multicall } from '~contract/contracts';
 
 import { MulticallContract } from './multicall.contract';
-import { IMulticallWrapper } from './multicall.interface';
-
-export type ContractCall = {
-  fragment: FunctionFragment;
-  address: string;
-  params: any[];
-  stack?: string;
-};
-
-type TargetContract = Pick<Contract, 'functions' | 'interface' | 'callStatic' | 'address'>;
+import { ContractCall, IMulticallWrapper, TargetContract } from './multicall.interface';
 
 export const isMulticallUnderlyingError = (err: Error) => err.message.includes('Multicall call failed for');
 

--- a/src/multicall/multicall.interface.ts
+++ b/src/multicall/multicall.interface.ts
@@ -1,10 +1,19 @@
-import { Contract } from 'ethers';
+import { FunctionFragment } from '@ethersproject/abi';
+import { Contract, ethers } from 'ethers';
 
 import { Multicall } from '~contract/contracts';
 
-type TargetContract = Pick<Contract, 'functions' | 'interface' | 'callStatic' | 'address'>;
+export type ContractCall = {
+  fragment: FunctionFragment;
+  address: string;
+  params: any[];
+  stack?: string;
+};
+
+export type TargetContract = Pick<Contract, 'functions' | 'interface' | 'callStatic' | 'address'>;
 
 export interface IMulticallWrapper {
   get contract(): Multicall;
+  load(call: ContractCall): Promise<ethers.utils.Result>;
   wrap<T extends TargetContract>(contract: T): T;
 }


### PR DESCRIPTION
## Description

Add `load` to the Multicall wrapper interface.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
