### PR TITLE
fix(yearn): Revert pointing to ydeamon stating environment

### DIFF
--- a/src/apps/yearn/common/yearn.vault.token-definitions-resolver.ts
+++ b/src/apps/yearn/common/yearn.vault.token-definitions-resolver.ts
@@ -23,7 +23,7 @@ export class YearnVaultTokenDefinitionsResolver {
     ttl: 5 * 60, // 5 minutes
   })
   private async getVaultDefinitionsData(network: Network) {
-    const url = `https://ydaemon.yearn.fi/${NETWORK_IDS[network]}/vaults/all`;
+    const url = `https://ydaemon.yearn.finance/${NETWORK_IDS[network]}/vaults/all`;
     const { data } = await Axios.get<YearnVaultData[]>(url);
     return data;
   }


### PR DESCRIPTION
## Description

Revert temporary yDeamon url update

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
