### PR TITLE
fix(pool-together-v5): decimals bug post-linting

### DIFF
--- a/src/apps/pool-together-v5/common/pool-together-v5.prize-vault.token-fetcher.ts
+++ b/src/apps/pool-together-v5/common/pool-together-v5.prize-vault.token-fetcher.ts
@@ -62,7 +62,7 @@ export abstract class PoolTogetherV5PrizeVaultTokenFetcher extends AppTokenTempl
   }
 
   async getPricePerShare({ contract, appToken }: GetPricePerShareParams<Erc4626>) {
-    const ratioRaw = await contract.convertToAssets(BigNumber.from((1e18).toString()));
+    const ratioRaw = await contract.convertToAssets(BigNumber.from((10 ** appToken.decimals).toString()));
     const ratio = Number(ratioRaw) / 10 ** appToken.decimals;
     return [ratio];
   }


### PR DESCRIPTION
## Description

After my PR was merged in, some linting changes and re-writes unfortunately introduced a decimal bug in calculating price per share of prize vaults. It is using 18 decimals for all calculations, but some tokens do not have 18 decimals.

Screenshot from the live Zapper app:

![image](https://github.com/Zapper-fi/studio/assets/22108522/5eed86ec-d245-4d69-b306-1c73accdf2be)

Prize WETH shows accurately because it has 18 decimals.
Prize USDC does not show accurately, because it has 6 decimals.

This PR updates one line of the code to fix this :)

## Checklist

- [x] I have followed the [Contributing Guidelines](https://github.com/Zapper-fi/studio/blob/main/CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: `ncookie.eth`
- [x] (optional) As a contributor, my Twitter handle is: `@ncookie_eth`

## How to test?

Feel free to use `ncookie.eth` to test this (address used for the screenshot above).
