### PR TITLE
fix(balancer-v2): Filter out faulty reawrd address from Balancer-v2 farm position

### DIFF
--- a/src/apps/balancer-v2/base/balancer-v2.farm.contract-position-fetcher.ts
+++ b/src/apps/balancer-v2/base/balancer-v2.farm.contract-position-fetcher.ts
@@ -6,4 +6,6 @@ import { BalancerV2FarmContractPositionFetcher } from '../common/balancer-v2.far
 export class BaseBalancerV2FarmContractPositionFetcher extends BalancerV2FarmContractPositionFetcher {
   groupLabel = 'Staked';
   subgraphUrl = 'https://api.studio.thegraph.com/query/24660/balancer-gauges-base/version/latest';
+
+  faultyRewardAddress = ['0x65226673f3d202e0f897c862590d7e1a992b2048'];
 }


### PR DESCRIPTION
## Description

One of the Balancer-v2 Gauge has a wrong setup and one of the reward token address is a gnosis safe. Will be filtering this address out from reward token addresses

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
