### PR TITLE
feat(abracadabra): Add support for GM cauldrons on Arbitrum

### DIFF
--- a/src/apps/abracadabra/arbitrum/abracadabra.arbitrum.constants.ts
+++ b/src/apps/abracadabra/arbitrum/abracadabra.arbitrum.constants.ts
@@ -5,6 +5,10 @@ export const ARBITRUM_CAULDRONS: AbracadabraCauldronContractPositionDefinition[]
   { version: 'V2', type: 'REGULAR', address: '0xc89958b03a55b5de2221acb25b58b89a000215e6' }, // wETH
   { version: 'V4', type: 'GLP', address: '0x5698135ca439f21a57bddbe8b582c62f090406d5' }, // GLP
   { version: 'V4', type: 'REGULAR', address: '0x726413d7402ff180609d0ebc79506df8633701b1' }, // magicGLP
+  { version: 'V4', type: 'REGULAR', address: '0x4F9737E994da9811B8830775Fd73E2F1C8e40741' }, // gmARB
+  { version: 'V4', type: 'REGULAR', address: '0xD7659D913430945600dfe875434B6d80646d552A' }, // gmBTC
+  { version: 'V4', type: 'REGULAR', address: '0x2b02bBeAb8eCAb792d3F4DDA7a76f63Aa21934FA' }, // gmETH
+  { version: 'V4', type: 'REGULAR', address: '0x7962ACFcfc2ccEBC810045391D60040F635404fb' }, // gmSOL
 ];
 
 export const ARBITRUM_GLP_TOKEN_ADDRESS = '0x4277f8f2c384827b5273592ff7cebd9f2c1ac258';


### PR DESCRIPTION
## Description

Add support for Abracadabra's GM cauldrons. I have not been able to test it as I am unable to run `pnpm install` in the project. The changes should be pretty straightforward though.

## Checklist

- [x] I have followed the [Contributing Guidelines](https://github.com/Zapper-fi/studio/blob/main/CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: 0xmDreamy.eth
- [x] (optional) As a contributor, my Twitter handle is: 0xmDreamy

## How to test?

**gmARB**: `0x972b0f9cde1266e860e546ac92e783741769400f`
**gmBTC**: `0x93652ae25d0ba757c3c92a4deb0b05dd1d4efe35`
**gmETH**: `0xd0f1258563a9d14fb746059246e11ef02632a5f6`
**gmSOL**: `0xf2df969f59b2c86e4b230da88918cdebcfc4ccbc`