### PR TITLE
fix(spool): ignore removed strategies

### DIFF
--- a/src/apps/spool/ethereum/spool.vault.contract-position-fetcher.ts
+++ b/src/apps/spool/ethereum/spool.vault.contract-position-fetcher.ts
@@ -57,7 +57,7 @@ const vaultsQuery = gql`
       fees {
         feeSize
       }
-      strategies(orderBy: position, orderDirection: asc) {
+      strategies(orderBy: position, orderDirection: asc, where: { strategy_: { isRemoved: false } }) {
         id
         position
         allocation


### PR DESCRIPTION
## Description

<!-- Provide a description of your changeset -->
Issue found when invoking `/apps/{appId}/balances`.

Subgraph query wasn't taking into account that strategies could be removed from the system and should be ignored. As a consequence, a contract call failed due to an invalid list of strategies.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
