### PR TITLE
feat(studio): Revert removal of overrides for get raw balances and get balance per token

### DIFF
--- a/src/apps/kyberswap-elastic/common/kyberswap-elastic.apy.data-loader.ts
+++ b/src/apps/kyberswap-elastic/common/kyberswap-elastic.apy.data-loader.ts
@@ -1,9 +1,7 @@
-import { Inject } from '@nestjs/common';
 import DataLoader from 'dataloader';
 import { gql } from 'graphql-request';
 import _ from 'lodash';
 
-import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { gqlFetch } from '~app-toolkit/helpers/the-graph.helper';
 
 import { getTimeDayAgo } from './kyberswap-elastic.liquidity.utils';
@@ -41,8 +39,6 @@ export const GET_POOL_INFOS = gql`
 `;
 
 export class KyberswapElasticApyDataLoader {
-  constructor(@Inject(APP_TOOLKIT) protected readonly appToolkit: IAppToolkit) {}
-
   getLoader({ subgraphUrl, blockSubgraphUrl }: { subgraphUrl: string; blockSubgraphUrl: string }) {
     const dataLoaderOptions = { cache: true, maxBatchSize: 1000 };
     return new DataLoader<string, number>(async (addresses: string[]) => {

--- a/src/apps/market-xyz/common/market-xyz.supply.token-fetcher.ts
+++ b/src/apps/market-xyz/common/market-xyz.supply.token-fetcher.ts
@@ -60,12 +60,11 @@ export abstract class MarketXyzSupplyTokenFetcher extends RariFuseSupplyTokenFet
     return contract.read.supplyRatePerBlock();
   }
 
-  getPoolsBySupplier(
+  async getPoolsBySupplier(
     address: string,
     contract: MarketXyzPoolLensContract,
   ): Promise<[BigNumberish[], { comptroller: string }[]]> {
-    return contract.read
-      .getPoolsBySupplier([address])
-      .then(([pools, comptrollers]) => [[...pools], comptrollers.map(c => ({ comptroller: c.comptroller }))]);
+    const [pools, comptrollers] = await contract.read.getPoolsBySupplier([address]);
+    return [[...pools], comptrollers.map(c => ({ comptroller: c.comptroller }))];
   }
 }

--- a/src/apps/rari-fuse/ethereum/rari-fuse.borrow.contract-position-fetcher.ts
+++ b/src/apps/rari-fuse/ethereum/rari-fuse.borrow.contract-position-fetcher.ts
@@ -71,12 +71,11 @@ export class EthereumRariFuseBorrowContractPositionFetcher extends RariFuseBorro
     return contract.read.borrowBalanceCurrent([address]);
   }
 
-  getPoolsBySupplier(
+  async getPoolsBySupplier(
     address: string,
     contract: RariFusePoolLensContract,
   ): Promise<[BigNumberish[], { comptroller: string }[]]> {
-    return contract.read
-      .getPoolsBySupplier([address])
-      .then(([pools, comptrollers]) => [[...pools], comptrollers.map(c => ({ comptroller: c.comptroller }))]);
+    const [pools, comptrollers] = await contract.read.getPoolsBySupplier([address]);
+    return [[...pools], comptrollers.map(c => ({ comptroller: c.comptroller }))];
   }
 }

--- a/src/apps/rari-fuse/ethereum/rari-fuse.supply.token-fetcher.ts
+++ b/src/apps/rari-fuse/ethereum/rari-fuse.supply.token-fetcher.ts
@@ -68,18 +68,10 @@ export class EthereumRariFuseSupplyTokenFetcher extends RariFuseSupplyTokenFetch
     return contract.read.supplyRatePerBlock();
   }
 
-  async getPoolsBySupplier(
-    address: string,
-    contract: RariFusePoolLensContract,
-  ): Promise<[BigNumberish[], { comptroller: string }[]]> {
-    const [pools, comptrollers] = await contract.read.getPoolsBySupplier([address]);
-    return [[...pools], comptrollers.map(c => ({ comptroller: c.comptroller }))];
-  }
-
   async getRawBalances(address: string): Promise<RawTokenBalance[]> {
     const lens = this.getLensContract(this.lensAddress);
-    const poolsBySupplier = await this.getPoolsBySupplier(address, lens);
-    const participatedComptrollers = poolsBySupplier[1].map(t => t.comptroller.toLowerCase());
+    const [, comptrollers] = await lens.read.getPoolsBySupplier([address]);
+    const participatedComptrollers = comptrollers.map(t => t.comptroller.toLowerCase());
 
     const multicall = this.appToolkit.getViemMulticall(this.network);
     const appTokens = await this.appToolkit.getAppTokenPositions<RariFuseSupplyTokenDataProps>({

--- a/src/apps/rari-fuse/ethereum/rari-fuse.supply.token-fetcher.ts
+++ b/src/apps/rari-fuse/ethereum/rari-fuse.supply.token-fetcher.ts
@@ -3,8 +3,9 @@ import { BigNumberish } from 'ethers';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
+import { RawTokenBalance } from '~position/position-balance.interface';
 
-import { RariFuseSupplyTokenFetcher } from '../common/rari-fuse.supply.token-fetcher';
+import { RariFuseSupplyTokenDataProps, RariFuseSupplyTokenFetcher } from '../common/rari-fuse.supply.token-fetcher';
 import { RariFuseViemContractFactory } from '../contracts';
 import { RariFuseComptroller, RariFusePoolLens, RariFusePoolsDirectory, RariFuseToken } from '../contracts/viem';
 import { RariFuseComptrollerContract } from '../contracts/viem/RariFuseComptroller';
@@ -67,12 +68,33 @@ export class EthereumRariFuseSupplyTokenFetcher extends RariFuseSupplyTokenFetch
     return contract.read.supplyRatePerBlock();
   }
 
-  getPoolsBySupplier(
+  async getPoolsBySupplier(
     address: string,
     contract: RariFusePoolLensContract,
   ): Promise<[BigNumberish[], { comptroller: string }[]]> {
-    return contract.read
-      .getPoolsBySupplier([address])
-      .then(([pools, comptrollers]) => [[...pools], comptrollers.map(c => ({ comptroller: c.comptroller }))]);
+    const [pools, comptrollers] = await contract.read.getPoolsBySupplier([address]);
+    return [[...pools], comptrollers.map(c => ({ comptroller: c.comptroller }))];
+  }
+
+  async getRawBalances(address: string): Promise<RawTokenBalance[]> {
+    const lens = this.getLensContract(this.lensAddress);
+    const poolsBySupplier = await this.getPoolsBySupplier(address, lens);
+    const participatedComptrollers = poolsBySupplier[1].map(t => t.comptroller.toLowerCase());
+
+    const multicall = this.appToolkit.getViemMulticall(this.network);
+    const appTokens = await this.appToolkit.getAppTokenPositions<RariFuseSupplyTokenDataProps>({
+      appId: this.appId,
+      network: this.network,
+      groupIds: [this.groupId],
+    });
+
+    return Promise.all(
+      appTokens
+        .filter(v => participatedComptrollers.includes(v.dataProps.comptroller))
+        .map(async appToken => {
+          const balanceRaw = await this.getBalancePerToken({ multicall, address, appToken });
+          return { key: this.appToolkit.getPositionKey(appToken), balance: balanceRaw.toString() };
+        }),
+    );
   }
 }

--- a/src/apps/synthetix/common/synthetix.snx.token-fetcher.ts
+++ b/src/apps/synthetix/common/synthetix.snx.token-fetcher.ts
@@ -1,9 +1,17 @@
 import { Inject } from '@nestjs/common';
+import { BigNumberish } from 'ethers';
 
 import { APP_TOOLKIT, IAppToolkit } from '~app-toolkit/app-toolkit.interface';
 import { getTokenImg } from '~app-toolkit/helpers/presentation/image.present';
+import { ViemMulticallDataLoader } from '~multicall';
+import { AppTokenPosition } from '~position/position.interface';
 import { AppTokenTemplatePositionFetcher } from '~position/template/app-token.template.position-fetcher';
-import { GetDataPropsParams, GetDisplayPropsParams, GetPriceParams } from '~position/template/app-token.template.types';
+import {
+  DefaultAppTokenDataProps,
+  GetDataPropsParams,
+  GetDisplayPropsParams,
+  GetPriceParams,
+} from '~position/template/app-token.template.types';
 
 import { SynthetixViemContractFactory } from '../contracts';
 import { SynthetixNetworkToken } from '../contracts/viem';
@@ -59,5 +67,18 @@ export abstract class SynthetixSnxTokenFetcher extends AppTokenTemplatePositionF
 
   async getImages({ appToken }: GetDisplayPropsParams<SynthetixNetworkToken>) {
     return [getTokenImg(appToken.address, this.network)];
+  }
+
+  async getBalancePerToken({
+    address,
+    appToken,
+    multicall,
+  }: {
+    address: string;
+    appToken: AppTokenPosition<DefaultAppTokenDataProps>;
+    multicall: ViemMulticallDataLoader;
+  }): Promise<BigNumberish> {
+    const contract = this.getContract(appToken.address);
+    return multicall.wrap(contract).read.transferableSynthetix([address]);
   }
 }

--- a/src/apps/uniswap-v2/ethereum/uniswap-v2.pool.token-fetcher.ts
+++ b/src/apps/uniswap-v2/ethereum/uniswap-v2.pool.token-fetcher.ts
@@ -1,8 +1,15 @@
 import { gql } from 'graphql-request';
+import { compact, chunk } from 'lodash';
 
+import { ZERO_ADDRESS } from '~app-toolkit/constants/address';
 import { PositionTemplate } from '~app-toolkit/decorators/position-template.decorator';
+import { drillBalance } from '~app-toolkit/helpers/drill-balance.helper';
+import { gqlFetch } from '~app-toolkit/helpers/the-graph.helper';
+import { AppTokenPositionBalance, RawAppTokenBalance } from '~position/position-balance.interface';
+import { isAppToken } from '~position/position.interface';
 
 import { UniswapV2DefaultPoolSubgraphTemplateTokenFetcher } from '../common/uniswap-v2.default.subgraph.template.token-fetcher';
+import { UniswapV2TokenDataProps } from '../common/uniswap-v2.pool.on-chain.template.token-fetcher';
 
 type UniswapV2BalancesData = {
   user?: {
@@ -36,4 +43,63 @@ export class EthereumUniswapV2PoolTokenFetcher extends UniswapV2DefaultPoolSubgr
   first = 5000;
   // Todo: remove when subgraph isn't throwing when calling volumeUSD
   skipVolume = true;
+
+  async getBalances(_address: string): Promise<AppTokenPositionBalance<UniswapV2TokenDataProps>[]> {
+    const multicall = this.appToolkit.getViemMulticall(this.network);
+    const tokenLoader = this.appToolkit.getTokenDependencySelector();
+    const address = await this.getAccountAddress(_address);
+    if (address === ZERO_ADDRESS) return [];
+
+    // Use the subgraph to determine holdings. Later, we'll optimize this to use our own holdings by default.
+    const data = await gqlFetch<UniswapV2BalancesData>({
+      endpoint: this.subgraphUrl,
+      query: UNISWAP_V2_BALANCES_QUERY,
+      variables: { address: address.toLowerCase() },
+    });
+
+    const heldTokenAddresses = data.user?.liquidityPositions.map(v => v.pair.id.toLowerCase()) ?? [];
+    const heldTokens = await tokenLoader.getMany(heldTokenAddresses.map(t => ({ address: t, network: this.network })));
+    const sanitized = compact(heldTokens).filter(isAppToken);
+
+    const balances = await Promise.all(
+      sanitized.map(async appToken => {
+        const balanceRaw = await this.getBalancePerToken({ multicall, address, appToken });
+        const tokenBalance = drillBalance(appToken, balanceRaw.toString(), { isDebt: this.isDebt });
+        return tokenBalance;
+      }),
+    );
+
+    return balances as AppTokenPositionBalance<UniswapV2TokenDataProps>[];
+  }
+
+  async getRawBalances(_address: string): Promise<RawAppTokenBalance[]> {
+    const multicall = this.appToolkit.getViemMulticall(this.network);
+    const tokenLoader = this.appToolkit.getTokenDependencySelector();
+    const address = await this.getAccountAddress(_address);
+    if (address === ZERO_ADDRESS) return [];
+
+    // Use the subgraph to determine holdings. Later, we'll optimize this to use our own holdings by default.
+    const data = await gqlFetch<UniswapV2BalancesData>({
+      endpoint: this.subgraphUrl,
+      query: UNISWAP_V2_BALANCES_QUERY,
+      variables: { address: address.toLowerCase() },
+    });
+
+    const heldTokenAddresses = data.user?.liquidityPositions.map(v => v.pair.id.toLowerCase()) ?? [];
+    const heldTokens = await tokenLoader.getMany(heldTokenAddresses.map(t => ({ address: t, network: this.network })));
+    const sanitized = compact(heldTokens).filter(isAppToken);
+
+    let results: RawAppTokenBalance[] = [];
+    for (const batch of chunk(sanitized, 100).values()) {
+      results = results.concat(
+        await Promise.all(
+          batch.map(async appToken => ({
+            key: this.appToolkit.getPositionKey(appToken),
+            balance: (await this.getBalancePerToken({ multicall, address, appToken })).toString(),
+          })),
+        ),
+      );
+    }
+    return results;
+  }
 }


### PR DESCRIPTION
## Description

These were removed while attempting to resolve Ethers memory spike problems in the balance calculations, but since migrating to Viem, this pattern can be reintroduced.

## Checklist

- [x] I have followed the [Contributing Guidelines](https://github.com/Zapper-fi/studio/blob/main/CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
