### PR TITLE
fix(studio): Fix multicall call struct types

### DIFF
--- a/src/multicall/impl/multicall.ethers.ts
+++ b/src/multicall/impl/multicall.ethers.ts
@@ -7,17 +7,18 @@ import { Multicall } from '~contract/contracts';
 import { DEFAULT_DATALOADER_OPTIONS } from '../multicall.constants';
 import { MulticallContract } from '../multicall.contract';
 import { ContractCall, IMulticallWrapper, TargetContract } from '../multicall.interface';
+import { MulticallCallStruct } from '~multicall/multicall.types';
 
 export const isMulticallUnderlyingError = (err: Error) => err.message.includes('Multicall call failed for');
 
 export type MulticallCallbackHooks = {
-  beforeCallHook?: (calls: ContractCall[], callRequests: Multicall.CallStruct[]) => void;
+  beforeCallHook?: (calls: ContractCall[], callRequests: MulticallCallStruct[]) => void;
 };
 
 export class EthersMulticallDataLoader implements IMulticallWrapper {
   private multicall: Multicall;
   private dataLoader: DataLoader<ContractCall, ethers.utils.Result>;
-  private beforeCallHook?: (calls: ContractCall[], callRequests: Multicall.CallStruct[]) => void;
+  private beforeCallHook?: (calls: ContractCall[], callRequests: MulticallCallStruct[]) => void;
 
   constructor(
     multicall: Multicall,

--- a/src/multicall/impl/multicall.viem.ts
+++ b/src/multicall/impl/multicall.viem.ts
@@ -16,6 +16,7 @@ import { MulticallWrappedReadRequestError } from '~multicall/errors/multicall.re
 import { DEFAULT_DATALOADER_OPTIONS } from '~multicall/multicall.constants';
 
 import { MulticallWrappedReadDecodeError } from '../errors/multicall.decode.error';
+import { MulticallCallStruct } from '~multicall/multicall.types';
 
 declare module 'abitype' {
   export interface Config {
@@ -35,20 +36,15 @@ export type ContractCall<T extends Abi = Abi, V extends string = string> = {
   stack?: string;
 };
 
-type CallStruct = {
-  target: string;
-  callData: string;
-};
-
 type MulticallCallbackHooks = {
-  beforeCallHook?: (calls: ContractCall[], callRequests: CallStruct[]) => void;
+  beforeCallHook?: (calls: ContractCall[], callRequests: MulticallCallStruct[]) => void;
   afterResultSerializer?: (result: ReadContractReturnType) => unknown;
 };
 
 export class ViemMulticallDataLoader {
   private multicall: MulticallContract;
   private dataLoader: DataLoader<ContractCall, ReadContractReturnType>;
-  private beforeCallHook?: (calls: ContractCall[], callRequests: CallStruct[]) => void;
+  private beforeCallHook?: (calls: ContractCall[], callRequests: MulticallCallStruct[]) => void;
   private afterResultSerializer?: (result: ReadContractReturnType) => unknown;
 
   constructor(

--- a/src/multicall/multicall.types.ts
+++ b/src/multicall/multicall.types.ts
@@ -1,0 +1,4 @@
+export type MulticallCallStruct = {
+  target: string;
+  callData: string;
+};


### PR DESCRIPTION
## Description

New Ethers versions create types as `PromiseOrValue`, but we just need the call struct as values.

## Checklist

- [x] I have followed the [Contributing Guidelines](https://github.com/Zapper-fi/studio/blob/main/CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
