### PR TITLE
fix(pickle): Fix Jars without getRatio method

### DIFF
--- a/src/apps/pickle/common/pickle.jar.token-fetcher.ts
+++ b/src/apps/pickle/common/pickle.jar.token-fetcher.ts
@@ -44,7 +44,12 @@ export abstract class PickleJarTokenFetcher extends AppTokenTemplatePositionFetc
   }
 
   async getPricePerShare({ contract }: GetPricePerShareParams<PickleJar, DefaultDataProps>) {
-    return contract.read.getRatio().then(v => [Number(v) / 10 ** 18]);
+    try {
+      const ratioRaw = await contract.read.getRatio();
+      return [Number(ratioRaw) / 10 ** 18];
+    } catch (error) {
+      return [1];
+    }
   }
 
   async getLiquidity({ appToken, contract }: GetDataPropsParams<PickleJar>) {


### PR DESCRIPTION
## Description

There's one jar on ethereum without a `getRatio()` method on the contract

## Checklist

- [x] I have followed the [Contributing Guidelines](https://github.com/Zapper-fi/studio/blob/main/CONTRIBUTING.md)
- [ ] (optional) As a contributor, my Ethereum address/ENS is:
- [ ] (optional) As a contributor, my Twitter handle is:

## How to test?

<!-- Provide a way to test your changeset, perhaps addresses -->
