### PR TITLE
feat(gmx): Add size and leverage to perp display props

### DIFF
--- a/src/apps/gmx/common/gmx.perp.contract-position-fetcher.ts
+++ b/src/apps/gmx/common/gmx.perp.contract-position-fetcher.ts
@@ -128,6 +128,7 @@ export abstract class GmxPerpContractPositionFetcher extends CustomContractPosit
 
         const [collateralToken, indexToken, usdcToken] = contractPosition.tokens;
         const isLong = contractPosition.dataProps.isLong;
+        const positionKey = contractPosition.dataProps.positionKey;
 
         const position = await contract.getPosition(address, collateralToken.address, indexToken.address, isLong);
         // non existing position returns size and collateral = 0
@@ -162,7 +163,16 @@ export abstract class GmxPerpContractPositionFetcher extends CustomContractPosit
           leverage: Number(leverage),
         };
 
+        const displayProps = {
+          ...contractPosition.displayProps,
+          isLong,
+          positionKey,
+          size,
+          leverage,
+        };
+
         contractPosition.dataProps = dataProps;
+        contractPosition.displayProps = displayProps;
 
         const allTokens = contractPosition.tokens.map((cp, idx) =>
           drillBalance(cp, balancesRaw[idx]?.toString() ?? '0', { isDebt: cp.metaType === MetaType.BORROWED }),


### PR DESCRIPTION
## Description

- Add size and leverage to dsplay props

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
