### PR TITLE
feat(studio): Remove overrides on getBalancePerToken

### DIFF
--- a/src/apps/exactly/common/exactly.borrow.token-fetcher.ts
+++ b/src/apps/exactly/common/exactly.borrow.token-fetcher.ts
@@ -1,5 +1,3 @@
-import type { IMulticallWrapper } from '~multicall/multicall.interface';
-import type { AppTokenPosition } from '~position/position.interface';
 import type { GetDataPropsParams, GetTokenPropsParams } from '~position/template/app-token.template.types';
 
 import type { ExactlyMarketDefinition } from '../common/exactly.definitions-resolver';
@@ -20,23 +18,5 @@ export abstract class ExactlyBorrowFetcher extends ExactlyTokenFetcher {
 
   getApr({ definition }: GetDataPropsParams<Market, ExactlyMarketProps, ExactlyMarketDefinition>) {
     return Number(definition.floatingBorrowRate) / 1e16;
-  }
-
-  async getBalancePerToken({
-    address,
-    appToken,
-    multicall,
-  }: {
-    address: string;
-    appToken: AppTokenPosition;
-    multicall: IMulticallWrapper;
-  }) {
-    const { floatingBorrowShares } = await this.definitionsResolver.getDefinition({
-      multicall,
-      network: this.network,
-      account: address,
-      market: appToken.address,
-    });
-    return floatingBorrowShares;
   }
 }

--- a/src/apps/exactly/common/exactly.fixed-borrow.token-fetcher.ts
+++ b/src/apps/exactly/common/exactly.fixed-borrow.token-fetcher.ts
@@ -1,7 +1,5 @@
 import { BigNumber, constants } from 'ethers';
 
-import type { IMulticallWrapper } from '~multicall/multicall.interface';
-import type { AppTokenPosition } from '~position/position.interface';
 import type { GetDataPropsParams, GetTokenPropsParams } from '~position/template/app-token.template.types';
 
 import type { ExactlyMarketDefinition } from '../common/exactly.definitions-resolver';
@@ -22,23 +20,5 @@ export abstract class ExactlyFixedBorrowFetcher extends ExactlyFixedPositionFetc
       (best, { maturity, minBorrowRate: rate }) => (BigNumber.from(rate).lt(best.rate) ? { maturity, rate } : best),
       { maturity: constants.Zero, rate: constants.MaxUint256 },
     );
-  }
-
-  async getBalancePerToken({
-    address,
-    appToken,
-    multicall,
-  }: {
-    address: string;
-    appToken: AppTokenPosition;
-    multicall: IMulticallWrapper;
-  }) {
-    const { fixedBorrowPositions } = await this.definitionsResolver.getDefinition({
-      multicall,
-      network: this.network,
-      account: address,
-      market: appToken.address,
-    });
-    return fixedBorrowPositions.reduce((total, { previewValue }) => total.add(previewValue), constants.Zero);
   }
 }

--- a/src/apps/exactly/common/exactly.fixed-deposit.token-fetcher.ts
+++ b/src/apps/exactly/common/exactly.fixed-deposit.token-fetcher.ts
@@ -1,7 +1,5 @@
 import { BigNumber, constants } from 'ethers';
 
-import type { IMulticallWrapper } from '~multicall/multicall.interface';
-import type { AppTokenPosition } from '~position/position.interface';
 import type { GetDataPropsParams, GetTokenPropsParams } from '~position/template/app-token.template.types';
 
 import type { ExactlyMarketDefinition } from '../common/exactly.definitions-resolver';
@@ -21,23 +19,5 @@ export abstract class ExactlyFixedDepositFetcher extends ExactlyFixedPositionFet
       (best, { maturity, depositRate: rate }) => (BigNumber.from(rate).gt(best.rate) ? { maturity, rate } : best),
       { maturity: constants.Zero, rate: constants.Zero },
     );
