### PR TITLE
fix(curve): Fix gauge v6 and dynamic pools without fee

### DIFF
--- a/src/apps/curve/common/curve.pool-dynamic-v2.token-fetcher.ts
+++ b/src/apps/curve/common/curve.pool-dynamic-v2.token-fetcher.ts
@@ -138,10 +138,14 @@ export abstract class CurvePoolDynamicV2TokenFetcher<T extends Contract> extends
     const defaultDataProps = await super.getDataProps(params);
 
     const { contract, definition } = params;
+    let fee: number;
 
-    const fees = await contract.fee();
-    const fee = Number(fees) / 10 ** 8;
-
+    try {
+      const fees = await contract.fee();
+      fee = Number(fees) / 10 ** 8;
+    } catch {
+      fee = 0;
+    }
     const volume = await this.volumeDataLoader.load(definition.address);
     const feeVolume = fee * volume;
     const apy = defaultDataProps.liquidity > 0 ? (feeVolume / defaultDataProps.liquidity) * 365 : 0;

--- a/src/apps/curve/common/curve.pool-gauge-v6.contract-position-fetcher.ts
+++ b/src/apps/curve/common/curve.pool-gauge-v6.contract-position-fetcher.ts
@@ -4,6 +4,7 @@ import _, { range } from 'lodash';
 import { duration } from 'moment';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
+import { ZERO_ADDRESS } from '~app-toolkit/constants/address';
 import { getLabelFromToken } from '~app-toolkit/helpers/presentation/image.present';
 import { IMulticallWrapper } from '~multicall';
 import { MetaType } from '~position/position.interface';
@@ -81,6 +82,9 @@ export abstract class CurvePoolGaugeV6ContractPositionFetcher<
       poolRange.map(async poolIndex => {
         const tokenAddress = await this.resolveTokenAddress({ contract, poolIndex, multicall });
         const gaugeAddress = await this.resolveGaugeAddress({ contract, tokenAddress, multicall });
+
+        if (gaugeAddress == ZERO_ADDRESS) return null;
+
         const gaugeV6Contract = this.contractFactory.curveGaugeV6({
           address: gaugeAddress.toLowerCase(),
           network: this.network,
@@ -101,7 +105,7 @@ export abstract class CurvePoolGaugeV6ContractPositionFetcher<
       }),
     );
 
-    return gaugeDefinitions;
+    return _.compact(gaugeDefinitions);
   }
 
   async getTokenDefinitions({ definition }: GetTokenDefinitionsParams<CurveGaugeV6, CurvePoolGaugeDefinition>) {


### PR DESCRIPTION
## Description

- some dynamic pools have fees
- some gauge v6 position aren't fully implemented yet and return the ZERO_ADDRESS instead of the 'real' gauge address

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
