### PR TITLE
fix(curve): Fix vesting escrow underlying token order

### DIFF
--- a/src/position/template/vesting-escrow.template-contract-position-fetcher.ts
+++ b/src/position/template/vesting-escrow.template-contract-position-fetcher.ts
@@ -30,8 +30,8 @@ export abstract class VestingEscrowTemplateContractPositionFetcher<
 
   async getTokenDefinitions(params: GetTokenDefinitionsParams<T>) {
     return [
-      { metaType: MetaType.CLAIMABLE, address: await this.getEscrowedTokenAddress(params), network: this.network },
       { metaType: MetaType.VESTING, address: await this.getEscrowedTokenAddress(params), network: this.network },
+      { metaType: MetaType.CLAIMABLE, address: await this.getEscrowedTokenAddress(params), network: this.network },
     ];
   }
 


### PR DESCRIPTION
## Description

- Fix underlying token order
edit:  Here's an example - ~51m CRV should show up as locked 
![image](https://github.com/Zapper-fi/studio/assets/18474228/e1ec1cf7-b66c-4585-ac9a-5ab9686e951f)


## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?


`0x7a16ff8270133f063aab6c9977183d9e72835428`
