### PR TITLE
fix(studio): Fix PoolTogether community pool fetcher

### DIFF
--- a/src/apps/pool-together-v3/common/pool-together-v3.community-ticket.token-fetcher.ts
+++ b/src/apps/pool-together-v3/common/pool-together-v3.community-ticket.token-fetcher.ts
@@ -74,8 +74,8 @@ export abstract class PoolTogetherV3CommunityTicketTokenFetcher extends AppToken
       poolBuilders.map(({ address, blockNumber }) =>
         this.logProvider.getPoolWithMultipleWinnersBuilderLogs({
           fromBlock: blockNumber,
-          address,
           network: this.network,
+          address,
         }),
       ),
     );
@@ -84,17 +84,16 @@ export abstract class PoolTogetherV3CommunityTicketTokenFetcher extends AppToken
     const definitions = await Promise.all(
       builderLogs.flatMap(logs =>
         flatMap(logs, (logsForType, type: PoolWithMultipleWinnersBuilderCreatedType) =>
-          logsForType.map(async log => {
-            const prizePool = log.args[0].toLowerCase();
-            const prizeStrategy = log.args[1].toLowerCase();
-            const contract = multicall.wrap(
-              this.contractFactory.poolTogetherV3MultipleWinners({
-                network: this.network,
-                address: prizeStrategy,
-              }),
-            );
+          logsForType.map(async ({ prizePool, prizeStrategy }) => {
+            const contract = this.contractFactory.poolTogetherV3MultipleWinners({
+              network: this.network,
+              address: prizeStrategy,
+            });
 
-            const ticketAddress = await contract.read.ticket().then(addr => addr.toLowerCase());
+            const ticketAddress = await multicall
+              .wrap(contract)
+              .read.ticket()
+              .then(addr => addr.toLowerCase());
 
             return {
               type,

--- a/src/apps/pool-together-v3/common/pool-together-v3.log-provider.ts
+++ b/src/apps/pool-together-v3/common/pool-together-v3.log-provider.ts
@@ -41,9 +41,18 @@ export class PoolTogetherV3LogProvider {
     ]);
 
     return {
-      [PoolWithMultipleWinnersBuilderCreatedType.STAKE]: stakeLogs,
-      [PoolWithMultipleWinnersBuilderCreatedType.COMPOUND]: compoundLogs,
-      [PoolWithMultipleWinnersBuilderCreatedType.YIELD]: yieldLogs,
+      [PoolWithMultipleWinnersBuilderCreatedType.STAKE]: stakeLogs.map(log => ({
+        prizePool: log.args.prizePool!,
+        prizeStrategy: log.args.prizeStrategy!,
+      })),
+      [PoolWithMultipleWinnersBuilderCreatedType.COMPOUND]: compoundLogs.map(log => ({
+        prizePool: log.args.prizePool!,
+        prizeStrategy: log.args.prizeStrategy!,
+      })),
+      [PoolWithMultipleWinnersBuilderCreatedType.YIELD]: yieldLogs.map(log => ({
+        prizePool: log.args.prizePool!,
+        prizeStrategy: log.args.prizeStrategy!,
+      })),
     };
   }
 }


### PR DESCRIPTION
## Description

BigInt is non-serializable (DUMB?). Instead, only cache the part of the logs that is required (which happens to be serializable already).

## Checklist

- [x] I have followed the [Contributing Guidelines](https://github.com/Zapper-fi/studio/blob/main/CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