-  }
-
-  async getBalancePerToken({
-    address,
-    appToken,
-    multicall,
-  }: {
-    address: string;
-    appToken: AppTokenPosition;
-    multicall: IMulticallWrapper;
-  }) {
-    const { fixedDepositPositions } = await this.definitionsResolver.getDefinition({
-      multicall,
-      network: this.network,
-      account: address,
-      market: appToken.address,
-    });
-    return fixedDepositPositions.reduce((total, { previewValue }) => total.add(previewValue), constants.Zero);
   }
 }

--- a/src/apps/spice-finance/ethereum/spice-finance.weth.token-fetcher.ts
+++ b/src/apps/spice-finance/ethereum/spice-finance.weth.token-fetcher.ts
@@ -1,11 +1,8 @@
 import { Inject } from '@nestjs/common';
-import { BigNumberish, constants } from 'ethers';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
 import { Erc721 } from '~contract/contracts';
-import { IMulticallWrapper } from '~multicall';
-import { AppTokenPosition } from '~position/position.interface';
 import { AppTokenTemplatePositionFetcher } from '~position/template/app-token.template.position-fetcher';
 import {
   GetAddressesParams,
@@ -72,29 +69,6 @@ export class EthereumSpiceFinanceWethTokenFetcher extends AppTokenTemplatePositi
     const reserveRaw = await vault.totalAssets();
     const reserve = Number(reserveRaw) / 10 ** appToken.tokens[0].decimals;
     return [reserve];
-  }
-
-  async getBalancePerToken({
-    address,
-  }: {
-    address: string;
-    appToken: AppTokenPosition;
-    multicall: IMulticallWrapper;
-  }): Promise<BigNumberish> {
-    const vault = this.spiceFinanceContractFactory.spiceFinanceNftVault({
-      address: this.vaultAddress,
-      network: this.network,
-    });
-    let balance = constants.Zero;
-    for (let i = 1; i <= 555; ++i) {
-      const owner = await vault.ownerOf(i);
-      if (owner.toLowerCase() === address.toLowerCase()) {
-        const shares = await vault.tokenShares(i);
-        const assets = await vault.convertToAssets(shares);
-        balance = balance.add(assets);
-      }
-    }
-    return balance;
   }
 
   async getApy(_params: GetDataPropsParams<Erc721>) {

--- a/src/apps/synthetix/common/synthetix.snx.token-fetcher.ts
+++ b/src/apps/synthetix/common/synthetix.snx.token-fetcher.ts
@@ -1,11 +1,7 @@
 import { Inject } from '@nestjs/common';
-import { BigNumberish } from 'ethers';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
-import { IMulticallWrapper } from '~multicall';
-import { DefaultDataProps } from '~position/display.interface';
-import { AppTokenPosition } from '~position/position.interface';
 import { AppTokenTemplatePositionFetcher } from '~position/template/app-token.template.position-fetcher';
 import { GetDataPropsParams, GetDisplayPropsParams, GetPriceParams } from '~position/template/app-token.template.types';
 
@@ -62,17 +58,5 @@ export abstract class SynthetixSnxTokenFetcher extends AppTokenTemplatePositionF
 
   async getImages({ appToken }: GetDisplayPropsParams<SynthetixNetworkToken>) {
     return [getTokenImg(appToken.address, this.network)];
-  }
-
-  async getBalancePerToken({
-    address,
-    appToken,
-    multicall,
-  }: {
-    address: string;
-    appToken: AppTokenPosition<DefaultDataProps>;
-    multicall: IMulticallWrapper;
-  }): Promise<BigNumberish> {
-    return multicall.wrap(this.getContract(appToken.address)).transferableSynthetix(address);
   }
 }


### PR DESCRIPTION
## Description

Working on simplifying the balances system for app tokens. Remove overrides for getBalancePerToken. Disabled Exactly since the implementation doesn't conform with `balanceOf` for tokens.

## Checklist

- [x] I have followed the [Contributing Guidelines](https://github.com/Zapper-fi/studio/blob/main/CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
