### PR TITLE
feat(studio): Use interface for app toolkit to avoid importing AppToolkit dependency tree

### DIFF
--- a/src/apps/aelin/optimism/aelin.farm.contract-position-fetcher.ts
+++ b/src/apps/aelin/optimism/aelin.farm.contract-position-fetcher.ts
@@ -1,7 +1,6 @@
 import { Inject } from '@nestjs/common';
 
-import { APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
-import { AppToolkit } from '~app-toolkit/app-toolkit.service';
+import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
 import { GetDataPropsParams, GetTokenBalancesParams } from '~position/template/contract-position.template.types';
 import {
@@ -30,7 +29,7 @@ export class OptimismAelinFarmContractPositionFetcher extends SingleStakingFarmT
   groupLabel = 'Farms';
 
   constructor(
-    @Inject(APP_TOOLKIT) protected readonly appToolkit: AppToolkit,
+    @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
     @Inject(AelinContractFactory) protected readonly contractFactory: AelinContractFactory,
   ) {
     super(appToolkit);

--- a/src/apps/gains-network/common/gains-network.staking.contract-position-fetcher.ts
+++ b/src/apps/gains-network/common/gains-network.staking.contract-position-fetcher.ts
@@ -1,7 +1,6 @@
 import { Inject } from '@nestjs/common';
 
-import { APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
-import { AppToolkit } from '~app-toolkit/app-toolkit.service';
+import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { GetDataPropsParams, GetTokenBalancesParams } from '~position/template/contract-position.template.types';
 import {
   SingleStakingFarmDataProps,
@@ -14,7 +13,7 @@ export abstract class GainsNetworkStakingContractPositionFetcher extends SingleS
   groupLabel = 'Staking';
 
   constructor(
-    @Inject(APP_TOOLKIT) protected readonly appToolkit: AppToolkit,
+    @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
     @Inject(GainsNetworkContractFactory) protected readonly contractFactory: GainsNetworkContractFactory,
   ) {
     super(appToolkit);

--- a/src/apps/helio/binance-smart-chain/helio.staking.contract-position-fetcher.ts
+++ b/src/apps/helio/binance-smart-chain/helio.staking.contract-position-fetcher.ts
@@ -1,7 +1,6 @@
 import { Inject } from '@nestjs/common';
 
-import { APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
-import { AppToolkit } from '~app-toolkit/app-toolkit.service';
+import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
 import { GetDataPropsParams, GetTokenBalancesParams } from '~position/template/contract-position.template.types';
 import {
@@ -25,7 +24,7 @@ export class BinanceSmartChainHelioStakingContractPositionFetcher extends Single
   groupLabel = 'Staking';
 
   constructor(
-    @Inject(APP_TOOLKIT) protected readonly appToolkit: AppToolkit,
+    @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
     @Inject(HelioContractFactory) protected readonly contractFactory: HelioContractFactory,
   ) {
     super(appToolkit);

--- a/src/apps/jones-dao/arbitrum/jones-dao.farm.contract-position-fetcher.ts
+++ b/src/apps/jones-dao/arbitrum/jones-dao.farm.contract-position-fetcher.ts
@@ -1,8 +1,7 @@
 import { Inject } from '@nestjs/common';
 import _, { range } from 'lodash';
 
-import { APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
-import { AppToolkit } from '~app-toolkit/app-toolkit.service';
+import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
 import { GetDataPropsParams, GetTokenBalancesParams } from '~position/template/contract-position.template.types';
 import {
@@ -18,7 +17,7 @@ export class ArbitrumJonesDaoFarmContractPositionFetcher extends SingleStakingFa
   groupLabel = 'Farms';
 
   constructor(
-    @Inject(APP_TOOLKIT) protected readonly appToolkit: AppToolkit,
+    @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
     @Inject(JonesDaoContractFactory) protected readonly contractFactory: JonesDaoContractFactory,
   ) {
     super(appToolkit);

--- a/src/apps/looks-rare/ethereum/looks-rare.farm.contract-position-fetcher.ts
+++ b/src/apps/looks-rare/ethereum/looks-rare.farm.contract-position-fetcher.ts
@@ -1,8 +1,7 @@
 import { Inject } from '@nestjs/common';
 import { BigNumberish } from 'ethers';
 
-import { APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
-import { AppToolkit } from '~app-toolkit/app-toolkit.service';
+import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
 import { DefaultDataProps } from '~position/display.interface';
 import { MetaType } from '~position/position.interface';
@@ -20,7 +19,7 @@ export class EthereumLooksRareFarmContractPositionFetcher extends ContractPositi
   groupLabel = 'Staking';
 
   constructor(
-    @Inject(APP_TOOLKIT) protected readonly appToolkit: AppToolkit,
+    @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
     @Inject(LooksRareContractFactory) protected readonly contractFactory: LooksRareContractFactory,
   ) {
     super(appToolkit);

--- a/src/apps/pie-dao/ethereum/pie-dao.farm-single-staking.contract-position-fetcher.ts
+++ b/src/apps/pie-dao/ethereum/pie-dao.farm-single-staking.contract-position-fetcher.ts
@@ -1,7 +1,6 @@
 import { Inject } from '@nestjs/common';
 
-import { APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
-import { AppToolkit } from '~app-toolkit/app-toolkit.service';
+import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
 import { GetDataPropsParams, GetTokenBalancesParams } from '~position/template/contract-position.template.types';
 import {
@@ -50,7 +49,7 @@ export class EthereumPieDaoFarmSingleStakingContractPositionFetcher extends Sing
   groupLabel = 'Farms';
 
   constructor(
-    @Inject(APP_TOOLKIT) protected readonly appToolkit: AppToolkit,
+    @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
     @Inject(PieDaoContractFactory) protected readonly contractFactory: PieDaoContractFactory,
   ) {
     super(appToolkit);

--- a/src/apps/tokemak/ethereum/tokemak.farm.contract-position-fetcher.ts
+++ b/src/apps/tokemak/ethereum/tokemak.farm.contract-position-fetcher.ts
@@ -1,7 +1,6 @@
 import { Inject } from '@nestjs/common';
 
-import { APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
-import { AppToolkit } from '~app-toolkit/app-toolkit.service';
+import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
 import { GetTokenBalancesParams } from '~position/template/contract-position.template.types';
 import {
@@ -25,7 +24,7 @@ export class EthereumTokemakFarmContractPositionFetcher extends SingleStakingFar
   groupLabel = 'Staking';
 
   constructor(
-    @Inject(APP_TOOLKIT) protected readonly appToolkit: AppToolkit,
+    @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
     @Inject(TokemakContractFactory) private readonly contractFactory: TokemakContractFactory,
   ) {
     super(appToolkit);

--- a/src/apps/wolf-game/ethereum/wolf-game.wool-pouch.contract-position-fetcher.ts
+++ b/src/apps/wolf-game/ethereum/wolf-game.wool-pouch.contract-position-fetcher.ts
@@ -1,8 +1,7 @@
 import { Inject } from '@nestjs/common';
 import { gql } from 'graphql-request';
 
-import { APP_TOOLKIT } from '~app-toolkit/app-toolkit.interface';
-import { AppToolkit } from '~app-toolkit/app-toolkit.service';
+import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
 import { drillBalance } from '~app-toolkit/helpers/drill-balance.helper';
 import { gqlFetch } from '~app-toolkit/helpers/the-graph.helper';
@@ -33,10 +32,10 @@ const pouchesQuery = gql`
 export class EthereumWolfGameWoolPouchContractPositionFetcher extends CustomContractPositionTemplatePositionFetcher<WolfGameWoolPouch> {
   groupLabel = 'Wool Pouches';
   constructor(
-    @Inject(APP_TOOLKIT) protected readonly appToolKit: AppToolkit,
+    @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
     @Inject(WolfGameContractFactory) protected readonly contractFactory: WolfGameContractFactory,
   ) {
-    super(appToolKit);
+    super(appToolkit);
   }
   async getDefinitions(): Promise<DefaultContractPositionDefinition[]> {
     return [{ address: '0xb76fbbb30e31f2c3bdaa2466cfb1cfe39b220d06' }];


### PR DESCRIPTION
## Description

In Zapper API, we import the module from Studio which ends up pulling the `AppToolkit` service class, which has downstream dependencies to `file-system-cache`. Instead, resolve the `IAppToolkit` interface to avoid pulling in the dependencies in the import structure.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
