### PR TITLE
feat(metastreet): Fix MetaStreet app

### DIFF
--- a/src/apps/meta-street/ethereum/meta-street.lending-v2-legacy.contract-position-fetcher.ts
+++ b/src/apps/meta-street/ethereum/meta-street.lending-v2-legacy.contract-position-fetcher.ts
@@ -216,16 +216,18 @@ export class EthereumMetaStreetLendingV2LegacyContractPositionFetcher extends Co
       ? redemptionAvailable.amount
       : activeShares.mul(tickData.value).div(tickData.shares).add(redemptionAvailable.amount);
 
-    /* Compute deposit position (deposit shares * depositor's avg share price - withdrawn amount) */
-    const depositPosition = deposited.shares.eq(constants.Zero)
-      ? constants.Zero
-      : deposited.shares.mul(deposited.amount).div(deposited.shares).sub(withdrawn.amount);
+    /* Compute deposit position based on remaining shares */
+    const depositPosition = deposited.shares.gt(0)
+      ? deposited.shares.sub(withdrawn.shares).mul(deposited.amount).div(deposited.shares)
+      : constants.Zero;
 
-    /* Compute supplied and claimable balances */
-    const suppliedBalance = depositPosition.gt(currentPosition) ? currentPosition : depositPosition;
-    const claimableBalance = depositPosition.gt(currentPosition)
-      ? constants.Zero
-      : currentPosition.sub(depositPosition);
+    /* Compute supplied balance (minimum of currentPosition and depositPosition) */
+    const suppliedBalance = currentPosition.gt(depositPosition) ? depositPosition : currentPosition;
+
+    /* Compute claimable balance (interest earned) */
+    const claimableBalance = currentPosition.gt(depositPosition)
+      ? currentPosition.sub(depositPosition)
+      : constants.Zero;
 
     return [suppliedBalance, claimableBalance];
   }


### PR DESCRIPTION
## Description

Fix computation of supplied and claimable balances to avoid negative balances.

## Checklist

- [x] I have followed the [Contributing Guidelines](../CONTRIBUTING.md)

## How to test?

The negative balance on Zapper causing the frontend bug is removed as observed in a local test.

**Bug on Zapper:**
[https://zapper.xyz/account/0x66ceac5ee8f093059c4bc9628c06e63076505b15?tab=apps](https://zapper.xyz/account/0x66ceac5ee8f093059c4bc9628c06e63076505b15?tab=apps)

**Tested locally:**
http://localhost:5001/apps/meta-street/balances?addresses[]=0x66ceac5ee8f093059c4bc9628c06e63076505b15&network=ethereum
