### PR TITLE
feat(llama-airforce): Add new uPRISMA pounder and distributor

### DIFF
--- a/src/apps/llama-airforce/ethereum/llama-airforce.airdrop.contract-position-fetcher.ts
+++ b/src/apps/llama-airforce/ethereum/llama-airforce.airdrop.contract-position-fetcher.ts
@@ -51,9 +51,8 @@ export class EthereumLlamaAirforceAirdropContractPositionFetcher extends Contrac
         address: '0x5682a28919389b528ae74dd627e0d632ca7e398c',
         rewardTokenAddress: '0x3a886455e5b33300a31c5e77bac01e76c0c7b29c', // uFXS
       },
-
       {
-        address: '0x27a11054b62c29c166f3fab2b0ac708043b0cb49',
+        address: '0x6788234f40931ca615b0d221c1afbf0ec07afcc5',
         rewardTokenAddress: '0x8659fc767cad6005de79af65dafe4249c57927af', // uCVX
       },
     ];

--- a/src/apps/llama-airforce/ethereum/llama-airforce.airdrop.contract-position-fetcher.ts
+++ b/src/apps/llama-airforce/ethereum/llama-airforce.airdrop.contract-position-fetcher.ts
@@ -55,6 +55,10 @@ export class EthereumLlamaAirforceAirdropContractPositionFetcher extends Contrac
         address: '0x6788234f40931ca615b0d221c1afbf0ec07afcc5',
         rewardTokenAddress: '0x8659fc767cad6005de79af65dafe4249c57927af', // uCVX
       },
+      {
+        address: '0xf09320ed7db384cab7fce9ea9947436a806754d3',
+        rewardTokenAddress: '0x9bfd08d7b3cc40129132a17b4d5b9ea3351464bd', // uPRISMA
+      },
     ];
   }
 

--- a/src/apps/llama-airforce/ethereum/llama-airforce.merkle-cache.ts
+++ b/src/apps/llama-airforce/ethereum/llama-airforce.merkle-cache.ts
@@ -23,7 +23,7 @@ export class EthereumLlamaAirforceMerkleCache extends MerkleCache<LlamaAirforceM
   network = Network.ETHEREUM_MAINNET;
 
   async resolveMerkleData() {
-    const [{ data: uCrvData }, { data: uFxsData }, { data: uCvxData }] = await Promise.all([
+    const [{ data: uCrvData }, { data: uFxsData }, { data: uCvxData }, { data: uPrismaData }] = await Promise.all([
       axios.get<LlamaAirforceMerkleData>(
         'https://raw.githubusercontent.com/0xAlunara/Llama-Airforce-Airdrops/master/ucrv/latest.json',
       ),
@@ -33,16 +33,21 @@ export class EthereumLlamaAirforceMerkleCache extends MerkleCache<LlamaAirforceM
       axios.get<LlamaAirforceMerkleData>(
         'https://raw.githubusercontent.com/0xAlunara/Llama-Airforce-Airdrops/master/ucvx/latest.json',
       ),
+      axios.get<LlamaAirforceMerkleData>(
+        'https://raw.githubusercontent.com/0xAlunara/Llama-Airforce-Airdrops/master/uprisma/latest.json',
+      ),
     ]);
 
     const uCrvTokenAddress = '0xde2bef0a01845257b4aef2a2eaa48f6eaeafa8b7';
     const uFxsTokenAddress = '0x3a886455e5b33300a31c5e77bac01e76c0c7b29c';
     const uCvxTokenAddress = '0x8659fc767cad6005de79af65dafe4249c57927af';
+    const uPrismaTokenAddress = '0x9bfd08d7b3cc40129132a17b4d5b9ea3351464bd';
 
     return {
       [uCrvTokenAddress]: uCrvData.claims,
       [uFxsTokenAddress]: uFxsData.claims,
       [uCvxTokenAddress]: uCvxData.claims,
+      [uPrismaTokenAddress]: uPrismaData.claims,
     };
   }
 }


### PR DESCRIPTION
## Description

<!-- Provide a description of your changeset -->
1. Fix the uCVX merkle distributor contract address, it was still pointing to the old version.
2. Add support for the new uPRISMA pounder and merkle distributor.

## Checklist

- [x] I have followed the [Contributing Guidelines](https://github.com/Zapper-fi/studio/blob/main/CONTRIBUTING.md)
- [x] (optional) As a contributor, my Ethereum address/ENS is: [0xaef6ea60f6443bad046e825c1d2b0c0b5ebc1f16](https://gnosis-safe.io/app/eth:0xaef6ea60f6443bad046e825c1d2b0c0b5ebc1f16)
- [x] (optional) As a contributor, my Twitter handle is: @0xAlunara

## How to test?

I used to be able to navigate to [http://localhost:5001/apps/llama-airforce/balances?addresses[]=[redacted]&network=ethereum](http://localhost:5001/apps/llama-airforce/balances?addresses%5B%5D=[redacted]&network=ethereum) and see both the balance of uTKN (uPRISMA in this case) I already held in my wallet and also the claimable amount from the distributor. However, I no longer see the the raw balances I hold in my wallet and only see claimable airdrop amounts. I'm also not seeing the new claimable balance for uPRISMA; not sure what I'm doing wrong. Maybe it's an issue with my local environment.

I also sometimes get `{"statusCode":500,"message":"Internal server error"}` at random intervals which also randomly fixes itself.

uPRISMA: [0x9bfd08d7b3cc40129132a17b4d5b9ea3351464bd](https://etherscan.io/address/0x9bfd08d7b3cc40129132a17b4d5b9ea3351464bd)
uPRISMA merkle: [0xf09320ed7db384cab7fce9ea9947436a806754d3](https://etherscan.io/address/0xf09320ed7db384cab7fce9ea9947436a806754d3)
<!-- Provide a way to test your changeset, perhaps addresses -->
