### PR TITLE
feat(studio): Fix Midas revert error

### DIFF
--- a/src/apps/midas/binance-smart-chain/midas.market.token-fetcher.ts
+++ b/src/apps/midas/binance-smart-chain/midas.market.token-fetcher.ts
@@ -20,7 +20,7 @@ export class BinanceSmartChainMidasMarketTokenFetcher extends MidasMarketTokenFe
   groupLabel = 'Lending';
 
   poolDirectoryAddress = '0x295d7347606f4bd810c8296bb8d75d657001fcf7';
-  poolLensAddress = '0x6f4e0b5405f3751f7327cf8095004c34fc307f55';
+  poolLensAddress = '0x2d3c31e38d3ad71571b1406639003a6648481628';
 
   constructor(
     @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
@@ -59,7 +59,6 @@ export class BinanceSmartChainMidasMarketTokenFetcher extends MidasMarketTokenFe
 
   async getMarketTokenAddresses(contract: MidasPoolLensContract, poolAddress: string): Promise<string[]> {
     const assets = await contract.simulate.getPoolAssetsWithData([poolAddress]).then(v => v.result);
-
     return assets.map(asset => asset.cToken);
   }
 

--- a/src/apps/midas/polygon/midas.market.token-fetcher.ts
+++ b/src/apps/midas/polygon/midas.market.token-fetcher.ts
@@ -20,7 +20,7 @@ export class PolygonMidasMarketTokenFetcher extends MidasMarketTokenFetcher<
   groupLabel = 'Lending';
 
   poolDirectoryAddress = '0x9a161e68ec0d5364f4d09a6080920daff6fff250';
-  poolLensAddress = '0xd94ca960132557385e9ad993c69cc22a3344c2e7';
+  poolLensAddress = '0x16d8c0ee982d5219285b1042d3675a6d9e247f9d';
 
   constructor(
     @Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit,
@@ -59,7 +59,6 @@ export class PolygonMidasMarketTokenFetcher extends MidasMarketTokenFetcher<
 
   async getMarketTokenAddresses(contract: MidasPoolLensContract, poolAddress: string): Promise<string[]> {
     const assets = await contract.simulate.getPoolAssetsWithData([poolAddress]).then(v => v.result);
-
     return assets.map(asset => asset.cToken);
   }
 


### PR DESCRIPTION
## Description

Midas lens addresses were incorrect. Also, the request for `getPoolAssetsWithData` fails for some comptrollers, so catch and handle the error by filtering out those markets.

## Checklist

- [x] I have followed the [Contributing Guidelines](https://github.com/Zapper-fi/studio/blob/main/CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
