### PR TITLE
fix(app-toolkit): Remove duplicate function

### DIFF
--- a/src/app-toolkit/app-toolkit.interface.ts
+++ b/src/app-toolkit/app-toolkit.interface.ts
@@ -43,10 +43,6 @@ export interface IAppToolkit {
     ...appTokenDefinition: AppGroupsDefinition[]
   ): Promise<AppTokenPosition<T>[]>;
 
-  getAppTokenPositionsFromDatabase<T = DefaultDataProps>(
-    ...appTokenDefinition: AppGroupsDefinition[]
-  ): Promise<AppTokenPosition<T>[]>;
-
   getAppContractPositions<T = DefaultDataProps>(
     ...appTokenDefinition: AppGroupsDefinition[]
   ): Promise<ContractPosition<T>[]>;

--- a/src/app-toolkit/app-toolkit.service.ts
+++ b/src/app-toolkit/app-toolkit.service.ts
@@ -6,6 +6,7 @@ import { ethers } from 'ethers';
 import { PublicClient } from 'viem';
 
 import { ContractFactory } from '~contract';
+import { ContractViemContractFactory } from '~contract/contracts';
 import { MulticallService } from '~multicall/multicall.service';
 import { NetworkProviderService } from '~network-provider/network-provider.service';
 import { DefaultDataProps } from '~position/display.interface';
@@ -19,7 +20,6 @@ import { PriceSelectorService } from '~token/selectors/token-price-selector.serv
 import { Network } from '~types/network.interface';
 
 import { IAppToolkit } from './app-toolkit.interface';
-import { ContractViemContractFactory } from '~contract/contracts';
 
 @Injectable()
 export class AppToolkit implements IAppToolkit {
@@ -81,10 +81,6 @@ export class AppToolkit implements IAppToolkit {
   // Positions
 
   getAppTokenPositions<T = DefaultDataProps>(...appTokenDefinitions: AppGroupsDefinition[]) {
-    return this.positionService.getAppTokenPositions<T>(...appTokenDefinitions);
-  }
-
-  getAppTokenPositionsFromDatabase<T = DefaultDataProps>(...appTokenDefinitions: AppGroupsDefinition[]) {
     return this.positionService.getAppTokenPositions<T>(...appTokenDefinitions);
   }
 


### PR DESCRIPTION
## Description

`getAppTokenPositionsFromDatabase` is a duplicate of `getAppContractPositions`

## Checklist

- [ ] I have followed the [Contributing Guidelines](https://github.com/Zapper-fi/studio/blob/main/CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
