### PR TITLE
feat(index-coop): Add Money Market Index ($icSMMT)

### DIFF
--- a/src/apps/index-coop/ethereum/index-coop.index.token-fetcher.ts
+++ b/src/apps/index-coop/ethereum/index-coop.index.token-fetcher.ts
@@ -40,6 +40,7 @@ export class EthereumIndexCoopIndexTokenFetcher extends AppTokenTemplatePosition
       '0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd', // ETH x2 Flex Leverage
       '0x0b498ff89709d3838a063f1dfa463091f9801c2b', // BTC x2 Flex Leverage
       '0x341c05c0e9b33c0e38d64de76516b2ce970bb3be', // DSETH
+      '0xc30fba978743a43e736fc32fbeed364b8a2039cd', // Money Market Index
       ...this.deprecatedProducts,
     ];
   }


### PR DESCRIPTION
Adding our money market index token, a stablecoin yield product which has $400k of our own treasury thus our treasury was showing a bit light in zapper without this token being recognized.

## Description

<!-- Provide a description of your changeset -->

## Checklist

- [ x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ x] (optional) As a contributor, my Ethereum address/ENS is:  crews.eth
- [ x] (optional) As a contributor, my Twitter handle is: @theyoungcrews

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
idk what this means really, but you can find the Money Market Index on coingecko at https://www.coingecko.com/en/coins/money-market-index
