### PR TITLE
fix(y2k finance): use subgraph to fetch markets, remove tokenId for y…

### DIFF
--- a/src/apps/y2k-finance/arbitrum/y2k-finance.mint-v1.contract-position-fetcher.ts
+++ b/src/apps/y2k-finance/arbitrum/y2k-finance.mint-v1.contract-position-fetcher.ts
@@ -73,7 +73,6 @@ export class ArbitrumY2KFinanceMintV1ContractPositionFetcher extends ContractPos
           metaType: MetaType.CLAIMABLE,
           address: claimableAsset,
           network: this.network,
-          tokenId,
         },
       ])
       .flat();
@@ -93,7 +92,9 @@ export class ArbitrumY2KFinanceMintV1ContractPositionFetcher extends ContractPos
     const vault = params.multicall.wrap(params.contract);
     const results = await Promise.all(
       epochIds.map(async id => {
+        const finalTVL = await vault.idFinalTVL(id);
         const balance = await vault.balanceOf(params.address, id);
+        if (finalTVL.isZero() || balance.isZero()) return [0, 0];
         const claimable = await vault.previewWithdraw(id, balance);
         return [balance, claimable];
       }),

--- a/src/apps/y2k-finance/arbitrum/y2k-finance.mint-v2.contract-position-fetcher.ts
+++ b/src/apps/y2k-finance/arbitrum/y2k-finance.mint-v2.contract-position-fetcher.ts
@@ -1,8 +1,10 @@
 import { Inject } from '@nestjs/common';
 import { BigNumberish } from 'ethers';
+import { gql } from 'graphql-request';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
+import { gqlFetch } from '~app-toolkit/helpers/the-graph.helper';
 import { DefaultDataProps } from '~position/display.interface';
 import { MetaType } from '~position/position.interface';
 import { ContractPositionTemplatePositionFetcher } from '~position/template/contract-position.template.position-fetcher';
@@ -17,12 +19,24 @@ import {
 
 import { Y2KFinanceCarousel, Y2KFinanceContractFactory } from '../contracts';
 
-const carouselFactory = '0xc3179ac01b7d68aed4f27a19510ffe2bfb78ab3e';
-const fromBlock = 96059531;
+export const VAULTS_QUERY = gql`
+  {
+    vaults(where: { isV2: true }) {
+      address
+    }
+  }
+`;
+
+export type VaultsResponse = {
+  vaults: {
+    address: string;
+  }[];
+};
 
 @PositionTemplate()
 export class ArbitrumY2KFinanceMintV2ContractPositionFetcher extends ContractPositionTemplatePositionFetcher<Y2KFinanceCarousel> {
   groupLabel = 'Positions';
+  subgraphUrl = 'https://subgraph.satsuma-prod.com/a30e504dd617/y2k-finance/v2-prod/api';
 
   constructor(
     @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
@@ -36,11 +50,11 @@ export class ArbitrumY2KFinanceMintV2ContractPositionFetcher extends ContractPos
   }
 
   async getDefinitions(_params: GetDefinitionsParams): Promise<DefaultContractPositionDefinition[]> {
-    const factory = this.contractFactory.y2KFinanceCarouselFactory({ address: carouselFactory, network: this.network });
-    const filter = factory.filters.MarketCreated();
-    const events = await factory.queryFilter(filter, fromBlock);
-    const vaults = events.map(e => [e.args.premium, e.args.collateral]).flat();
-    return vaults.map(vault => ({ address: vault }));
+    const vaultsResponse = await gqlFetch<VaultsResponse>({
+      endpoint: this.subgraphUrl,
+      query: VAULTS_QUERY,
+    });
+    return vaultsResponse.vaults.map(vault => ({ address: vault.address }));
   }
 
   async getTokenDefinitions(
@@ -55,6 +69,7 @@ export class ArbitrumY2KFinanceMintV2ContractPositionFetcher extends ContractPos
         {
           metaType: MetaType.SUPPLIED,
           address: params.contract.address,
+          // address: '0x892785f33cdee22a30aef750f285e18c18040c3e',
           network: this.network,
           tokenId,
         },
@@ -62,7 +77,6 @@ export class ArbitrumY2KFinanceMintV2ContractPositionFetcher extends ContractPos
           metaType: MetaType.CLAIMABLE,
           address: claimableAsset,
           network: this.network,
-          tokenId,
         },
         {
           metaType: MetaType.CLAIMABLE,
@@ -87,7 +101,9 @@ export class ArbitrumY2KFinanceMintV2ContractPositionFetcher extends ContractPos
     const vault = params.multicall.wrap(params.contract);
     const results = await Promise.all(
       epochIds.map(async id => {
+        const finalTVL = await vault.finalTVL(id);
         const balance = await vault.balanceOf(params.address, id);
+        if (finalTVL.isZero() || balance.isZero()) return [0, 0, 0];
         const claimable = await vault.previewWithdraw(id, balance);
         const emission = await vault.previewEmissionsWithdraw(id, balance);
         return [balance, claimable, emission];


### PR DESCRIPTION
## Description

- use subgraph to fetch y2k markets
- remove tokenId for y2k in token definitions

## Checklist

- [ ] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

vlY2K: `0x7d34105c4731cd837f1e5bb0d787cec827432156`, `0x36f4e1803f6ff34562db567f347dea00dec87246`
v1 mint: `0x14e735f177286cfe1898435f8ec8318d02899c23` (more can be found in https://arbiscan.io/token/0x38589723f8a024cfed58f58ad36f56e45b941119#balances)
v2 mint: `0x0337922dd51b417b26255357cea209b5cda47f7a`(more can be found in https://arbiscan.io/token/0x853ead5f4811c32e0ee88592f8a53183a4d29270#balances)
farms: 0xd02073f30afe262968a174668d99256511671118